### PR TITLE
feat: Namespace and Scope Registry

### DIFF
--- a/contracts/data/dataRegistryV2/DataRegistryV2Implementation.sol
+++ b/contracts/data/dataRegistryV2/DataRegistryV2Implementation.sol
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
+import "./interfaces/DataRegistryV2StorageV1.sol";
+
+/**
+ * @title DataRegistryV2Implementation
+ * @notice Fresh data-point registry keyed by sequential ids, with versioned
+ *         metadata per data point. UUPS upgradeable.
+ *
+ *         This is independent of the legacy `DataRegistry` (file-based). The
+ *         two registries can coexist; consumers choose which one to read from.
+ */
+contract DataRegistryV2Implementation is
+    UUPSUpgradeable,
+    PausableUpgradeable,
+    AccessControlUpgradeable,
+    DataRegistryV2StorageV1
+{
+    /// @dev Reverts unless `msg.sender` owns the data point with `id`.
+    modifier onlyDataPointOwner(uint256 id) {
+        if (_dataPoints[id].status == Status.None) revert DataPointNotFound(id);
+        if (_dataPoints[id].owner != msg.sender) revert NotDataPointOwner(id, msg.sender);
+        _;
+    }
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    function initialize(address ownerAddress, address scopeRegistryAddress) external initializer {
+        if (ownerAddress == address(0)) revert ZeroAddress();
+        if (scopeRegistryAddress == address(0)) revert EmptyScopeRegistry();
+
+        __AccessControl_init();
+        __UUPSUpgradeable_init();
+        __Pausable_init();
+
+        scopeRegistry = IScopeRegistry(scopeRegistryAddress);
+
+        _grantRole(DEFAULT_ADMIN_ROLE, ownerAddress);
+    }
+
+    function _authorizeUpgrade(address newImplementation) internal virtual override onlyRole(DEFAULT_ADMIN_ROLE) {}
+
+    function version() external pure virtual override returns (uint256) {
+        return 1;
+    }
+
+    // ====================== Admin ======================
+
+    function pause() external override onlyRole(DEFAULT_ADMIN_ROLE) {
+        _pause();
+    }
+
+    function unpause() external override onlyRole(DEFAULT_ADMIN_ROLE) {
+        _unpause();
+    }
+
+    function updateScopeRegistry(address newScopeRegistry) external override onlyRole(DEFAULT_ADMIN_ROLE) {
+        if (newScopeRegistry == address(0)) revert EmptyScopeRegistry();
+        address previous = address(scopeRegistry);
+        scopeRegistry = IScopeRegistry(newScopeRegistry);
+        emit ScopeRegistryUpdated(previous, newScopeRegistry);
+    }
+
+    // ====================== Views ======================
+
+    function dataPoints(uint256 id) external view override returns (DataPointInfo memory) {
+        DataPoint storage d = _dataPoints[id];
+        return DataPointInfo({
+            id: id,
+            owner: d.owner,
+            scopeId: d.scopeId,
+            createdAt: d.createdAt,
+            modifiedAt: d.modifiedAt,
+            status: d.status,
+            metadataVersion: d.metadataVersion
+        });
+    }
+
+    function metadata(uint256 id) external view override returns (string memory) {
+        DataPoint storage d = _dataPoints[id];
+        if (d.status == Status.None) return "";
+        return d.metadata[d.metadataVersion];
+    }
+
+    function metadataAt(uint256 id, uint256 version_) external view override returns (string memory) {
+        DataPoint storage d = _dataPoints[id];
+        if (d.status == Status.None) revert DataPointNotFound(id);
+        if (version_ == 0 || version_ > d.metadataVersion) revert InvalidVersion(id, version_);
+        return d.metadata[version_];
+    }
+
+    // ====================== Mutations ======================
+
+    function register(bytes32 scopeId, string calldata metadata_) external override whenNotPaused returns (uint256) {
+        if (bytes(metadata_).length == 0) revert EmptyMetadata();
+        if (scopeRegistry.scopeStatus(scopeId) != IScopeRegistry.Status.Active) revert ScopeNotActive(scopeId);
+
+        uint256 id = ++dataPointsCount;
+        DataPoint storage d = _dataPoints[id];
+
+        d.owner = msg.sender;
+        d.scopeId = scopeId;
+        d.createdAt = block.timestamp;
+        d.modifiedAt = block.timestamp;
+        d.status = Status.Active;
+        d.metadataVersion = 1;
+        d.metadata[1] = metadata_;
+
+        emit DataPointRegistered(id, msg.sender, scopeId, metadata_);
+        return id;
+    }
+
+    function updateMetadata(uint256 id, string calldata metadata_)
+        external
+        override
+        whenNotPaused
+        onlyDataPointOwner(id)
+    {
+        if (bytes(metadata_).length == 0) revert EmptyMetadata();
+
+        DataPoint storage d = _dataPoints[id];
+        uint256 newVersion = ++d.metadataVersion;
+        d.metadata[newVersion] = metadata_;
+        d.modifiedAt = block.timestamp;
+
+        emit DataPointMetadataUpdated(id, newVersion, metadata_);
+    }
+
+    function setStatus(uint256 id, Status newStatus) external override whenNotPaused onlyDataPointOwner(id) {
+        if (newStatus == Status.None) revert InvalidStatus();
+
+        DataPoint storage d = _dataPoints[id];
+        d.status = newStatus;
+        d.modifiedAt = block.timestamp;
+
+        emit DataPointStatusChanged(id, newStatus);
+    }
+}

--- a/contracts/data/dataRegistryV2/DataRegistryV2Proxy.sol
+++ b/contracts/data/dataRegistryV2/DataRegistryV2Proxy.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+contract DataRegistryV2Proxy is ERC1967Proxy {
+    constructor(address logic, bytes memory data) ERC1967Proxy(logic, data) {}
+}

--- a/contracts/data/dataRegistryV2/interfaces/DataRegistryV2StorageV1.sol
+++ b/contracts/data/dataRegistryV2/interfaces/DataRegistryV2StorageV1.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import "./IDataRegistryV2.sol";
+
+/**
+ * @title Storage for DataRegistryV2
+ * @notice For future upgrades, do not change DataRegistryV2StorageV1. Create a new
+ * contract which implements DataRegistryV2StorageV1.
+ */
+abstract contract DataRegistryV2StorageV1 is IDataRegistryV2 {
+    IScopeRegistry public override scopeRegistry;
+
+    uint256 public override dataPointsCount;
+
+    mapping(uint256 id => DataPoint) internal _dataPoints;
+}

--- a/contracts/data/dataRegistryV2/interfaces/IDataRegistryV2.sol
+++ b/contracts/data/dataRegistryV2/interfaces/IDataRegistryV2.sol
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import "../../scopeRegistry/interfaces/IScopeRegistry.sol";
+
+/**
+ * @title IDataRegistryV2
+ * @author Vana Network
+ * @notice Registry of data points keyed by a sequential id. Each data point
+ *         is owned by a single address, scoped under a ScopeRegistry scope,
+ *         and carries versioned metadata. Anyone may register their own data
+ *         points; only the owner may update them.
+ *
+ *         A data point's metadata is a monotonic version history: every
+ *         `updateMetadata` call increments `metadataVersion` and writes a new
+ *         string under that version. Old versions remain readable.
+ *
+ *         Scope status is verified at registration time only — if a scope is
+ *         deprecated after a data point is registered, existing data points
+ *         remain unaffected.
+ *
+ * @custom:security-contact security@vana.org
+ */
+interface IDataRegistryV2 {
+    enum Status {
+        None,
+        Active,
+        Inactive,
+        Unavailable
+    }
+
+    /// @dev Storage shape. Not returned from views because it contains a mapping.
+    struct DataPoint {
+        address owner;
+        bytes32 scopeId;
+        uint256 createdAt;
+        uint256 modifiedAt;
+        Status status;
+        uint256 metadataVersion;
+        mapping(uint256 version => string metadata) metadata;
+    }
+
+    /// @dev Memory-safe view of a data point (omits the metadata mapping).
+    struct DataPointInfo {
+        uint256 id;
+        address owner;
+        bytes32 scopeId;
+        uint256 createdAt;
+        uint256 modifiedAt;
+        Status status;
+        uint256 metadataVersion;
+    }
+
+    // ====================== Errors ======================
+
+    error ZeroAddress();
+    error EmptyMetadata();
+    error ScopeNotActive(bytes32 scopeId);
+    error DataPointNotFound(uint256 id);
+    error NotDataPointOwner(uint256 id, address caller);
+    error InvalidStatus();
+    error InvalidVersion(uint256 id, uint256 version);
+    error EmptyScopeRegistry();
+
+    // ====================== Events ======================
+
+    event DataPointRegistered(
+        uint256 indexed id,
+        address indexed owner,
+        bytes32 indexed scopeId,
+        string metadata
+    );
+
+    event DataPointMetadataUpdated(uint256 indexed id, uint256 indexed version, string metadata);
+
+    event DataPointStatusChanged(uint256 indexed id, Status indexed status);
+
+    event ScopeRegistryUpdated(address indexed previous, address indexed current);
+
+    // ====================== Views ======================
+
+    function version() external pure returns (uint256);
+
+    function scopeRegistry() external view returns (IScopeRegistry);
+
+    function dataPointsCount() external view returns (uint256);
+
+    /// @notice Returns the memory-safe view of a data point. For metadata,
+    ///         use `metadata(id)` or `metadataAt(id, version)`.
+    function dataPoints(uint256 id) external view returns (DataPointInfo memory);
+
+    /// @notice Latest metadata string for the data point.
+    function metadata(uint256 id) external view returns (string memory);
+
+    /// @notice Metadata at a specific version (1 = initial, monotonically increasing).
+    function metadataAt(uint256 id, uint256 version_) external view returns (string memory);
+
+    // ====================== Admin ======================
+
+    function pause() external;
+
+    function unpause() external;
+
+    function updateScopeRegistry(address newScopeRegistry) external;
+
+    // ====================== Mutations ======================
+
+    /// @notice Register a new data point under `scopeId` with initial metadata.
+    ///         Caller becomes the owner; status starts as Active.
+    /// @return id The newly assigned data point id.
+    function register(bytes32 scopeId, string calldata metadata_) external returns (uint256 id);
+
+    /// @notice Append a new metadata version. Bumps `metadataVersion` and
+    ///         updates `modifiedAt`. Caller must be the owner.
+    function updateMetadata(uint256 id, string calldata metadata_) external;
+
+    /// @notice Change the status of a data point. Caller must be the owner.
+    ///         Cannot set to `None` (that's the unregistered sentinel).
+    function setStatus(uint256 id, Status newStatus) external;
+}

--- a/contracts/data/namespaceRegistry/NamespaceRegistryImplementation.sol
+++ b/contracts/data/namespaceRegistry/NamespaceRegistryImplementation.sol
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
+import "@openzeppelin/contracts/utils/Strings.sol";
+import "./interfaces/NamespaceRegistryStorageV1.sol";
+
+/**
+ * @title NamespaceRegistryImplementation
+ * @notice Registry for address-derived and named namespaces. UUPS upgradeable.
+ */
+contract NamespaceRegistryImplementation is
+    UUPSUpgradeable,
+    PausableUpgradeable,
+    AccessControlUpgradeable,
+    NamespaceRegistryStorageV1
+{
+    /// @notice Role required to register named namespaces.
+    bytes32 public constant NAMED_NAMESPACE_ROLE = keccak256("NAMED_NAMESPACE_ROLE");
+
+    /// @dev Reverts unless `msg.sender` is the current owner of namespace `id`.
+    modifier onlyNamespaceOwner(bytes32 id) {
+        if (_namespaces[id].owner != msg.sender) revert NotNamespaceOwner(id, msg.sender);
+        _;
+    }
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    function initialize(address ownerAddress) external initializer {
+        if (ownerAddress == address(0)) revert ZeroAddress();
+
+        __AccessControl_init();
+        __UUPSUpgradeable_init();
+        __Pausable_init();
+
+        _grantRole(DEFAULT_ADMIN_ROLE, ownerAddress);
+    }
+
+    function _authorizeUpgrade(address newImplementation) internal virtual override onlyRole(DEFAULT_ADMIN_ROLE) {}
+
+    function version() external pure virtual override returns (uint256) {
+        return 1;
+    }
+
+    // ====================== Admin ======================
+
+    function pause() external override onlyRole(DEFAULT_ADMIN_ROLE) {
+        _pause();
+    }
+
+    function unpause() external override onlyRole(DEFAULT_ADMIN_ROLE) {
+        _unpause();
+    }
+
+    // ====================== Views ======================
+
+    function namespaces(bytes32 id) external view override returns (Namespace memory) {
+        return _namespaces[id];
+    }
+
+    function namespaceName(bytes32 id) external view override returns (string memory) {
+        Namespace storage ns = _namespaces[id];
+        if (ns.status == Status.None) return "";
+        if (bytes(ns.name).length > 0) return ns.name;
+        // Address-derived: id encodes the address directly; synthesize canonical hex.
+        return Strings.toHexString(address(uint160(uint256(id))));
+    }
+
+    function addressNamespaceId(address addr) public pure override returns (bytes32) {
+        return bytes32(uint256(uint160(addr)));
+    }
+
+    function namedNamespaceId(string calldata name) public pure override returns (bytes32) {
+        return keccak256(bytes(name));
+    }
+
+    // ====================== Registration ======================
+
+    function registerAddressNamespace(address addr) external override whenNotPaused {
+        if (addr == address(0)) revert ZeroAddress();
+        if (msg.sender != addr) revert CallerNotAddress(addr, msg.sender);
+
+        bytes32 id = addressNamespaceId(addr);
+        if (_namespaces[id].status != Status.None) revert NamespaceAlreadyExists(id);
+
+        _namespaces[id] = Namespace({id: id, owner: addr, status: Status.Active, name: ""});
+
+        emit AddressNamespaceRegistered(id, addr);
+    }
+
+    // Admin convention: names registered here MUST NOT contain a slash.
+    // ScopeRegistry derives scope ids as keccak256 over a string of the form
+    //   AT-SIGN namespace SLASH scopeName
+    // so distinct namespace names that overlap across the slash boundary
+    // would alias to the same scope id. Worked example:
+    //
+    //   register namespace "vana"     -> owner Alice
+    //   register namespace "vana/x"   -> owner Bob          <-- DON'T DO THIS
+    //   Alice can then claim scope ("vana", "x/profile")
+    //   Bob   can also claim scope ("vana/x", "profile")
+    //   Both produce id = keccak256("@vana/x/profile") and squat each other.
+    //
+    // The invariant is enforced socially by the holder of NAMED_NAMESPACE_ROLE
+    // (single source of truth) rather than on-chain, to keep registration
+    // cheap. If you ever need to delegate this role widely, add a slash-reject
+    // check below.
+    function registerNamedNamespace(string calldata name, address owner)
+        external
+        override
+        whenNotPaused
+        onlyRole(NAMED_NAMESPACE_ROLE)
+    {
+        if (bytes(name).length == 0) revert EmptyName();
+        if (owner == address(0)) revert ZeroAddress();
+
+        bytes32 id = namedNamespaceId(name);
+        if (_namespaces[id].status != Status.None) revert NamespaceAlreadyExists(id);
+
+        _namespaces[id] = Namespace({id: id, owner: owner, status: Status.Active, name: name});
+
+        emit NamedNamespaceRegistered(id, owner, name);
+    }
+
+    // ====================== Namespace ops ======================
+
+    function transferOwnership(bytes32 id, address newOwner)
+        external
+        override
+        whenNotPaused
+        onlyNamespaceOwner(id)
+    {
+        if (newOwner == address(0)) revert ZeroAddress();
+
+        Namespace storage ns = _namespaces[id];
+        if (ns.status != Status.Active) revert NamespaceNotActive(id);
+
+        address previousOwner = ns.owner;
+        ns.owner = newOwner;
+
+        emit NamespaceOwnershipTransferred(id, previousOwner, newOwner);
+    }
+
+    function deprecate(bytes32 id) external override whenNotPaused onlyNamespaceOwner(id) {
+        Namespace storage ns = _namespaces[id];
+        if (ns.status != Status.Active) revert NamespaceNotActive(id);
+
+        ns.status = Status.Deprecated;
+
+        emit NamespaceDeprecated(id);
+    }
+}

--- a/contracts/data/namespaceRegistry/NamespaceRegistryProxy.sol
+++ b/contracts/data/namespaceRegistry/NamespaceRegistryProxy.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+contract NamespaceRegistryProxy is ERC1967Proxy {
+    constructor(address logic, bytes memory data) ERC1967Proxy(logic, data) {}
+}

--- a/contracts/data/namespaceRegistry/interfaces/INamespaceRegistry.sol
+++ b/contracts/data/namespaceRegistry/interfaces/INamespaceRegistry.sol
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+/**
+ * @title INamespaceRegistry
+ * @author Vana Network
+ * @notice Registry for two kinds of namespaces:
+ *           - Address-derived: any EOA / contract can claim its own namespace
+ *             (id = `bytes32(uint256(uint160(addr)))`, caller must equal `addr`).
+ *           - Named: arbitrary string namespace gated by NAMED_NAMESPACE_ROLE
+ *             (id = `keccak256(bytes(name))`).
+ *
+ *         Both share a single id space. The address-derived form only ever
+ *         produces ids whose top 96 bits are zero, while named ids come from
+ *         keccak256 — so accidental collision is cryptographically negligible.
+ *
+ * @custom:security-contact security@vana.org
+ */
+interface INamespaceRegistry {
+    enum Status {
+        None,
+        Active,
+        Deprecated
+    }
+
+    struct Namespace {
+        bytes32 id;
+        address owner;
+        Status status;
+        /// @dev Human-readable name. Set for named namespaces; empty for
+        ///      address-derived namespaces (the address is recoverable from `id`).
+        string name;
+    }
+
+    // ====================== Errors ======================
+
+    error ZeroAddress();
+    error EmptyName();
+    error CallerNotAddress(address expected, address caller);
+    error NamespaceAlreadyExists(bytes32 id);
+    error NamespaceNotActive(bytes32 id);
+    error NotNamespaceOwner(bytes32 id, address caller);
+
+    // ====================== Events ======================
+
+    event AddressNamespaceRegistered(bytes32 indexed id, address indexed owner);
+
+    event NamedNamespaceRegistered(bytes32 indexed id, address indexed owner, string name);
+
+    event NamespaceOwnershipTransferred(
+        bytes32 indexed id,
+        address indexed previousOwner,
+        address indexed newOwner
+    );
+
+    event NamespaceDeprecated(bytes32 indexed id);
+
+    // ====================== Views ======================
+
+    function version() external pure returns (uint256);
+
+    function namespaces(bytes32 id) external view returns (Namespace memory);
+
+    /// @notice Canonical human-readable name of a namespace.
+    ///           - For named namespaces, returns the registered string.
+    ///           - For address-derived namespaces, returns the address in
+    ///             canonical lowercase 0x-prefixed hex (length 42).
+    ///           - For unregistered ids, returns the empty string.
+    function namespaceName(bytes32 id) external view returns (string memory);
+
+    /// @notice id for an address-derived namespace.
+    function addressNamespaceId(address addr) external pure returns (bytes32);
+
+    /// @notice id for a named namespace.
+    function namedNamespaceId(string calldata name) external pure returns (bytes32);
+
+    // ====================== Admin ======================
+
+    function pause() external;
+
+    function unpause() external;
+
+    // ====================== Registration ======================
+
+    /// @notice Claim the namespace derived from `addr`. Caller must be `addr`.
+    function registerAddressNamespace(address addr) external;
+
+    /// @notice Register a named namespace; restricted to NAMED_NAMESPACE_ROLE.
+    /// @param name  Human-readable name (will be hashed to derive the id)
+    /// @param owner Address that will own the new namespace
+    function registerNamedNamespace(string calldata name, address owner) external;
+
+    // ====================== Namespace ops ======================
+
+    /// @notice Transfer ownership of a namespace. Caller must be the current owner.
+    function transferOwnership(bytes32 id, address newOwner) external;
+
+    /// @notice Mark a namespace as deprecated. Caller must be the current owner.
+    ///         Deprecated namespaces are frozen — no further transfers, and the
+    ///         id cannot be re-registered.
+    function deprecate(bytes32 id) external;
+}

--- a/contracts/data/namespaceRegistry/interfaces/NamespaceRegistryStorageV1.sol
+++ b/contracts/data/namespaceRegistry/interfaces/NamespaceRegistryStorageV1.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import "./INamespaceRegistry.sol";
+
+/**
+ * @title Storage for NamespaceRegistry
+ * @notice For future upgrades, do not change NamespaceRegistryStorageV1. Create a new
+ * contract which implements NamespaceRegistryStorageV1.
+ */
+abstract contract NamespaceRegistryStorageV1 is INamespaceRegistry {
+    mapping(bytes32 id => Namespace) internal _namespaces;
+}

--- a/contracts/data/scopeRegistry/ScopeRegistryImplementation.sol
+++ b/contracts/data/scopeRegistry/ScopeRegistryImplementation.sol
@@ -75,6 +75,10 @@ contract ScopeRegistryImplementation is
         return _scopes[id].status != Status.None;
     }
 
+    function scopeStatus(bytes32 id) external view override returns (Status) {
+        return _scopes[id].status;
+    }
+
     function scopeId(string calldata namespaceName, string calldata scopeName)
         external
         pure

--- a/contracts/data/scopeRegistry/ScopeRegistryImplementation.sol
+++ b/contracts/data/scopeRegistry/ScopeRegistryImplementation.sol
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
+import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+import "./interfaces/ScopeRegistryStorageV1.sol";
+
+/**
+ * @title ScopeRegistryImplementation
+ * @notice Registers scopes under a NamespaceRegistry-managed namespace.
+ * @dev UUPS upgradeable.
+ */
+contract ScopeRegistryImplementation is
+    UUPSUpgradeable,
+    PausableUpgradeable,
+    AccessControlUpgradeable,
+    ScopeRegistryStorageV1
+{
+    using EnumerableSet for EnumerableSet.Bytes32Set;
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    function initialize(address ownerAddress, address namespaceRegistryAddress) external initializer {
+        if (ownerAddress == address(0)) revert ZeroAddress();
+        if (namespaceRegistryAddress == address(0)) revert EmptyNamespaceRegistry();
+
+        __AccessControl_init();
+        __UUPSUpgradeable_init();
+        __Pausable_init();
+
+        namespaceRegistry = INamespaceRegistry(namespaceRegistryAddress);
+
+        _grantRole(DEFAULT_ADMIN_ROLE, ownerAddress);
+    }
+
+    function _authorizeUpgrade(address newImplementation) internal virtual override onlyRole(DEFAULT_ADMIN_ROLE) {}
+
+    function version() external pure virtual override returns (uint256) {
+        return 1;
+    }
+
+    // ====================== Admin ======================
+
+    function pause() external override onlyRole(DEFAULT_ADMIN_ROLE) {
+        _pause();
+    }
+
+    function unpause() external override onlyRole(DEFAULT_ADMIN_ROLE) {
+        _unpause();
+    }
+
+    function updateNamespaceRegistry(address newNamespaceRegistry)
+        external
+        override
+        onlyRole(DEFAULT_ADMIN_ROLE)
+    {
+        if (newNamespaceRegistry == address(0)) revert EmptyNamespaceRegistry();
+        address previous = address(namespaceRegistry);
+        namespaceRegistry = INamespaceRegistry(newNamespaceRegistry);
+        emit NamespaceRegistryUpdated(previous, newNamespaceRegistry);
+    }
+
+    // ====================== Views ======================
+
+    function scopes(bytes32 id) external view override returns (Scope memory) {
+        return _scopes[id];
+    }
+
+    function isRegistered(bytes32 id) external view override returns (bool) {
+        return _scopes[id].status != Status.None;
+    }
+
+    function scopeId(string calldata namespaceName, string calldata scopeName)
+        external
+        pure
+        override
+        returns (bytes32)
+    {
+        return _scopeId(bytes(namespaceName), bytes(scopeName));
+    }
+
+    function fullScope(bytes32 id) external view override returns (string memory) {
+        Scope storage s = _scopes[id];
+        if (s.status == Status.None) return "";
+
+        string memory nsName = namespaceRegistry.namespaceName(s.namespaceId);
+        return string(abi.encodePacked(bytes1("@"), bytes(nsName), bytes1("/"), bytes(s.name)));
+    }
+
+    function namespaceScopesCount(bytes32 namespaceId) external view override returns (uint256) {
+        return _scopesByNamespace[namespaceId].length();
+    }
+
+    function namespaceScopeIdAt(bytes32 namespaceId, uint256 index) external view override returns (bytes32) {
+        return _scopesByNamespace[namespaceId].at(index);
+    }
+
+    function namespaceScopeIds(bytes32 namespaceId) external view override returns (bytes32[] memory) {
+        return _scopesByNamespace[namespaceId].values();
+    }
+
+    // ====================== Registration ======================
+
+    function register(string calldata namespaceName, string calldata scopeName) external override whenNotPaused {
+        bytes calldata nsBytes = bytes(namespaceName);
+        bytes calldata snBytes = bytes(scopeName);
+
+        if (nsBytes.length == 0 || snBytes.length == 0) revert InvalidScopeFormat();
+
+        // NOTE: scope-id collisions across distinct (namespace, scopeName) pairs
+        // are prevented at the namespace boundary — the admin must not register
+        // named namespaces whose names contain a slash. See NamespaceRegistry.
+        bytes32 nsId = keccak256(nsBytes);
+        bytes32 id = _scopeId(nsBytes, snBytes);
+
+        if (_scopes[id].status != Status.None) revert ScopeAlreadyExists(id);
+
+        INamespaceRegistry.Namespace memory ns = namespaceRegistry.namespaces(nsId);
+        if (ns.status != INamespaceRegistry.Status.Active) revert NamespaceNotActiveOrMissing(nsId);
+        if (ns.owner != msg.sender) revert NotNamespaceOwner(nsId, msg.sender);
+
+        _scopes[id] = Scope({id: id, namespaceId: nsId, status: Status.Active, name: scopeName});
+        _scopesByNamespace[nsId].add(id);
+
+        emit ScopeRegistered(id, nsId, msg.sender, namespaceName, scopeName);
+    }
+
+    function deprecate(bytes32 id) external override whenNotPaused {
+        Scope storage s = _scopes[id];
+        if (s.status != Status.Active) revert ScopeNotActive(id);
+
+        bytes32 nsId = s.namespaceId;
+        INamespaceRegistry.Namespace memory ns = namespaceRegistry.namespaces(nsId);
+        if (ns.owner != msg.sender) revert NotNamespaceOwner(nsId, msg.sender);
+
+        s.status = Status.Deprecated;
+
+        emit ScopeDeprecated(id);
+    }
+
+    // Canonical scope id: keccak256 over the packed bytes  AT-SIGN ns SLASH sn .
+    function _scopeId(bytes memory ns, bytes memory sn) internal pure returns (bytes32) {
+        return keccak256(abi.encodePacked(bytes1("@"), ns, bytes1("/"), sn));
+    }
+}

--- a/contracts/data/scopeRegistry/ScopeRegistryProxy.sol
+++ b/contracts/data/scopeRegistry/ScopeRegistryProxy.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+contract ScopeRegistryProxy is ERC1967Proxy {
+    constructor(address logic, bytes memory data) ERC1967Proxy(logic, data) {}
+}

--- a/contracts/data/scopeRegistry/interfaces/IScopeRegistry.sol
+++ b/contracts/data/scopeRegistry/interfaces/IScopeRegistry.sol
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import "../../namespaceRegistry/interfaces/INamespaceRegistry.sol";
+
+/**
+ * @title IScopeRegistry
+ * @author Vana Network
+ * @notice Registry for scopes nested under a namespace.
+ *
+ *         Callers pass the namespace name and the local scope name separately
+ *         (no parsing). The canonical scope id is keccak256 over the packed
+ *         bytes  AT-SIGN  namespace  SLASH  scopeName  — equivalent to hashing
+ *         the joined string. The namespace id is keccak256(bytes(namespace))
+ *         and must reference an Active named namespace whose owner is the
+ *         caller.
+ *
+ *         Collision safety relies on an upstream invariant: NamespaceRegistry
+ *         must not contain named namespaces whose names include a slash. See
+ *         that contract's docs for the rationale and worked example.
+ *
+ *         Address-derived namespaces are not supported in this version.
+ *
+ * @custom:security-contact security@vana.org
+ */
+interface IScopeRegistry {
+    enum Status {
+        None,
+        Active,
+        Deprecated
+    }
+
+    struct Scope {
+        bytes32 id;
+        bytes32 namespaceId;
+        Status status;
+        /// @dev Local scope name only (e.g. "instagram.profile"). The full
+        ///      canonical form is reconstructable via `fullScope(id)`.
+        string name;
+    }
+
+    // ====================== Errors ======================
+
+    error InvalidScopeFormat();
+    error EmptyNamespaceRegistry();
+    error ZeroAddress();
+    error ScopeAlreadyExists(bytes32 id);
+    error ScopeNotActive(bytes32 id);
+    error NamespaceNotActiveOrMissing(bytes32 namespaceId);
+    error NotNamespaceOwner(bytes32 namespaceId, address caller);
+
+    // ====================== Events ======================
+
+    event ScopeRegistered(
+        bytes32 indexed id,
+        bytes32 indexed namespaceId,
+        address indexed owner,
+        string namespaceName,
+        string scopeName
+    );
+
+    event ScopeDeprecated(bytes32 indexed id);
+
+    event NamespaceRegistryUpdated(address indexed previous, address indexed current);
+
+    // ====================== Views ======================
+
+    function version() external pure returns (uint256);
+
+    function namespaceRegistry() external view returns (INamespaceRegistry);
+
+    function scopes(bytes32 id) external view returns (Scope memory);
+
+    function isRegistered(bytes32 scopeId) external view returns (bool);
+
+    /// @notice Compute the on-chain id for a (namespace, scopeName) pair.
+    function scopeId(string calldata namespaceName, string calldata scopeName) external pure returns (bytes32);
+
+    /// @notice Returns the full canonical scope string (form: at-sign namespace
+    ///         slash scopeName) by joining the namespace's name (looked up in
+    ///         NamespaceRegistry) with the local scope name. Returns the empty
+    ///         string for ids that aren't registered.
+    function fullScope(bytes32 id) external view returns (string memory);
+
+    /// @notice Number of scopes (Active + Deprecated) registered under `namespaceId`.
+    function namespaceScopesCount(bytes32 namespaceId) external view returns (uint256);
+
+    /// @notice Scope id at `index` within the namespace's set. Order is insertion-stable
+    ///         until something is removed; we never remove, so it's effectively registration order.
+    function namespaceScopeIdAt(bytes32 namespaceId, uint256 index) external view returns (bytes32);
+
+    /// @notice All scope ids ever registered under `namespaceId`.
+    /// @dev    Gas-unbounded — intended for off-chain reads. On-chain callers
+    ///         should paginate via `namespaceScopesCount` + `namespaceScopeIdAt`.
+    function namespaceScopeIds(bytes32 namespaceId) external view returns (bytes32[] memory);
+
+    // ====================== Admin ======================
+
+    function pause() external;
+
+    function unpause() external;
+
+    function updateNamespaceRegistry(address newNamespaceRegistry) external;
+
+    // ====================== Registration ======================
+
+    /// @notice Register a new scope under `namespaceName`. Caller must own the
+    ///         referenced named namespace. `namespaceName` must not contain a
+    ///         slash; both inputs must be non-empty.
+    function register(string calldata namespaceName, string calldata scopeName) external;
+
+    /// @notice Mark a scope as deprecated. Caller must own the parent namespace.
+    ///         Deprecated scopes are frozen; the id cannot be re-registered.
+    function deprecate(bytes32 id) external;
+}

--- a/contracts/data/scopeRegistry/interfaces/IScopeRegistry.sol
+++ b/contracts/data/scopeRegistry/interfaces/IScopeRegistry.sol
@@ -73,6 +73,11 @@ interface IScopeRegistry {
 
     function isRegistered(bytes32 scopeId) external view returns (bool);
 
+    /// @notice Status of a scope by id. Cheaper than `scopes(id).status` for
+    ///         on-chain callers since the return is a single uint8 slot
+    ///         instead of the full Scope struct.
+    function scopeStatus(bytes32 scopeId) external view returns (Status);
+
     /// @notice Compute the on-chain id for a (namespace, scopeName) pair.
     function scopeId(string calldata namespaceName, string calldata scopeName) external pure returns (bytes32);
 

--- a/contracts/data/scopeRegistry/interfaces/ScopeRegistryStorageV1.sol
+++ b/contracts/data/scopeRegistry/interfaces/ScopeRegistryStorageV1.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+import "./IScopeRegistry.sol";
+
+/**
+ * @title Storage for ScopeRegistry
+ * @notice For future upgrades, do not change ScopeRegistryStorageV1. Create a new
+ * contract which implements ScopeRegistryStorageV1.
+ */
+abstract contract ScopeRegistryStorageV1 is IScopeRegistry {
+    /// @dev Reference to the namespace registry used for owner / status checks.
+    INamespaceRegistry public override namespaceRegistry;
+
+    mapping(bytes32 id => Scope) internal _scopes;
+
+    /// @dev All scope ids ever registered under a given namespace (includes
+    ///      Deprecated). Use the `status` field on each scope to filter.
+    mapping(bytes32 namespaceId => EnumerableSet.Bytes32Set) internal _scopesByNamespace;
+}


### PR DESCRIPTION
Add NamespaceRegistry and ScopeRegistry under contracts/data. Namespaces come in two flavors — address-derived (caller registers their own) and named (role-gated). Scopes are nested under a namespace and registered by the namespace owner. Per-namespace scope enumeration via EnumerableSet, with canonical full-scope reconstruction via on-demand join against NamespaceRegistry (no duplicated name storage).