### PR TITLE
Security disclosure contact requested

### DIFF
--- a/SECURITY_CONTACT_REQUEST.md
+++ b/SECURITY_CONTACT_REQUEST.md
@@ -1,0 +1,15 @@
+# Security Disclosure Contact Request
+
+A responsible security disclosure package for the Vana smart contracts repository at commit ea6a85c7bbcc42070931993067bae1339ead7012 has been prepared. Vulnerability details and proof-of-concept code are intentionally withheld from this public pull request.
+
+I attempted to use the documented private contact paths before opening this public GitHub request:
+
+1. dev@vana.org, listed in Vana security documentation, returned 550 5.1.1 NoSuchUser.
+2. security@vana.org, listed in contract NatSpec, returned 550 5.1.1 NoSuchUser.
+3. GitHub private vulnerability reporting is disabled for this repository.
+4. Issues and Discussions are disabled for this repository.
+5. No public recipient encryption key was found for the available contact addresses.
+
+A copy of the disclosure package was also sent to dev@vana.com, the address listed on the GitHub organization profile. Please confirm the correct private security contact or enable GitHub private vulnerability reporting so the disclosure can be delivered through the preferred channel.
+
+No vulnerability details, exploit steps, or proof-of-concept code are included here intentionally.


### PR DESCRIPTION
This pull request is being opened only because the available private disclosure channels could not be completed. It intentionally does not include vulnerability details, exploit steps, proof-of-concept code, or affected-function details.

A responsible security disclosure package for the Vana smart contracts repository at commit ea6a85c7bbcc42070931993067bae1339ead7012 has been prepared.

Documented contact attempts failed as follows:

1. dev@vana.org, listed in Vana security documentation, returned 550 5.1.1 NoSuchUser.
2. security@vana.org, listed in contract NatSpec, returned 550 5.1.1 NoSuchUser.
3. GitHub private vulnerability reporting is disabled for this repository.
4. Issues and Discussions are disabled for this repository.
5. No public recipient encryption key was found for the available contact addresses.

A copy of the disclosure package was also sent to dev@vana.com, the address listed on the GitHub organization profile. Please confirm receipt, provide the correct private security contact, or enable GitHub private vulnerability reporting so the disclosure can be delivered through the preferred channel.

No vulnerability details are included here intentionally to avoid public exposure before remediation.