### PR TITLE
feat: runOpAndSettle + delegated signing across the dp_escrow stack

### DIFF
--- a/contracts/data/dataRegistryV2/DataRegistryV2Implementation.sol
+++ b/contracts/data/dataRegistryV2/DataRegistryV2Implementation.sol
@@ -124,7 +124,10 @@ contract DataRegistryV2Implementation is
         override
         returns (DataPointInfo memory)
     {
-        bytes32 id = _dataPointId(ownerAddress, scope);
+        return dataPointById(_dataPointId(ownerAddress, scope));
+    }
+
+    function dataPointById(bytes32 id) public view override returns (DataPointInfo memory) {
         DataPoint storage d = _dataPoints[id];
         return
             DataPointInfo({

--- a/contracts/data/dataRegistryV2/DataRegistryV2Implementation.sol
+++ b/contracts/data/dataRegistryV2/DataRegistryV2Implementation.sol
@@ -278,7 +278,20 @@ contract DataRegistryV2Implementation is
 
         address signer = ECDSA.recover(digest, signature);
         if (signer == address(0)) revert InvalidSignature();
-        if (signer != ownerAddress) revert OwnerMismatch(ownerAddress, signer);
+
+        // Two accepted authorities, identical to `addPermissionWithSignature`:
+        //   1. Owner self-signed — original V2 behavior.
+        //   2. Delegate — a personal server currently registered to the owner
+        //      in `dataPortabilityServers`. Trust is evaluated at execution
+        //      time; revocation in the servers registry immediately removes
+        //      signing authority.
+        // When `dataPortabilityServers` is unset, only path 1 is accepted —
+        // preserves pre-upgrade behavior bit-for-bit.
+        bool isOwner = signer == ownerAddress;
+        bool isDelegate = !isOwner
+            && address(dataPortabilityServers) != address(0)
+            && _isTrustedServer(ownerAddress, signer);
+        if (!isOwner && !isDelegate) revert OwnerMismatch(ownerAddress, signer);
 
         // Replay + rollback protection: signer must commit to the exact next
         // version. If anyone (the same owner via the direct path, or another
@@ -287,7 +300,8 @@ contract DataRegistryV2Implementation is
         uint256 nextVersion = uint256(_dataPoints[idCheck].currentVersion) + 1;
         if (expectedVersion != nextVersion) revert UnexpectedVersion(nextVersion, expectedVersion);
 
-        return _addData(ownerAddress, scope, dataHash, metadataHash);
+        (id, version_) = _addData(ownerAddress, scope, dataHash, metadataHash);
+        if (isDelegate) emit DataSignedByDelegate(id, ownerAddress, signer);
     }
 
     // ====================== Access recording ======================

--- a/contracts/data/dataRegistryV2/DataRegistryV2Implementation.sol
+++ b/contracts/data/dataRegistryV2/DataRegistryV2Implementation.sol
@@ -1,0 +1,397 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol";
+import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+import "./interfaces/DataRegistryV2StorageV1.sol";
+
+/**
+ * @title DataRegistryV2Implementation
+ * @notice Scope-first data point registry. UUPS upgradeable.
+ *
+ *         See `IDataRegistryV2` for the full contract; this implementation
+ *         enforces:
+ *           - one data point per (owner, scope)
+ *           - upsert semantics on `addData` (auto-revives Inactive/Unavailable)
+ *           - `recordDataAccess` is gated by ACCESS_RECORDER_ROLE AND requires an
+ *             EIP-712 signature from one of the owner's trusted personal
+ *             servers (verified via DataPortabilityServers)
+ *           - EIP-712 delegated writes via `addDataWithSignature` with
+ *             per-data-point version monotonicity for replay protection
+ */
+contract DataRegistryV2Implementation is
+    UUPSUpgradeable,
+    PausableUpgradeable,
+    AccessControlUpgradeable,
+    EIP712Upgradeable,
+    DataRegistryV2StorageV1
+{
+    using ECDSA for bytes32;
+    using EnumerableSet for EnumerableSet.Bytes32Set;
+
+    string private constant SIGNING_DOMAIN = "Vana Data Portability";
+    string private constant SIGNATURE_VERSION = "1";
+
+    /// @dev Soft cap on scope string length to prevent gas griefing on the
+    ///      single SSTORE for the `scope` field.
+    uint256 private constant MAX_SCOPE_BYTES = 256;
+
+    /// @notice Role required to submit `recordDataAccess` calls.
+    bytes32 public constant ACCESS_RECORDER_ROLE = keccak256("ACCESS_RECORDER_ROLE");
+
+    bytes32 public constant override ADD_DATA_TYPEHASH =
+        keccak256(
+            "AddData(address ownerAddress,string scope,bytes32 dataHash,bytes32 metadataHash,uint256 expectedVersion)"
+        );
+
+    bytes32 public constant override RECORD_ACCESS_TYPEHASH =
+        keccak256(
+            "RecordDataAccess(address ownerAddress,string scope,uint256 version,address accessor,bytes32 recordId)"
+        );
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    function initialize(address ownerAddress) external initializer {
+        if (ownerAddress == address(0)) revert ZeroAddress();
+
+        __AccessControl_init();
+        __UUPSUpgradeable_init();
+        __Pausable_init();
+        __EIP712_init(SIGNING_DOMAIN, SIGNATURE_VERSION);
+
+        _grantRole(DEFAULT_ADMIN_ROLE, ownerAddress);
+    }
+
+    function _authorizeUpgrade(address newImplementation) internal virtual override onlyRole(DEFAULT_ADMIN_ROLE) {}
+
+    function version() external pure virtual override returns (uint256) {
+        return 1;
+    }
+
+    // ====================== Admin ======================
+
+    function pause() external override onlyRole(DEFAULT_ADMIN_ROLE) {
+        _pause();
+    }
+
+    function unpause() external override onlyRole(DEFAULT_ADMIN_ROLE) {
+        _unpause();
+    }
+
+    function setDataPortabilityServers(address newDataPortabilityServers)
+        external
+        override
+        onlyRole(DEFAULT_ADMIN_ROLE)
+    {
+        if (newDataPortabilityServers == address(0)) revert ZeroAddress();
+        address previous = address(dataPortabilityServers);
+        dataPortabilityServers = IDataPortabilityServersV2(newDataPortabilityServers);
+        emit DataPortabilityServersUpdated(previous, newDataPortabilityServers);
+    }
+
+    // ====================== Pure helpers ======================
+
+    function dataPointId(address ownerAddress, string calldata scope)
+        public
+        pure
+        override
+        returns (bytes32)
+    {
+        return _dataPointId(ownerAddress, scope);
+    }
+
+    function computeCommitment(bytes32 dataHash, bytes32 metadataHash)
+        external
+        pure
+        override
+        returns (bytes32)
+    {
+        return keccak256(abi.encode(dataHash, metadataHash));
+    }
+
+    // ====================== Views ======================
+
+    function dataPoints(address ownerAddress, string calldata scope)
+        external
+        view
+        override
+        returns (DataPointInfo memory)
+    {
+        bytes32 id = _dataPointId(ownerAddress, scope);
+        DataPoint storage d = _dataPoints[id];
+        return
+            DataPointInfo({
+                id: id,
+                owner: d.owner,
+                scope: d.scope,
+                status: d.status,
+                currentVersion: d.currentVersion,
+                currentCommitment: d.commitments[d.currentVersion],
+                createdAt: d.createdAt,
+                modifiedAt: d.modifiedAt,
+                totalAccesses: d.totalAccesses
+            });
+    }
+
+    function dataCommitment(address ownerAddress, string calldata scope, uint256 version_)
+        external
+        view
+        override
+        returns (bytes32)
+    {
+        return _dataPoints[_dataPointId(ownerAddress, scope)].commitments[version_];
+    }
+
+    function currentCommitment(address ownerAddress, string calldata scope)
+        external
+        view
+        override
+        returns (bytes32)
+    {
+        DataPoint storage d = _dataPoints[_dataPointId(ownerAddress, scope)];
+        return d.commitments[d.currentVersion];
+    }
+
+    function currentVersion(address ownerAddress, string calldata scope)
+        external
+        view
+        override
+        returns (uint256)
+    {
+        return _dataPoints[_dataPointId(ownerAddress, scope)].currentVersion;
+    }
+
+    function accessCount(address ownerAddress, string calldata scope, uint256 version_)
+        external
+        view
+        override
+        returns (uint256)
+    {
+        return _dataPoints[_dataPointId(ownerAddress, scope)].accessesByVersion[version_];
+    }
+
+    function totalAccesses(address ownerAddress, string calldata scope)
+        external
+        view
+        override
+        returns (uint256)
+    {
+        return _dataPoints[_dataPointId(ownerAddress, scope)].totalAccesses;
+    }
+
+    function scopeDataPointsCount(string calldata scope) external view override returns (uint256) {
+        return _dataPointsByScope[keccak256(bytes(scope))].length();
+    }
+
+    function scopeDataPointIdAt(string calldata scope, uint256 index)
+        external
+        view
+        override
+        returns (bytes32)
+    {
+        return _dataPointsByScope[keccak256(bytes(scope))].at(index);
+    }
+
+    function scopeDataPointIds(
+        string calldata scope,
+        uint256 offset,
+        uint256 limit
+    ) external view override returns (bytes32[] memory) {
+        EnumerableSet.Bytes32Set storage set = _dataPointsByScope[keccak256(bytes(scope))];
+        uint256 total = set.length();
+        if (offset >= total) {
+            return new bytes32[](0);
+        }
+        uint256 end = offset + limit;
+        if (end > total) end = total;
+        uint256 size = end - offset;
+        bytes32[] memory result = new bytes32[](size);
+        for (uint256 i = 0; i < size; ) {
+            result[i] = set.at(offset + i);
+            unchecked {
+                ++i;
+            }
+        }
+        return result;
+    }
+
+    function isRecordIdUsed(bytes32 recordId) external view override returns (bool) {
+        return _usedRecordIds[recordId];
+    }
+
+    // ====================== Writes (direct) ======================
+
+    function addData(string calldata scope, bytes32 dataHash, bytes32 metadataHash)
+        external
+        override
+        whenNotPaused
+        returns (bytes32 id, uint256 version_)
+    {
+        return _addData(msg.sender, scope, dataHash, metadataHash);
+    }
+
+    function setStatus(string calldata scope, Status newStatus) external override whenNotPaused {
+        if (newStatus == Status.None) revert InvalidStatus();
+
+        bytes32 id = _dataPointId(msg.sender, scope);
+        DataPoint storage d = _dataPoints[id];
+        if (d.currentVersion == 0) revert DataPointNotFound(id);
+        if (d.status == newStatus) return; // silent no-op
+
+        d.status = newStatus;
+        d.modifiedAt = uint64(block.timestamp);
+        emit DataPointStatusChanged(id, newStatus);
+    }
+
+    // ====================== Writes (signed, delegated) ======================
+
+    function addDataWithSignature(
+        address ownerAddress,
+        string calldata scope,
+        bytes32 dataHash,
+        bytes32 metadataHash,
+        uint256 expectedVersion,
+        bytes calldata signature
+    ) external override whenNotPaused returns (bytes32 id, uint256 version_) {
+        bytes32 digest = _hashTypedDataV4(
+            keccak256(
+                abi.encode(
+                    ADD_DATA_TYPEHASH,
+                    ownerAddress,
+                    keccak256(bytes(scope)),
+                    dataHash,
+                    metadataHash,
+                    expectedVersion
+                )
+            )
+        );
+
+        address signer = ECDSA.recover(digest, signature);
+        if (signer == address(0)) revert InvalidSignature();
+        if (signer != ownerAddress) revert OwnerMismatch(ownerAddress, signer);
+
+        // Replay + rollback protection: signer must commit to the exact next
+        // version. If anyone (the same owner via the direct path, or another
+        // signature) raced ahead, this reverts.
+        bytes32 idCheck = _dataPointId(ownerAddress, scope);
+        uint256 nextVersion = uint256(_dataPoints[idCheck].currentVersion) + 1;
+        if (expectedVersion != nextVersion) revert UnexpectedVersion(nextVersion, expectedVersion);
+
+        return _addData(ownerAddress, scope, dataHash, metadataHash);
+    }
+
+    // ====================== Access recording ======================
+
+    function recordDataAccess(
+        address ownerAddress,
+        string calldata scope,
+        uint256 version_,
+        address accessor,
+        bytes32 recordId,
+        bytes calldata signature
+    ) external override whenNotPaused onlyRole(ACCESS_RECORDER_ROLE) {
+        if (address(dataPortabilityServers) == address(0)) revert DataPortabilityServersNotSet();
+        if (_usedRecordIds[recordId]) revert RecordIdAlreadyUsed(recordId);
+
+        // Recover the signer (must be one of the owner's trusted personal servers).
+        bytes32 digest = _hashTypedDataV4(
+            keccak256(
+                abi.encode(
+                    RECORD_ACCESS_TYPEHASH,
+                    ownerAddress,
+                    keccak256(bytes(scope)),
+                    version_,
+                    accessor,
+                    recordId
+                )
+            )
+        );
+        address server = ECDSA.recover(digest, signature);
+        if (server == address(0)) revert InvalidSignature();
+        if (!_isTrustedServer(ownerAddress, server)) revert UntrustedServer(ownerAddress, server);
+
+        bytes32 id = _dataPointId(ownerAddress, scope);
+        DataPoint storage d = _dataPoints[id];
+        if (version_ == 0 || version_ > d.currentVersion) revert UnknownVersion(id, version_);
+
+        _usedRecordIds[recordId] = true;
+
+        uint256 newVersionCount;
+        uint256 newTotal;
+        unchecked {
+            newVersionCount = d.accessesByVersion[version_] + 1;
+            newTotal = d.totalAccesses + 1;
+        }
+        d.accessesByVersion[version_] = newVersionCount;
+        d.totalAccesses = newTotal;
+
+        emit DataAccessRecorded(id, version_, accessor, server, recordId, newVersionCount, newTotal);
+    }
+
+    /// @dev Checks DataPortabilityServersV2 to confirm `server` has an active
+    ///      registration AND that registration's owner is `ownerAddress`.
+    ///      In V2 a server address has at most one active owner at a time.
+    function _isTrustedServer(address ownerAddress, address server) internal view returns (bool) {
+        bytes32 sId = dataPortabilityServers.activeServerId(server);
+        if (sId == bytes32(0)) return false;
+        IDataPortabilityServersV2.ServerInfo memory info = dataPortabilityServers.getServer(sId);
+        return info.ownerAddress == ownerAddress;
+    }
+
+    // ====================== Internals ======================
+
+    function _dataPointId(address ownerAddress, string calldata scope) internal pure returns (bytes32) {
+        return keccak256(abi.encode(ownerAddress, scope));
+    }
+
+    function _addData(
+        address ownerAddress,
+        string calldata scope,
+        bytes32 dataHash,
+        bytes32 metadataHash
+    ) internal returns (bytes32 id, uint256 version_) {
+        if (ownerAddress == address(0)) revert ZeroAddress();
+        uint256 scopeLen = bytes(scope).length;
+        if (scopeLen == 0) revert EmptyScope();
+        if (scopeLen > MAX_SCOPE_BYTES) revert ScopeTooLong();
+
+        id = _dataPointId(ownerAddress, scope);
+        DataPoint storage d = _dataPoints[id];
+        bytes32 commitment = keccak256(abi.encode(dataHash, metadataHash));
+
+        if (d.currentVersion == 0) {
+            // First write: create.
+            d.owner = ownerAddress;
+            d.scope = scope;
+            d.status = Status.Active;
+            d.createdAt = uint64(block.timestamp);
+            version_ = 1;
+
+            _dataPointsByScope[keccak256(bytes(scope))].add(id);
+            emit DataPointCreated(id, ownerAddress, keccak256(bytes(scope)), scope);
+        } else {
+            // Append.
+            unchecked {
+                version_ = uint256(d.currentVersion) + 1;
+            }
+            // Auto-revive Inactive/Unavailable on new data.
+            if (d.status != Status.Active) {
+                d.status = Status.Active;
+                emit DataPointStatusChanged(id, Status.Active);
+            }
+        }
+
+        d.currentVersion = uint64(version_);
+        d.modifiedAt = uint64(block.timestamp);
+        d.commitments[version_] = commitment;
+
+        emit DataVersionAdded(id, version_, dataHash, metadataHash, commitment);
+    }
+}

--- a/contracts/data/dataRegistryV2/DataRegistryV2Implementation.sol
+++ b/contracts/data/dataRegistryV2/DataRegistryV2Implementation.sol
@@ -53,6 +53,11 @@ contract DataRegistryV2Implementation is
             "RecordDataAccess(address ownerAddress,string scope,uint256 version,address accessor,bytes32 recordId)"
         );
 
+    bytes32 public constant override SET_STATUS_TYPEHASH =
+        keccak256(
+            "SetStatus(address ownerAddress,string scope,uint8 newStatus,uint256 expectedSequence)"
+        );
+
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
         _disableInitializers();
@@ -229,6 +234,15 @@ contract DataRegistryV2Implementation is
         return _usedRecordIds[recordId];
     }
 
+    function statusSequence(address ownerAddress, string calldata scope)
+        external
+        view
+        override
+        returns (uint256)
+    {
+        return _statusSequences[_dataPointId(ownerAddress, scope)];
+    }
+
     // ====================== Writes (direct) ======================
 
     function addData(string calldata scope, bytes32 dataHash, bytes32 metadataHash)
@@ -302,6 +316,65 @@ contract DataRegistryV2Implementation is
 
         (id, version_) = _addData(ownerAddress, scope, dataHash, metadataHash);
         if (isDelegate) emit DataSignedByDelegate(id, ownerAddress, signer);
+    }
+
+    /// @inheritdoc IDataRegistryV2
+    /// @dev Mirrors `addDataWithSignature`'s dual-signer + monotonic-counter
+    ///      pattern, against `_statusSequences` instead of `currentVersion` so
+    ///      data writes and status flips can't invalidate each other's
+    ///      pending signatures. The sequence is consumed even on the
+    ///      silent-no-op case (status already equals newStatus) so the
+    ///      signature can never be replayed.
+    function setStatusWithSignature(
+        address ownerAddress,
+        string calldata scope,
+        Status newStatus,
+        uint256 expectedSequence,
+        bytes calldata signature
+    ) external override whenNotPaused {
+        if (newStatus == Status.None) revert InvalidStatus();
+
+        bytes32 digest = _hashTypedDataV4(
+            keccak256(
+                abi.encode(
+                    SET_STATUS_TYPEHASH,
+                    ownerAddress,
+                    keccak256(bytes(scope)),
+                    uint8(newStatus),
+                    expectedSequence
+                )
+            )
+        );
+
+        address signer = ECDSA.recover(digest, signature);
+        if (signer == address(0)) revert InvalidSignature();
+
+        bool isOwner = signer == ownerAddress;
+        bool isDelegate = !isOwner
+            && address(dataPortabilityServers) != address(0)
+            && _isTrustedServer(ownerAddress, signer);
+        if (!isOwner && !isDelegate) revert OwnerMismatch(ownerAddress, signer);
+
+        bytes32 id = _dataPointId(ownerAddress, scope);
+        DataPoint storage d = _dataPoints[id];
+        if (d.currentVersion == 0) revert DataPointNotFound(id);
+
+        uint256 nextSequence = _statusSequences[id] + 1;
+        if (expectedSequence != nextSequence) revert UnexpectedVersion(nextSequence, expectedSequence);
+        _statusSequences[id] = nextSequence;
+
+        // Status already at target: counter is consumed (anti-replay), but no
+        // state mutation and no event — matches direct setStatus's silent
+        // no-op semantics on the status side.
+        if (d.status == newStatus) {
+            if (isDelegate) emit StatusSignedByDelegate(id, ownerAddress, signer);
+            return;
+        }
+
+        d.status = newStatus;
+        d.modifiedAt = uint64(block.timestamp);
+        emit DataPointStatusChanged(id, newStatus);
+        if (isDelegate) emit StatusSignedByDelegate(id, ownerAddress, signer);
     }
 
     // ====================== Access recording ======================

--- a/contracts/data/dataRegistryV2/DataRegistryV2Proxy.sol
+++ b/contracts/data/dataRegistryV2/DataRegistryV2Proxy.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+contract DataRegistryV2Proxy is ERC1967Proxy {
+    constructor(address logic, bytes memory data) ERC1967Proxy(logic, data) {}
+}

--- a/contracts/data/dataRegistryV2/interfaces/DataRegistryV2StorageV1.sol
+++ b/contracts/data/dataRegistryV2/interfaces/DataRegistryV2StorageV1.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+import "./IDataRegistryV2.sol";
+
+/**
+ * @title Storage for DataRegistryV2
+ * @notice For future upgrades, do not change DataRegistryV2StorageV1. Create a new
+ * contract which implements DataRegistryV2StorageV1.
+ */
+abstract contract DataRegistryV2StorageV1 is IDataRegistryV2 {
+    /// @dev Storage shape (contains mappings — not directly returnable from views).
+    struct DataPoint {
+        address owner;
+        Status status;
+        uint64 currentVersion;
+        uint64 createdAt;
+        uint64 modifiedAt;
+        string scope;
+        uint256 totalAccesses;
+        mapping(uint256 version => bytes32 dataCommitment) commitments;
+        mapping(uint256 version => uint256 accessCount) accessesByVersion;
+    }
+
+    /// @dev Data points keyed by `keccak256(abi.encode(owner, scope))`.
+    mapping(bytes32 id => DataPoint) internal _dataPoints;
+
+    /// @dev All data point ids registered under a given scope (insertion-stable).
+    mapping(bytes32 scopeHash => EnumerableSet.Bytes32Set) internal _dataPointsByScope;
+
+    /// @dev DataPortabilityServersV2 reference used to authorize personal-server
+    ///      signers on `recordDataAccess`. Set post-deploy via setter.
+    IDataPortabilityServersV2 public override dataPortabilityServers;
+
+    /// @dev Replay-protection set for `recordDataAccess` payloads. Caller-chosen
+    ///      recordIds are marked used the first time they appear.
+    mapping(bytes32 recordId => bool used) internal _usedRecordIds;
+}

--- a/contracts/data/dataRegistryV2/interfaces/DataRegistryV2StorageV1.sol
+++ b/contracts/data/dataRegistryV2/interfaces/DataRegistryV2StorageV1.sol
@@ -36,4 +36,11 @@ abstract contract DataRegistryV2StorageV1 is IDataRegistryV2 {
     /// @dev Replay-protection set for `recordDataAccess` payloads. Caller-chosen
     ///      recordIds are marked used the first time they appear.
     mapping(bytes32 recordId => bool used) internal _usedRecordIds;
+
+    /// @dev Monotonic per-data-point counter that gates
+    ///      `setStatusWithSignature`. Independent of `currentVersion` so status
+    ///      flips and data writes do not invalidate each other's pending
+    ///      signatures. Keyed by the same `_dataPointId(owner, scope)` used by
+    ///      `_dataPoints`.
+    mapping(bytes32 id => uint256 sequence) internal _statusSequences;
 }

--- a/contracts/data/dataRegistryV2/interfaces/IDataRegistryV2.sol
+++ b/contracts/data/dataRegistryV2/interfaces/IDataRegistryV2.sol
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import "../../../dataPortability/dataPortabilityServersV2/interfaces/IDataPortabilityServersV2.sol";
+
+/**
+ * @title IDataRegistryV2
+ * @author Vana Network
+ * @notice Scope-first data point registry. Each data point is identified by
+ *         `keccak256(abi.encode(owner, scope))` (content-addressed), carries a
+ *         monotonically increasing version, and tracks per-version + total
+ *         access counters.
+ *
+ *         Each (owner, scope) maps to exactly one data point. Multiple
+ *         "states" of the same data point are expressed as versions — calling
+ *         `addData` again with the same scope appends a new version rather
+ *         than creating a new record.
+ *
+ *         Access recording uses layered auth:
+ *           - Caller must hold ACCESS_RECORDER_ROLE on this contract.
+ *           - The signed payload must be authored by a "personal server" that
+ *             the data owner has registered + trusts in DataPortabilityServers.
+ *
+ *         Signature-based delegation: `addDataWithSignature` lets a relayer
+ *         submit a write on behalf of an owner who signed the EIP-712 payload.
+ *         Replay/rollback protection is per-data-point: the signer commits to
+ *         `expectedVersion`, which must equal `currentVersion + 1`.
+ *
+ * @custom:security-contact security@vana.org
+ */
+interface IDataRegistryV2 {
+    enum Status {
+        None,
+        Active,
+        Inactive,
+        Unavailable
+    }
+
+    /// @dev Memory-safe view of a data point (omits the per-version mappings).
+    struct DataPointInfo {
+        bytes32 id;
+        address owner;
+        string scope;
+        Status status;
+        uint256 currentVersion;
+        bytes32 currentCommitment;
+        uint256 createdAt;
+        uint256 modifiedAt;
+        uint256 totalAccesses;
+    }
+
+    // ====================== Errors ======================
+
+    error ZeroAddress();
+    error EmptyScope();
+    error ScopeTooLong();
+    error OwnerMismatch(address claimed, address actual);
+    error DataPointNotFound(bytes32 id);
+    error InvalidStatus();
+    error UnknownVersion(bytes32 id, uint256 version);
+    error UnexpectedVersion(uint256 expected, uint256 actual);
+    error InvalidSignature();
+    error DataPortabilityServersNotSet();
+    error UntrustedServer(address owner, address server);
+    error RecordIdAlreadyUsed(bytes32 recordId);
+
+    // ====================== Events ======================
+
+    event DataPointCreated(
+        bytes32 indexed id,
+        address indexed owner,
+        bytes32 indexed scopeHash,
+        string scope
+    );
+
+    event DataVersionAdded(
+        bytes32 indexed id,
+        uint256 indexed version,
+        bytes32 dataHash,
+        bytes32 metadataHash,
+        bytes32 dataCommitment
+    );
+
+    event DataPointStatusChanged(bytes32 indexed id, Status indexed newStatus);
+
+    event DataAccessRecorded(
+        bytes32 indexed id,
+        uint256 indexed version,
+        address indexed accessor,
+        address server,
+        bytes32 recordId,
+        uint256 versionAccessCount,
+        uint256 dataPointTotalAccesses
+    );
+
+    event DataPortabilityServersUpdated(address indexed previous, address indexed current);
+
+    // ====================== Pure helpers ======================
+
+    function version() external pure returns (uint256);
+
+    /// @notice Deterministic id for a (owner, scope) pair.
+    function dataPointId(address ownerAddress, string calldata scope) external pure returns (bytes32);
+
+    /// @notice keccak256(abi.encode(dataHash, metadataHash))
+    function computeCommitment(bytes32 dataHash, bytes32 metadataHash) external pure returns (bytes32);
+
+    /// @notice EIP-712 typehash for `addDataWithSignature`. Type:
+    ///         AddData(address ownerAddress,string scope,bytes32 dataHash,
+    ///         bytes32 metadataHash,uint256 expectedVersion)
+    function ADD_DATA_TYPEHASH() external view returns (bytes32);
+
+    /// @notice EIP-712 typehash for `recordDataAccess`. Type:
+    ///         RecordDataAccess(address ownerAddress,string scope,uint256 version,
+    ///         address accessor,bytes32 recordId)
+    function RECORD_ACCESS_TYPEHASH() external view returns (bytes32);
+
+    // ====================== Views ======================
+
+    /// @notice Cross-referenced personal-servers registry used to authorize
+    ///         signers of `recordDataAccess`. Set post-deploy via
+    ///         `setDataPortabilityServers` (admin-only).
+    function dataPortabilityServers() external view returns (IDataPortabilityServersV2);
+
+    function dataPoints(address ownerAddress, string calldata scope) external view returns (DataPointInfo memory);
+
+    function dataCommitment(address ownerAddress, string calldata scope, uint256 version_)
+        external view returns (bytes32);
+
+    function currentCommitment(address ownerAddress, string calldata scope) external view returns (bytes32);
+
+    function currentVersion(address ownerAddress, string calldata scope) external view returns (uint256);
+
+    function accessCount(address ownerAddress, string calldata scope, uint256 version_)
+        external view returns (uint256);
+
+    function totalAccesses(address ownerAddress, string calldata scope) external view returns (uint256);
+
+    function isRecordIdUsed(bytes32 recordId) external view returns (bool);
+
+    // Scope enumeration — paginated.
+    function scopeDataPointsCount(string calldata scope) external view returns (uint256);
+    function scopeDataPointIdAt(string calldata scope, uint256 index) external view returns (bytes32);
+    function scopeDataPointIds(
+        string calldata scope,
+        uint256 offset,
+        uint256 limit
+    ) external view returns (bytes32[] memory);
+
+    // ====================== Admin ======================
+
+    function pause() external;
+
+    function unpause() external;
+
+    /// @notice Set or update the DataPortabilityServers contract used to
+    ///         authorize personal-server signers on `recordDataAccess`.
+    function setDataPortabilityServers(address newDataPortabilityServers) external;
+
+    // ====================== Writes (direct, msg.sender is owner) ======================
+
+    /// @notice Create a new data point or append a new version to an existing one.
+    ///         Auto-transitions status to Active if previously Inactive/Unavailable.
+    /// @return id        Deterministic data point id.
+    /// @return version_  New version number (1 if created, currentVersion+1 if appended).
+    function addData(
+        string calldata scope,
+        bytes32 dataHash,
+        bytes32 metadataHash
+    ) external returns (bytes32 id, uint256 version_);
+
+    function setStatus(string calldata scope, Status newStatus) external;
+
+    // ====================== Writes (delegated, EIP-712 signed) ======================
+
+    /// @notice Write on behalf of `ownerAddress`, who signed the EIP-712 payload.
+    ///         `expectedVersion` must equal `currentVersion + 1` for the
+    ///         (owner, scope) slot — both replay and rollback protection.
+    function addDataWithSignature(
+        address ownerAddress,
+        string calldata scope,
+        bytes32 dataHash,
+        bytes32 metadataHash,
+        uint256 expectedVersion,
+        bytes calldata signature
+    ) external returns (bytes32 id, uint256 version_);
+
+    // ====================== Access recording ======================
+
+    /// @notice Record one access against a specific version.
+    /// @dev    Auth:
+    ///           - msg.sender must hold ACCESS_RECORDER_ROLE on this contract.
+    ///           - `signature` must recover to an address registered as a
+    ///             trusted server of `ownerAddress` in DataPortabilityServers.
+    ///         Replay protection: each `recordId` may only be used once.
+    /// @param  ownerAddress  Data point owner whose counter is incremented.
+    /// @param  scope         Data point scope.
+    /// @param  version_      Version against which the access is recorded.
+    /// @param  accessor      Address that performed the access.
+    /// @param  recordId      Caller-chosen unique id; reverts if reused.
+    /// @param  signature     EIP-712 signature by one of the owner's trusted
+    ///                       personal servers over the record payload.
+    function recordDataAccess(
+        address ownerAddress,
+        string calldata scope,
+        uint256 version_,
+        address accessor,
+        bytes32 recordId,
+        bytes calldata signature
+    ) external;
+}

--- a/contracts/data/dataRegistryV2/interfaces/IDataRegistryV2.sol
+++ b/contracts/data/dataRegistryV2/interfaces/IDataRegistryV2.sol
@@ -124,6 +124,11 @@ interface IDataRegistryV2 {
 
     function dataPoints(address ownerAddress, string calldata scope) external view returns (DataPointInfo memory);
 
+    /// @notice Look up a data point by its deterministic id directly.
+    /// @dev For unregistered ids every field returns its zero default
+    ///      (`info.owner == address(0)` signals "not found").
+    function dataPointById(bytes32 id) external view returns (DataPointInfo memory);
+
     function dataCommitment(address ownerAddress, string calldata scope, uint256 version_)
         external view returns (bytes32);
 

--- a/contracts/data/dataRegistryV2/interfaces/IDataRegistryV2.sol
+++ b/contracts/data/dataRegistryV2/interfaces/IDataRegistryV2.sol
@@ -100,6 +100,12 @@ interface IDataRegistryV2 {
     ///         signed `addDataWithSignature` calls.
     event DataSignedByDelegate(bytes32 indexed id, address indexed ownerAddress, address indexed delegate);
 
+    /// @notice Emitted alongside `DataPointStatusChanged` when the EIP-712
+    ///         signature on `setStatusWithSignature` was produced by a delegate
+    ///         (personal server currently trusted by `ownerAddress`). Not
+    ///         emitted for direct `setStatus` or owner-self-signed calls.
+    event StatusSignedByDelegate(bytes32 indexed id, address indexed ownerAddress, address indexed delegate);
+
     event DataPortabilityServersUpdated(address indexed previous, address indexed current);
 
     // ====================== Pure helpers ======================
@@ -121,6 +127,18 @@ interface IDataRegistryV2 {
     ///         RecordDataAccess(address ownerAddress,string scope,uint256 version,
     ///         address accessor,bytes32 recordId)
     function RECORD_ACCESS_TYPEHASH() external view returns (bytes32);
+
+    /// @notice EIP-712 typehash for `setStatusWithSignature`. Type:
+    ///         SetStatus(address ownerAddress,string scope,uint8 newStatus,
+    ///         uint256 expectedSequence)
+    function SET_STATUS_TYPEHASH() external view returns (bytes32);
+
+    /// @notice Monotonic per-`(owner, scope)` counter that gates
+    ///         `setStatusWithSignature` (signer must commit to `currentSequence + 1`).
+    ///         Independent of `currentVersion` so status flips do not require
+    ///         a data write. Starts at 0; first signed flip uses sequence 1.
+    function statusSequence(address ownerAddress, string calldata scope)
+        external view returns (uint256);
 
     // ====================== Views ======================
 
@@ -182,6 +200,45 @@ interface IDataRegistryV2 {
     ) external returns (bytes32 id, uint256 version_);
 
     function setStatus(string calldata scope, Status newStatus) external;
+
+    // ====================== Writes (delegated, EIP-712 signed) ======================
+
+    /// @notice Flip the status of a data point on behalf of `ownerAddress` via
+    ///         an EIP-712 signature. Same dual-signer model as
+    ///         `addDataWithSignature`: the signature is accepted from EITHER
+    ///         the owner OR a personal server currently registered to the
+    ///         owner in `dataPortabilityServers`. If the servers contract is
+    ///         unset, only owner-self-signed signatures are accepted.
+    /// @dev    Replay/rollback protection: `expectedSequence` must equal the
+    ///         current `statusSequence(owner, scope) + 1`. The sequence is
+    ///         independent of `currentVersion` so flipping status does not
+    ///         require a data write, and a write does not invalidate pending
+    ///         status signatures.
+    ///
+    ///         Reverts with:
+    ///           - `InvalidStatus` if `newStatus == Status.None`
+    ///           - `DataPointNotFound` if no data point exists at `(owner, scope)`
+    ///           - `UnexpectedVersion(expected, actual)` on sequence mismatch
+    ///             (reusing the `UnexpectedVersion` error keeps the surface
+    ///             tight; `expected` is the next sequence, `actual` is what
+    ///             the caller supplied)
+    ///           - `InvalidSignature` / `OwnerMismatch` as in `addDataWithSignature`
+    ///
+    ///         Same silent-no-op semantic as direct `setStatus` when the
+    ///         status is already the requested value — the sequence is still
+    ///         consumed so the signature cannot be replayed.
+    /// @param  ownerAddress     Data point owner.
+    /// @param  scope            Data point scope.
+    /// @param  newStatus        Target status (must not be `Status.None`).
+    /// @param  expectedSequence Must equal `statusSequence(owner, scope) + 1`.
+    /// @param  signature        EIP-712 signature over the SetStatus payload.
+    function setStatusWithSignature(
+        address ownerAddress,
+        string calldata scope,
+        Status newStatus,
+        uint256 expectedSequence,
+        bytes calldata signature
+    ) external;
 
     // ====================== Writes (delegated, EIP-712 signed) ======================
 

--- a/contracts/data/dataRegistryV2/interfaces/IDataRegistryV2.sol
+++ b/contracts/data/dataRegistryV2/interfaces/IDataRegistryV2.sol
@@ -93,6 +93,13 @@ interface IDataRegistryV2 {
         uint256 dataPointTotalAccesses
     );
 
+    /// @notice Emitted alongside `DataVersionAdded` when the EIP-712 signature
+    ///         on `addDataWithSignature` was produced by a delegate (personal
+    ///         server currently trusted by `ownerAddress`) rather than the
+    ///         owner directly. Not emitted for direct `addData` or owner-self-
+    ///         signed `addDataWithSignature` calls.
+    event DataSignedByDelegate(bytes32 indexed id, address indexed ownerAddress, address indexed delegate);
+
     event DataPortabilityServersUpdated(address indexed previous, address indexed current);
 
     // ====================== Pure helpers ======================
@@ -178,7 +185,18 @@ interface IDataRegistryV2 {
 
     // ====================== Writes (delegated, EIP-712 signed) ======================
 
-    /// @notice Write on behalf of `ownerAddress`, who signed the EIP-712 payload.
+    /// @notice Write on behalf of `ownerAddress`. Authority comes from the
+    ///         EIP-712 signature, which is accepted from EITHER:
+    ///           (a) `ownerAddress` itself, OR
+    ///           (b) a personal server currently registered to `ownerAddress`
+    ///               in the configured `dataPortabilityServers` registry —
+    ///               server-as-delegate. Identical trust model to
+    ///               `recordDataAccess`: revoking the server in the servers
+    ///               registry immediately removes signing authority.
+    ///         If `dataPortabilityServers` is unset (zero address), only (a) is
+    ///         accepted; behavior matches the pre-upgrade contract exactly.
+    ///         In case (b), `DataSignedByDelegate` is emitted alongside the
+    ///         standard `DataVersionAdded` / `DataPointCreated` events.
     ///         `expectedVersion` must equal `currentVersion + 1` for the
     ///         (owner, scope) slot — both replay and rollback protection.
     function addDataWithSignature(

--- a/contracts/dataPortability/dataPortabilityEscrow/DataPortabilityEscrowImplementation.sol
+++ b/contracts/dataPortability/dataPortabilityEscrow/DataPortabilityEscrowImplementation.sol
@@ -7,6 +7,7 @@ import "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 import "../dataPortabilityPermissionsV2/interfaces/IDataPortabilityPermissionsV2.sol";
 import "../../data/dataRegistryV2/interfaces/IDataRegistryV2.sol";
 import "./interfaces/DataPortabilityEscrowStorageV1.sol";
@@ -38,6 +39,8 @@ contract DataPortabilityEscrowImplementation is
     DataPortabilityEscrowStorageV1
 {
     using SafeERC20 for IERC20;
+    using EnumerableSet for EnumerableSet.AddressSet;
+    using EnumerableSet for EnumerableSet.Bytes32Set;
 
     bytes32 public constant FACILITATOR_ROLE = keccak256("FACILITATOR_ROLE");
 
@@ -99,10 +102,62 @@ contract DataPortabilityEscrowImplementation is
         emit DataRegistryUpdated(previous, newDataRegistry);
     }
 
+    /// @inheritdoc IDataPortabilityEscrow
+    /// @dev Maintains both `_allowedSelectorsByTarget[target]` (the actual gate)
+    ///      and `_allowedTargets` (the enumerable target list). The target is
+    ///      auto-added when its first selector is allowed and auto-removed when
+    ///      its last selector is disallowed — admins never manage the target
+    ///      set directly.
+    ///
+    ///      Idempotent: setting an already-correct flag is a no-op (no event)
+    ///      so off-chain indexers don't see spurious enable/disable churn.
+    function setOpAllowed(address target, bytes4 selector, bool allowed)
+        external
+        override
+        onlyRole(DEFAULT_ADMIN_ROLE)
+    {
+        if (target == address(0)) revert ZeroAddress();
+
+        EnumerableSet.Bytes32Set storage selectors = _allowedSelectorsByTarget[target];
+        bytes32 selectorKey = bytes32(selector);
+
+        if (allowed) {
+            if (!selectors.add(selectorKey)) return; // already allowed — idempotent
+            // First selector for this target → also register it in the target set.
+            _allowedTargets.add(target);
+            emit OpAllowed(target, selector);
+        } else {
+            if (!selectors.remove(selectorKey)) return; // wasn't allowed — idempotent
+            // Last selector for this target → drop it from the target set too.
+            if (selectors.length() == 0) {
+                _allowedTargets.remove(target);
+            }
+            emit OpDisallowed(target, selector);
+        }
+    }
+
     // ====================== Views ======================
 
     function balanceOf(address account, address asset) external view override returns (uint256) {
         return _balances[account][asset];
+    }
+
+    function isAllowedOp(address target, bytes4 selector) external view override returns (bool) {
+        return _allowedSelectorsByTarget[target].contains(bytes32(selector));
+    }
+
+    function getAllowedTargets() external view override returns (address[] memory) {
+        return _allowedTargets.values();
+    }
+
+    function getAllowedSelectors(address target) external view override returns (bytes4[] memory out) {
+        bytes32[] memory raw = _allowedSelectorsByTarget[target].values();
+        uint256 len = raw.length;
+        out = new bytes4[](len);
+        for (uint256 i = 0; i < len; ) {
+            out[i] = bytes4(raw[i]);
+            unchecked { ++i; }
+        }
     }
 
     // ====================== Deposits ======================
@@ -273,6 +328,67 @@ contract DataPortabilityEscrowImplementation is
 
         // Step 2: identical loop to settleBatch — same event shape so indexers
         // don't need a special case for bundled txs.
+        uint256 len = ops.length;
+        for (uint256 i = 0; i < len; ) {
+            SettleOp calldata op = ops[i];
+            _payout(op.from, op.to, op.asset, op.amount);
+            emit Settled(op.from, op.to, op.asset, op.amount, op.opKind);
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
+    // ====================== Facilitator: generalized op + settle (atomic) ======================
+
+    /// @inheritdoc IDataPortabilityEscrow
+    /// @dev Generalized companion to `registerAndSettle` / `recordAccessAndSettle`.
+    ///      The contract is intentionally NOT a router for arbitrary external
+    ///      calls — every reachable `(target, selector)` pair must be admin-
+    ///      allowlisted via `setOpAllowed`. The facilitator role only gates
+    ///      *who* may submit; the *what* is gated by the allowlist.
+    ///
+    ///      Call semantics:
+    ///        - Value forwarded: 0. The escrow never pays the target from its
+    ///          own balance; any user-facing payment goes through `ops` and
+    ///          `_payout`, which debit the named account.
+    ///        - Revert bubbling: if the target reverts, its return data is
+    ///          re-raised verbatim so callers observe the target's typed error
+    ///          (e.g. `RecordIdAlreadyUsed`) rather than a generic wrapper.
+    ///        - Idempotency: delegated to the target. Reusing a request that
+    ///          the target rejects (e.g. duplicate `recordId`) reverts the
+    ///          whole bundle including the settle loop.
+    function runOpAndSettle(
+        address target,
+        bytes calldata callData,
+        SettleOp[] calldata ops
+    )
+        external
+        override
+        onlyRole(FACILITATOR_ROLE)
+        whenNotPaused
+        nonReentrant
+        returns (bytes memory returnData)
+    {
+        if (callData.length < 4) revert CallDataTooShort();
+        bytes4 selector = bytes4(callData[:4]);
+        if (!_allowedSelectorsByTarget[target].contains(bytes32(selector))) {
+            revert OpNotAllowed(target, selector);
+        }
+
+        // Step 1: dispatch the call with zero value. Bubble the target's revert
+        // data on failure so typed errors survive the wrapper.
+        bool ok;
+        (ok, returnData) = target.call(callData);
+        if (!ok) {
+            assembly {
+                revert(add(returnData, 0x20), mload(returnData))
+            }
+        }
+        emit OpExecuted(target, selector, returnData);
+
+        // Step 2: identical loop to settleBatch — preserves event shape so
+        // indexers don't need a special case for bundled txs.
         uint256 len = ops.length;
         for (uint256 i = 0; i < len; ) {
             SettleOp calldata op = ops[i];

--- a/contracts/dataPortability/dataPortabilityEscrow/DataPortabilityEscrowImplementation.sol
+++ b/contracts/dataPortability/dataPortabilityEscrow/DataPortabilityEscrowImplementation.sol
@@ -131,7 +131,7 @@ contract DataPortabilityEscrowImplementation is
 
     // ====================== Facilitator: settle (pay external) ======================
 
-    function settle(address from, address to, address asset, uint256 amount, bytes32 ref)
+    function settle(address from, address to, address asset, uint256 amount, OpKind opKind)
         external
         override
         whenNotPaused
@@ -139,7 +139,7 @@ contract DataPortabilityEscrowImplementation is
         nonReentrant
     {
         _payout(from, to, asset, amount);
-        emit Settled(from, to, asset, amount, ref);
+        emit Settled(from, to, asset, amount, opKind);
     }
 
     function settleBatch(SettleOp[] calldata ops)
@@ -153,7 +153,7 @@ contract DataPortabilityEscrowImplementation is
         for (uint256 i = 0; i < len; ) {
             SettleOp calldata op = ops[i];
             _payout(op.from, op.to, op.asset, op.amount);
-            emit Settled(op.from, op.to, op.asset, op.amount, op.ref);
+            emit Settled(op.from, op.to, op.asset, op.amount, op.opKind);
             unchecked {
                 ++i;
             }
@@ -227,7 +227,7 @@ contract DataPortabilityEscrowImplementation is
         for (uint256 i = 0; i < len; ) {
             SettleOp calldata op = ops[i];
             _payout(op.from, op.to, op.asset, op.amount);
-            emit Settled(op.from, op.to, op.asset, op.amount, op.ref);
+            emit Settled(op.from, op.to, op.asset, op.amount, op.opKind);
             unchecked {
                 ++i;
             }

--- a/contracts/dataPortability/dataPortabilityEscrow/DataPortabilityEscrowImplementation.sol
+++ b/contracts/dataPortability/dataPortabilityEscrow/DataPortabilityEscrowImplementation.sol
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "./interfaces/DataPortabilityEscrowStorageV1.sol";
+
+/**
+ * @title DataPortabilityEscrowImplementation
+ * @notice Per-account escrow custody for native VANA and whitelisted ERC-20s.
+ * @dev UUPS upgradeable. Deposits are open; only FACILITATOR_ROLE can move funds out.
+ *
+ *      Withdrawal/settlement do NOT re-check the token whitelist: once funds are
+ *      credited, they remain movable even if the token is later de-whitelisted.
+ *      The whitelist only gates incoming deposits.
+ *
+ *      Reentrancy model:
+ *      - Every state-mutating external entry point is `nonReentrant`. The guard
+ *        is a single shared lock, so callbacks during native sends, ERC-20 hooks
+ *        (e.g. ERC-777), or facilitator-controlled receivers cannot re-enter any
+ *        balance-touching function on this contract.
+ *      - `withdraw` follows checks-effects-interactions: the sender's balance
+ *        is debited before the external send, so even without the guard a
+ *        recursive call would observe the post-debit state.
+ *      - `receive()` reverts; the contract never accepts bare native transfers.
+ */
+contract DataPortabilityEscrowImplementation is
+    UUPSUpgradeable,
+    PausableUpgradeable,
+    AccessControlUpgradeable,
+    ReentrancyGuardUpgradeable,
+    DataPortabilityEscrowStorageV1
+{
+    using SafeERC20 for IERC20;
+
+    bytes32 public constant FACILITATOR_ROLE = keccak256("FACILITATOR_ROLE");
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    function initialize(address ownerAddress, address facilitatorAddress) external initializer {
+        if (ownerAddress == address(0) || facilitatorAddress == address(0)) revert ZeroAddress();
+
+        __AccessControl_init();
+        __UUPSUpgradeable_init();
+        __Pausable_init();
+        __ReentrancyGuard_init();
+
+        _grantRole(DEFAULT_ADMIN_ROLE, ownerAddress);
+        _grantRole(FACILITATOR_ROLE, facilitatorAddress);
+    }
+
+    function _authorizeUpgrade(address newImplementation) internal virtual override onlyRole(DEFAULT_ADMIN_ROLE) {}
+
+    function version() external pure virtual override returns (uint256) {
+        return 1;
+    }
+
+    // ====================== Admin ======================
+
+    function pause() external override onlyRole(DEFAULT_ADMIN_ROLE) {
+        _pause();
+    }
+
+    function unpause() external override onlyRole(DEFAULT_ADMIN_ROLE) {
+        _unpause();
+    }
+
+    function setTokenWhitelisted(address token, bool whitelisted)
+        external
+        override
+        onlyRole(DEFAULT_ADMIN_ROLE)
+    {
+        // address(0) is reserved for native VANA — never on the whitelist.
+        if (token == address(0)) revert ZeroAddress();
+        isWhitelistedToken[token] = whitelisted;
+        emit TokenWhitelistUpdated(token, whitelisted);
+    }
+
+    // ====================== Views ======================
+
+    function balanceOf(address account, address asset) external view override returns (uint256) {
+        return _balances[account][asset];
+    }
+
+    // ====================== Deposits ======================
+
+    function depositNative(address account) external payable override whenNotPaused nonReentrant {
+        if (msg.value == 0) revert ZeroAmount();
+        if (account == address(0)) revert ZeroAddress();
+
+        _balances[account][address(0)] += msg.value;
+        emit Deposited(msg.sender, account, address(0), msg.value);
+    }
+
+    function depositToken(address account, address token, uint256 amount)
+        external
+        override
+        whenNotPaused
+        nonReentrant
+    {
+        if (amount == 0) revert ZeroAmount();
+        if (account == address(0)) revert ZeroAddress();
+        if (!isWhitelistedToken[token]) revert AssetNotSupported(token);
+
+        // Credit only what was actually received, in case `token` deducts a fee
+        // on transfer or otherwise diverges from the amount parameter.
+        uint256 balanceBefore = IERC20(token).balanceOf(address(this));
+        IERC20(token).safeTransferFrom(msg.sender, address(this), amount);
+        uint256 received = IERC20(token).balanceOf(address(this)) - balanceBefore;
+        if (received == 0) revert ZeroAmount();
+
+        _balances[account][token] += received;
+
+        emit Deposited(msg.sender, account, token, received);
+    }
+
+    // ====================== Facilitator: settle (pay external) ======================
+
+    function settle(address from, address to, address asset, uint256 amount, bytes32 ref)
+        external
+        override
+        whenNotPaused
+        onlyRole(FACILITATOR_ROLE)
+        nonReentrant
+    {
+        _payout(from, to, asset, amount);
+        emit Settled(from, to, asset, amount, ref);
+    }
+
+    function settleBatch(SettleOp[] calldata ops)
+        external
+        override
+        whenNotPaused
+        onlyRole(FACILITATOR_ROLE)
+        nonReentrant
+    {
+        uint256 len = ops.length;
+        for (uint256 i = 0; i < len; ) {
+            SettleOp calldata op = ops[i];
+            _payout(op.from, op.to, op.asset, op.amount);
+            emit Settled(op.from, op.to, op.asset, op.amount, op.ref);
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
+    // ====================== Facilitator: withdraw (refund to account holder) ======================
+
+    function withdraw(address account, address asset, uint256 amount, bytes32 ref)
+        external
+        override
+        whenNotPaused
+        onlyRole(FACILITATOR_ROLE)
+        nonReentrant
+    {
+        _payout(account, account, asset, amount);
+        emit Withdrawn(account, asset, amount, ref);
+    }
+
+    /// @dev Debit `from`'s in-escrow balance and send the funds to external address `to`.
+    ///      Checks-effects-interactions: the balance is updated before the external send.
+    function _payout(address from, address to, address asset, uint256 amount) internal {
+        if (amount == 0) revert ZeroAmount();
+        if (from == address(0) || to == address(0)) revert ZeroAddress();
+
+        uint256 fromBal = _balances[from][asset];
+        if (fromBal < amount) revert InsufficientBalance(from, asset, amount, fromBal);
+
+        unchecked {
+            _balances[from][asset] = fromBal - amount;
+        }
+
+        if (asset == address(0)) {
+            (bool ok, ) = payable(to).call{value: amount}("");
+            if (!ok) revert NativeTransferFailed();
+        } else {
+            IERC20(asset).safeTransfer(to, amount);
+        }
+    }
+
+    // ====================== Fallback ======================
+
+    /// @dev Reject blind native transfers — depositors must call `depositNative(account)`
+    ///      so the funds are accounted to a specific recipient.
+    receive() external payable {
+        revert UnexpectedNativeValue();
+    }
+}

--- a/contracts/dataPortability/dataPortabilityEscrow/DataPortabilityEscrowImplementation.sol
+++ b/contracts/dataPortability/dataPortabilityEscrow/DataPortabilityEscrowImplementation.sol
@@ -10,6 +10,7 @@ import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 import "../dataPortabilityPermissionsV2/interfaces/IDataPortabilityPermissionsV2.sol";
 import "../../data/dataRegistryV2/interfaces/IDataRegistryV2.sol";
+import "./interfaces/IERC3009.sol";
 import "./interfaces/DataPortabilityEscrowStorageV1.sol";
 
 /**
@@ -192,9 +193,58 @@ contract DataPortabilityEscrowImplementation is
         emit Deposited(msg.sender, account, token, received);
     }
 
+    /// @inheritdoc IDataPortabilityEscrow
+    /// @dev The nonce passed to the token is recomputed here from (account,
+    ///      salt) rather than taken as a parameter. This is what makes the
+    ///      beneficiary tamper-proof: the signer committed to the nonce inside
+    ///      the EIP-3009 signature, so any relayer-substituted `account` yields
+    ///      a nonce the signature doesn't cover and the token reverts.
+    function depositTokenWithAuthorization(
+        address account,
+        address from,
+        address token,
+        uint256 value,
+        uint256 validAfter,
+        uint256 validBefore,
+        bytes32 salt,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external override whenNotPaused nonReentrant {
+        if (value == 0) revert ZeroAmount();
+        if (account == address(0) || from == address(0)) revert ZeroAddress();
+        if (!isWhitelistedToken[token]) revert AssetNotSupported(token);
+
+        // Beneficiary commitment: the signer derived this exact nonce from the
+        // intended `account` when signing the authorization.
+        bytes32 nonce = keccak256(abi.encode(account, salt));
+
+        // The token verifies the EIP-712 signature, the (from, nonce) replay
+        // state, the validity window, AND that msg.sender == to. Any failure
+        // reverts inside the token with its own error.
+        uint256 balanceBefore = IERC20(token).balanceOf(address(this));
+        IERC3009(token).receiveWithAuthorization(
+            from,
+            address(this),
+            value,
+            validAfter,
+            validBefore,
+            nonce,
+            v,
+            r,
+            s
+        );
+        uint256 received = IERC20(token).balanceOf(address(this)) - balanceBefore;
+        if (received == 0) revert ZeroAmount();
+
+        _balances[account][token] += received;
+
+        emit Deposited(from, account, token, received);
+    }
+
     // ====================== Facilitator: settle (pay external) ======================
 
-    function settle(address from, address to, address asset, uint256 amount, OpKind opKind)
+    function settle(address from, address to, address asset, uint256 amount, OpKind opKind, bytes32 ref)
         external
         override
         whenNotPaused
@@ -202,7 +252,7 @@ contract DataPortabilityEscrowImplementation is
         nonReentrant
     {
         _payout(from, to, asset, amount);
-        emit Settled(from, to, asset, amount, opKind);
+        emit Settled(from, to, ref, asset, amount, opKind);
     }
 
     function settleBatch(SettleOp[] calldata ops)
@@ -216,7 +266,7 @@ contract DataPortabilityEscrowImplementation is
         for (uint256 i = 0; i < len; ) {
             SettleOp calldata op = ops[i];
             _payout(op.from, op.to, op.asset, op.amount);
-            emit Settled(op.from, op.to, op.asset, op.amount, op.opKind);
+            emit Settled(op.from, op.to, op.ref, op.asset, op.amount, op.opKind);
             unchecked {
                 ++i;
             }
@@ -290,7 +340,7 @@ contract DataPortabilityEscrowImplementation is
         for (uint256 i = 0; i < len; ) {
             SettleOp calldata op = ops[i];
             _payout(op.from, op.to, op.asset, op.amount);
-            emit Settled(op.from, op.to, op.asset, op.amount, op.opKind);
+            emit Settled(op.from, op.to, op.ref, op.asset, op.amount, op.opKind);
             unchecked {
                 ++i;
             }
@@ -332,7 +382,7 @@ contract DataPortabilityEscrowImplementation is
         for (uint256 i = 0; i < len; ) {
             SettleOp calldata op = ops[i];
             _payout(op.from, op.to, op.asset, op.amount);
-            emit Settled(op.from, op.to, op.asset, op.amount, op.opKind);
+            emit Settled(op.from, op.to, op.ref, op.asset, op.amount, op.opKind);
             unchecked {
                 ++i;
             }
@@ -393,7 +443,7 @@ contract DataPortabilityEscrowImplementation is
         for (uint256 i = 0; i < len; ) {
             SettleOp calldata op = ops[i];
             _payout(op.from, op.to, op.asset, op.amount);
-            emit Settled(op.from, op.to, op.asset, op.amount, op.opKind);
+            emit Settled(op.from, op.to, op.ref, op.asset, op.amount, op.opKind);
             unchecked {
                 ++i;
             }

--- a/contracts/dataPortability/dataPortabilityEscrow/DataPortabilityEscrowImplementation.sol
+++ b/contracts/dataPortability/dataPortabilityEscrow/DataPortabilityEscrowImplementation.sol
@@ -8,6 +8,7 @@ import "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "../dataPortabilityPermissionsV2/interfaces/IDataPortabilityPermissionsV2.sol";
+import "../../data/dataRegistryV2/interfaces/IDataRegistryV2.sol";
 import "./interfaces/DataPortabilityEscrowStorageV1.sol";
 
 /**
@@ -89,6 +90,13 @@ contract DataPortabilityEscrowImplementation is
         address previous = address(permissions);
         permissions = IDataPortabilityPermissionsV2(newPermissions);
         emit PermissionsUpdated(previous, newPermissions);
+    }
+
+    function setDataRegistry(address newDataRegistry) external override onlyRole(DEFAULT_ADMIN_ROLE) {
+        if (newDataRegistry == address(0)) revert ZeroAddress();
+        address previous = address(dataRegistry);
+        dataRegistry = IDataRegistryV2(newDataRegistry);
+        emit DataRegistryUpdated(previous, newDataRegistry);
     }
 
     // ====================== Views ======================
@@ -223,6 +231,48 @@ contract DataPortabilityEscrowImplementation is
 
         // Step 2: identical loop to settleBatch — preserves event shape so
         // indexers don't need a special case for bundled txs.
+        uint256 len = ops.length;
+        for (uint256 i = 0; i < len; ) {
+            SettleOp calldata op = ops[i];
+            _payout(op.from, op.to, op.asset, op.amount);
+            emit Settled(op.from, op.to, op.asset, op.amount, op.opKind);
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
+    // ====================== Facilitator: record access + settle (atomic) ======================
+
+    /// @inheritdoc IDataPortabilityEscrow
+    /// @dev Same pattern as `registerAndSettle`. Bundle-level idempotency comes
+    ///      for free from the EVM: `dataRegistry.recordDataAccess` reverts on
+    ///      duplicate recordId (or untrusted server, unknown version, etc.),
+    ///      which rolls back the entire bundle including the settle loop.
+    function recordAccessAndSettle(
+        address ownerAddress,
+        string calldata scope,
+        uint256 version_,
+        address accessor,
+        bytes32 recordId,
+        bytes calldata serverSignature,
+        SettleOp[] calldata ops
+    )
+        external
+        override
+        onlyRole(FACILITATOR_ROLE)
+        whenNotPaused
+        nonReentrant
+    {
+        if (address(dataRegistry) == address(0)) revert DataRegistryNotSet();
+
+        // Step 1: record the access. Reverts on RecordIdAlreadyUsed,
+        // UntrustedServer, UnknownVersion, InvalidSignature,
+        // DataPortabilityServersNotSet — all from DataRegistryV2.
+        dataRegistry.recordDataAccess(ownerAddress, scope, version_, accessor, recordId, serverSignature);
+
+        // Step 2: identical loop to settleBatch — same event shape so indexers
+        // don't need a special case for bundled txs.
         uint256 len = ops.length;
         for (uint256 i = 0; i < len; ) {
             SettleOp calldata op = ops[i];

--- a/contracts/dataPortability/dataPortabilityEscrow/DataPortabilityEscrowImplementation.sol
+++ b/contracts/dataPortability/dataPortabilityEscrow/DataPortabilityEscrowImplementation.sol
@@ -7,6 +7,7 @@ import "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "../dataPortabilityPermissionsV2/interfaces/IDataPortabilityPermissionsV2.sol";
 import "./interfaces/DataPortabilityEscrowStorageV1.sol";
 
 /**
@@ -81,6 +82,13 @@ contract DataPortabilityEscrowImplementation is
         if (token == address(0)) revert ZeroAddress();
         isWhitelistedToken[token] = whitelisted;
         emit TokenWhitelistUpdated(token, whitelisted);
+    }
+
+    function setPermissions(address newPermissions) external override onlyRole(DEFAULT_ADMIN_ROLE) {
+        if (newPermissions == address(0)) revert ZeroAddress();
+        address previous = address(permissions);
+        permissions = IDataPortabilityPermissionsV2(newPermissions);
+        emit PermissionsUpdated(previous, newPermissions);
     }
 
     // ====================== Views ======================
@@ -183,6 +191,46 @@ contract DataPortabilityEscrowImplementation is
             if (!ok) revert NativeTransferFailed();
         } else {
             IERC20(asset).safeTransfer(to, amount);
+        }
+    }
+
+    // ====================== Facilitator: register + settle (atomic) ======================
+
+    /// @inheritdoc IDataPortabilityEscrow
+    /// @dev Register first, then run the payouts. Any sub-failure reverts the
+    ///      whole tx — so a partial state (grant on-chain but fee unpaid, or
+    ///      vice versa) is impossible. Both PermissionSet (from the permissions
+    ///      contract) and one Settled per op (from this contract) are emitted
+    ///      identically to the underlying primitives — no wrapper event.
+    function registerAndSettle(
+        IDataPortabilityPermissionsV2.AddPermissionInput calldata input,
+        bytes calldata signature,
+        SettleOp[] calldata ops
+    )
+        external
+        override
+        onlyRole(FACILITATOR_ROLE)
+        whenNotPaused
+        nonReentrant
+        returns (bytes32 grantId)
+    {
+        if (address(permissions) == address(0)) revert PermissionsNotSet();
+
+        // Step 1: register on the permissions contract. Reverts on any of:
+        // InvalidSignature, GrantorMismatch, InvalidGrantVersion, EmptyScopes,
+        // ZeroAddress, ZeroGranteeId — all from addPermissionWithSignature.
+        grantId = permissions.addPermissionWithSignature(input, signature);
+
+        // Step 2: identical loop to settleBatch — preserves event shape so
+        // indexers don't need a special case for bundled txs.
+        uint256 len = ops.length;
+        for (uint256 i = 0; i < len; ) {
+            SettleOp calldata op = ops[i];
+            _payout(op.from, op.to, op.asset, op.amount);
+            emit Settled(op.from, op.to, op.asset, op.amount, op.ref);
+            unchecked {
+                ++i;
+            }
         }
     }
 

--- a/contracts/dataPortability/dataPortabilityEscrow/DataPortabilityEscrowProxy.sol
+++ b/contracts/dataPortability/dataPortabilityEscrow/DataPortabilityEscrowProxy.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+contract DataPortabilityEscrowProxy is ERC1967Proxy {
+    constructor(address logic, bytes memory data) ERC1967Proxy(logic, data) {}
+}

--- a/contracts/dataPortability/dataPortabilityEscrow/interfaces/DataPortabilityEscrowStorageV1.sol
+++ b/contracts/dataPortability/dataPortabilityEscrow/interfaces/DataPortabilityEscrowStorageV1.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.24;
 
+import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 import "./IDataPortabilityEscrow.sol";
 
 /**
@@ -24,4 +25,15 @@ abstract contract DataPortabilityEscrowStorageV1 is IDataPortabilityEscrow {
     ///      Set post-deploy via `setDataRegistry`. If left unset,
     ///      `recordAccessAndSettle` reverts with `DataRegistryNotSet`.
     IDataRegistryV2 public override dataRegistry;
+
+    /// @dev Enumerable set of every target address that currently has at least
+    ///      one allowed selector. Maintained in lockstep with
+    ///      `_allowedSelectorsByTarget` so off-chain consumers can list every
+    ///      contract `runOpAndSettle` may dispatch to.
+    EnumerableSet.AddressSet internal _allowedTargets;
+
+    /// @dev Per-target enumerable set of allowed function selectors (left-aligned
+    ///      `bytes4` stored as `bytes32`). Lookup via
+    ///      `EnumerableSet.contains(_allowedSelectorsByTarget[target], bytes32(selector))`.
+    mapping(address target => EnumerableSet.Bytes32Set selectors) internal _allowedSelectorsByTarget;
 }

--- a/contracts/dataPortability/dataPortabilityEscrow/interfaces/DataPortabilityEscrowStorageV1.sol
+++ b/contracts/dataPortability/dataPortabilityEscrow/interfaces/DataPortabilityEscrowStorageV1.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import "./IDataPortabilityEscrow.sol";
+
+/**
+ * @title Storage for DataPortabilityEscrow
+ * @notice For future upgrades, do not change DataPortabilityEscrowStorageV1. Create a new
+ * contract which implements DataPortabilityEscrowStorageV1.
+ */
+abstract contract DataPortabilityEscrowStorageV1 is IDataPortabilityEscrow {
+    /// @dev account => asset => balance. Asset `address(0)` is native VANA.
+    mapping(address account => mapping(address asset => uint256 balance)) internal _balances;
+
+    /// @dev Whitelisted ERC-20s eligible for deposit. Native (address(0)) is always supported and not tracked here.
+    mapping(address token => bool whitelisted) public override isWhitelistedToken;
+}

--- a/contracts/dataPortability/dataPortabilityEscrow/interfaces/DataPortabilityEscrowStorageV1.sol
+++ b/contracts/dataPortability/dataPortabilityEscrow/interfaces/DataPortabilityEscrowStorageV1.sol
@@ -19,4 +19,9 @@ abstract contract DataPortabilityEscrowStorageV1 is IDataPortabilityEscrow {
     ///      Set post-deploy via `setPermissions`. If left unset, `registerAndSettle`
     ///      reverts with `PermissionsNotSet`.
     IDataPortabilityPermissionsV2 public override permissions;
+
+    /// @dev Cross-referenced data-registry contract used by `recordAccessAndSettle`.
+    ///      Set post-deploy via `setDataRegistry`. If left unset,
+    ///      `recordAccessAndSettle` reverts with `DataRegistryNotSet`.
+    IDataRegistryV2 public override dataRegistry;
 }

--- a/contracts/dataPortability/dataPortabilityEscrow/interfaces/DataPortabilityEscrowStorageV1.sol
+++ b/contracts/dataPortability/dataPortabilityEscrow/interfaces/DataPortabilityEscrowStorageV1.sol
@@ -14,4 +14,9 @@ abstract contract DataPortabilityEscrowStorageV1 is IDataPortabilityEscrow {
 
     /// @dev Whitelisted ERC-20s eligible for deposit. Native (address(0)) is always supported and not tracked here.
     mapping(address token => bool whitelisted) public override isWhitelistedToken;
+
+    /// @dev Cross-referenced permissions contract used by `registerAndSettle`.
+    ///      Set post-deploy via `setPermissions`. If left unset, `registerAndSettle`
+    ///      reverts with `PermissionsNotSet`.
+    IDataPortabilityPermissionsV2 public override permissions;
 }

--- a/contracts/dataPortability/dataPortabilityEscrow/interfaces/IDataPortabilityEscrow.sol
+++ b/contracts/dataPortability/dataPortabilityEscrow/interfaces/IDataPortabilityEscrow.sol
@@ -23,18 +23,27 @@ import "../../dataPortabilityPermissionsV2/interfaces/IDataPortabilityPermission
  * @custom:security-contact security@vana.org
  */
 interface IDataPortabilityEscrow {
-    /// @notice Single settlement entry used by `settleBatch`.
+    /// @notice Categorizes a settlement op for off-chain indexing / accounting.
+    ///         `Unspecified` (0) is the zero default for callers who don't care
+    ///         to classify. Extend by appending values — never reorder.
+    enum OpKind {
+        Unspecified,
+        Registration, // registration fee for a grant (used by `registerAndSettle`)
+        DataAccess    // per-access payment for data use
+    }
+
+    /// @notice Single settlement entry used by `settleBatch` / `registerAndSettle`.
     /// @param from   In-escrow account whose balance is debited
     /// @param to     External recipient of the funds
     /// @param asset  Asset to transfer; `address(0)` for native VANA
     /// @param amount Amount to transfer
-    /// @param ref    Caller-supplied tag (paymentId / invoice hash). May be zero.
+    /// @param opKind Classification of the operation (off-chain hint).
     struct SettleOp {
         address from;
         address to;
         address asset;
         uint256 amount;
-        bytes32 ref;
+        OpKind opKind;
     }
 
     // ====================== Errors ======================
@@ -57,13 +66,13 @@ interface IDataPortabilityEscrow {
 
     /// @notice Emitted when the facilitator settles a payment: debits `from`'s
     ///         in-escrow balance and transfers funds to external address `to`.
-    /// @param ref Caller-supplied tag (e.g. paymentId / invoice hash). May be zero.
+    /// @param opKind Classification of the operation (off-chain hint).
     event Settled(
         address indexed from,
         address indexed to,
         address indexed asset,
         uint256 amount,
-        bytes32 ref
+        OpKind opKind
     );
 
     /// @notice Emitted when the facilitator returns funds to the account holder:
@@ -116,7 +125,7 @@ interface IDataPortabilityEscrow {
     // ====================== Facilitator ops ======================
 
     /// @notice Debit `from`'s in-escrow balance and transfer the funds to external address `to`.
-    function settle(address from, address to, address asset, uint256 amount, bytes32 ref) external;
+    function settle(address from, address to, address asset, uint256 amount, OpKind opKind) external;
 
     /// @notice Batched variant of `settle`.
     function settleBatch(SettleOp[] calldata ops) external;

--- a/contracts/dataPortability/dataPortabilityEscrow/interfaces/IDataPortabilityEscrow.sol
+++ b/contracts/dataPortability/dataPortabilityEscrow/interfaces/IDataPortabilityEscrow.sol
@@ -26,11 +26,15 @@ import "../../../data/dataRegistryV2/interfaces/IDataRegistryV2.sol";
 interface IDataPortabilityEscrow {
     /// @notice Categorizes a settlement op for off-chain indexing / accounting.
     ///         `Unspecified` (0) is the zero default for callers who don't care
-    ///         to classify. Extend by appending values — never reorder.
+    ///         to classify. Wire format is `uint8` — future additions should
+    ///         append (never reorder) once any non-test usage exists.
     enum OpKind {
-        Unspecified,
-        Registration, // registration fee for a grant (used by `registerAndSettle`)
-        DataAccess    // per-access payment for data use
+        Unspecified,         // 0 — default catch-all
+        DataRegistration,    // 1 — fee for registering / adding data
+        ServerRegistration,  // 2 — fee for registering a personal server
+        BuilderRegistration, // 3 — fee for registering a builder / grantee
+        GrantRegistration,   // 4 — fee for registering a grant (was named `Registration` previously)
+        DataAccess           // 5 — per-access payment for data use
     }
 
     /// @notice Single settlement entry used by `settleBatch` / `registerAndSettle`.
@@ -57,6 +61,8 @@ interface IDataPortabilityEscrow {
     error UnexpectedNativeValue();
     error PermissionsNotSet();
     error DataRegistryNotSet();
+    error OpNotAllowed(address target, bytes4 selector);
+    error CallDataTooShort();
 
     // ====================== Events ======================
 
@@ -95,6 +101,15 @@ interface IDataPortabilityEscrow {
     /// @notice Emitted when the admin updates the cross-referenced data-registry contract.
     event DataRegistryUpdated(address indexed previous, address indexed current);
 
+    /// @notice Emitted when admin allows a `(target, selector)` pair to be invoked via `runOpAndSettle`.
+    event OpAllowed(address indexed target, bytes4 indexed selector);
+
+    /// @notice Emitted when admin removes a previously-allowed `(target, selector)` pair.
+    event OpDisallowed(address indexed target, bytes4 indexed selector);
+
+    /// @notice Emitted for each call dispatched through `runOpAndSettle`.
+    event OpExecuted(address indexed target, bytes4 indexed selector, bytes returnData);
+
     // ====================== Views ======================
 
     function version() external pure returns (uint256);
@@ -111,6 +126,15 @@ interface IDataPortabilityEscrow {
     ///         Settable post-deploy via `setDataRegistry` (admin-only).
     function dataRegistry() external view returns (IDataRegistryV2);
 
+    /// @notice True iff the `(target, selector)` pair is allowed for `runOpAndSettle`.
+    function isAllowedOp(address target, bytes4 selector) external view returns (bool);
+
+    /// @notice Enumerate every target address that currently has at least one allowed selector.
+    function getAllowedTargets() external view returns (address[] memory);
+
+    /// @notice Enumerate the selectors currently allowed for a given target.
+    function getAllowedSelectors(address target) external view returns (bytes4[] memory);
+
     // ====================== Admin ======================
 
     function setTokenWhitelisted(address token, bool whitelisted) external;
@@ -120,6 +144,12 @@ interface IDataPortabilityEscrow {
 
     /// @notice Set or update the data-registry contract used by `recordAccessAndSettle`.
     function setDataRegistry(address newDataRegistry) external;
+
+    /// @notice Allow or disallow a `(target, selector)` pair for `runOpAndSettle`.
+    /// @dev When the last selector for a target is removed, the target is also removed
+    ///      from `getAllowedTargets`. When the first selector for a fresh target is
+    ///      added, the target is added.
+    function setOpAllowed(address target, bytes4 selector, bool allowed) external;
 
     function pause() external;
 
@@ -185,4 +215,26 @@ interface IDataPortabilityEscrow {
         bytes calldata signature,
         SettleOp[] calldata ops
     ) external returns (bytes32 grantId);
+
+    /// @notice Atomically dispatch an admin-allowed call to an external contract and execute
+    ///         associated payouts. Both succeed or both revert.
+    /// @dev Authorization model:
+    ///        - Caller must hold `FACILITATOR_ROLE` (gate against unsolicited bundles).
+    ///        - The `(target, selector)` pair must be admin-allowlisted via `setOpAllowed`.
+    ///        - The target contract is responsible for its own per-call authentication
+    ///          (e.g. embedded EIP-712 signatures, replay protection / idempotency).
+    ///        The escrow forwards `callData` verbatim with zero value attached. The
+    ///        target's revert reason is bubbled up unmodified on failure, so callers
+    ///        observe the target's typed error rather than a generic wrapper.
+    /// @param target   Contract to invoke. Must be in `getAllowedTargets`.
+    /// @param callData ABI-encoded call (selector + args). First 4 bytes are matched
+    ///                 against the per-target allowlist.
+    /// @param ops      Payouts to execute after the call succeeds; may be empty.
+    /// @return returnData Raw return data from the target call. Callers that don't need
+    ///                    it can ignore the value; on-chain consumers can decode it.
+    function runOpAndSettle(
+        address target,
+        bytes calldata callData,
+        SettleOp[] calldata ops
+    ) external returns (bytes memory returnData);
 }

--- a/contracts/dataPortability/dataPortabilityEscrow/interfaces/IDataPortabilityEscrow.sol
+++ b/contracts/dataPortability/dataPortabilityEscrow/interfaces/IDataPortabilityEscrow.sol
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+/**
+ * @title IDataPortabilityEscrow
+ * @author Vana Network
+ * @notice Per-account custodial escrow supporting native VANA and whitelisted ERC-20s.
+ *
+ * Roles:
+ * - DEFAULT_ADMIN_ROLE: manages token whitelist, grants roles, upgrades the proxy
+ * - FACILITATOR_ROLE: settles balances between accounts and withdraws to external addresses
+ *
+ * Conventions:
+ * - The native asset (VANA) is represented by `address(0)`.
+ * - Deposits are permissionless: any caller may credit any account.
+ * - Settlement and withdrawal are restricted to FACILITATOR_ROLE and both
+ *   transfer funds OUT of the contract:
+ *     - `settle`   pays an arbitrary external `to` from `from`'s in-escrow balance
+ *     - `withdraw` returns funds to the account holder (recipient == account)
+ *
+ * @custom:security-contact security@vana.org
+ */
+interface IDataPortabilityEscrow {
+    /// @notice Single settlement entry used by `settleBatch`.
+    /// @param from   In-escrow account whose balance is debited
+    /// @param to     External recipient of the funds
+    /// @param asset  Asset to transfer; `address(0)` for native VANA
+    /// @param amount Amount to transfer
+    /// @param ref    Caller-supplied tag (paymentId / invoice hash). May be zero.
+    struct SettleOp {
+        address from;
+        address to;
+        address asset;
+        uint256 amount;
+        bytes32 ref;
+    }
+
+    // ====================== Errors ======================
+
+    error ZeroAmount();
+    error ZeroAddress();
+    error AssetNotSupported(address asset);
+    error InsufficientBalance(address account, address asset, uint256 requested, uint256 available);
+    error NativeTransferFailed();
+    error UnexpectedNativeValue();
+
+    // ====================== Events ======================
+
+    /// @notice Emitted when funds are credited to an account.
+    /// @param from   Address that supplied the funds (depositor / msg.sender)
+    /// @param account Address whose escrow balance increased
+    /// @param asset  Asset address; `address(0)` for native VANA
+    event Deposited(address indexed from, address indexed account, address indexed asset, uint256 amount);
+
+    /// @notice Emitted when the facilitator settles a payment: debits `from`'s
+    ///         in-escrow balance and transfers funds to external address `to`.
+    /// @param ref Caller-supplied tag (e.g. paymentId / invoice hash). May be zero.
+    event Settled(
+        address indexed from,
+        address indexed to,
+        address indexed asset,
+        uint256 amount,
+        bytes32 ref
+    );
+
+    /// @notice Emitted when the facilitator returns funds to the account holder:
+    ///         debits `account`'s in-escrow balance and transfers funds to `account`.
+    event Withdrawn(
+        address indexed account,
+        address indexed asset,
+        uint256 amount,
+        bytes32 ref
+    );
+
+    /// @notice Emitted when the admin updates the ERC-20 whitelist.
+    event TokenWhitelistUpdated(address indexed token, bool whitelisted);
+
+    // ====================== Views ======================
+
+    function version() external pure returns (uint256);
+
+    function isWhitelistedToken(address token) external view returns (bool);
+
+    function balanceOf(address account, address asset) external view returns (uint256);
+
+    // ====================== Admin ======================
+
+    function setTokenWhitelisted(address token, bool whitelisted) external;
+
+    function pause() external;
+
+    function unpause() external;
+
+    // ====================== Deposits (permissionless) ======================
+
+    /// @notice Deposit native VANA to credit `account`'s escrow balance.
+    function depositNative(address account) external payable;
+
+    /// @notice Deposit a whitelisted ERC-20 to credit `account`'s escrow balance.
+    /// @dev Caller must have approved `amount` to this contract.
+    function depositToken(address account, address token, uint256 amount) external;
+
+    // ====================== Facilitator ops ======================
+
+    /// @notice Debit `from`'s in-escrow balance and transfer the funds to external address `to`.
+    function settle(address from, address to, address asset, uint256 amount, bytes32 ref) external;
+
+    /// @notice Batched variant of `settle`.
+    function settleBatch(SettleOp[] calldata ops) external;
+
+    /// @notice Debit `account`'s in-escrow balance and return the funds to `account` itself.
+    function withdraw(address account, address asset, uint256 amount, bytes32 ref) external;
+}

--- a/contracts/dataPortability/dataPortabilityEscrow/interfaces/IDataPortabilityEscrow.sol
+++ b/contracts/dataPortability/dataPortabilityEscrow/interfaces/IDataPortabilityEscrow.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.24;
 
+import "../../dataPortabilityPermissionsV2/interfaces/IDataPortabilityPermissionsV2.sol";
+
 /**
  * @title IDataPortabilityEscrow
  * @author Vana Network
@@ -43,6 +45,7 @@ interface IDataPortabilityEscrow {
     error InsufficientBalance(address account, address asset, uint256 requested, uint256 available);
     error NativeTransferFailed();
     error UnexpectedNativeValue();
+    error PermissionsNotSet();
 
     // ====================== Events ======================
 
@@ -75,6 +78,9 @@ interface IDataPortabilityEscrow {
     /// @notice Emitted when the admin updates the ERC-20 whitelist.
     event TokenWhitelistUpdated(address indexed token, bool whitelisted);
 
+    /// @notice Emitted when the admin updates the cross-referenced permissions contract.
+    event PermissionsUpdated(address indexed previous, address indexed current);
+
     // ====================== Views ======================
 
     function version() external pure returns (uint256);
@@ -83,9 +89,16 @@ interface IDataPortabilityEscrow {
 
     function balanceOf(address account, address asset) external view returns (uint256);
 
+    /// @notice Cross-referenced permissions contract used by `registerAndSettle`.
+    ///         Settable post-deploy via `setPermissions` (admin-only).
+    function permissions() external view returns (IDataPortabilityPermissionsV2);
+
     // ====================== Admin ======================
 
     function setTokenWhitelisted(address token, bool whitelisted) external;
+
+    /// @notice Set or update the permissions contract used by `registerAndSettle`.
+    function setPermissions(address newPermissions) external;
 
     function pause() external;
 
@@ -110,4 +123,22 @@ interface IDataPortabilityEscrow {
 
     /// @notice Debit `account`'s in-escrow balance and return the funds to `account` itself.
     function withdraw(address account, address asset, uint256 amount, bytes32 ref) external;
+
+    /// @notice Atomically register a permission and execute associated payouts.
+    ///         Both succeed or both revert.
+    /// @dev Order: register first (via `permissions.addPermissionWithSignature`),
+    ///      then loop the ops calling `_payout` + emitting `Settled`. Reverts if
+    ///      the permissions contract is not set, the signature is invalid, the
+    ///      grantor mismatches, the grantVersion is stale, scopes are empty,
+    ///      or any op's balance is insufficient.
+    /// @param input the permission registration payload (matches the gateway's
+    ///        GrantRegistration EIP-712 type)
+    /// @param signature grantor's EIP-712 signature over `input`
+    /// @param ops payouts to execute after a successful registration; may be empty
+    /// @return grantId the deterministic grant id returned by the permissions contract
+    function registerAndSettle(
+        IDataPortabilityPermissionsV2.AddPermissionInput calldata input,
+        bytes calldata signature,
+        SettleOp[] calldata ops
+    ) external returns (bytes32 grantId);
 }

--- a/contracts/dataPortability/dataPortabilityEscrow/interfaces/IDataPortabilityEscrow.sol
+++ b/contracts/dataPortability/dataPortabilityEscrow/interfaces/IDataPortabilityEscrow.sol
@@ -43,12 +43,34 @@ interface IDataPortabilityEscrow {
     /// @param asset  Asset to transfer; `address(0)` for native VANA
     /// @param amount Amount to transfer
     /// @param opKind Classification of the operation (off-chain hint).
+    /// @param ref    Caller-asserted correlation id joining this settlement to
+    ///               the protocol entity it pays for. NOT verified on-chain —
+    ///               an indexing hint, not consensus data. Every value below is
+    ///               content-addressed and precomputable before the tx.
+    ///
+    ///               Convention by `opKind`:
+    ///                 Unspecified         — `bytes32(0)` or free-form
+    ///                 DataRegistration    — dataPointId
+    ///                                       = keccak256(abi.encode(owner, scope))
+    ///                 ServerRegistration  — serverId
+    ///                                       = keccak256(abi.encode(serversDomainSeparator,
+    ///                                         serverAddress, publicKey, serverUrl))
+    ///                 BuilderRegistration — granteeId (opaque bytes32 used in grants)
+    ///                 GrantRegistration   — grantId
+    ///                                       = keccak256(abi.encode(permissionsDomainSeparator,
+    ///                                         grantorAddress, granteeId))
+    ///                 DataAccess          — grantId under which the access was
+    ///                                       authorized. (recordId is NOT the ref:
+    ///                                       it is already joinable via the same-tx
+    ///                                       `DataAccessRecorded` event; grantId is
+    ///                                       the link that event lacks.)
     struct SettleOp {
         address from;
         address to;
         address asset;
         uint256 amount;
         OpKind opKind;
+        bytes32 ref;
     }
 
     // ====================== Errors ======================
@@ -74,11 +96,17 @@ interface IDataPortabilityEscrow {
 
     /// @notice Emitted when the facilitator settles a payment: debits `from`'s
     ///         in-escrow balance and transfers funds to external address `to`.
+    /// @dev `ref` is indexed (instead of `asset`) so indexers can filter
+    ///      settlements by grantId / dataPointId / serverId via log topics —
+    ///      e.g. "all payments under grant X" is a single eth_getLogs query.
+    ///      See the `SettleOp.ref` docs for the per-OpKind ref convention.
     /// @param opKind Classification of the operation (off-chain hint).
+    /// @param ref    Caller-asserted correlation id (see SettleOp.ref).
     event Settled(
         address indexed from,
         address indexed to,
-        address indexed asset,
+        bytes32 indexed ref,
+        address asset,
         uint256 amount,
         OpKind opKind
     );
@@ -164,10 +192,64 @@ interface IDataPortabilityEscrow {
     /// @dev Caller must have approved `amount` to this contract.
     function depositToken(address account, address token, uint256 amount) external;
 
+    /// @notice Deposit a whitelisted EIP-3009 ERC-20 (e.g. USDC) using the token
+    ///         owner's off-chain authorization — no prior `approve` tx needed —
+    ///         crediting `account`'s escrow balance (which may differ from the
+    ///         token owner `from`).
+    ///
+    ///         The beneficiary is tamper-proof despite not being a field of the
+    ///         EIP-3009 payload: the authorization's nonce MUST be computed as
+    ///
+    ///           nonce = keccak256(abi.encode(account, salt))
+    ///
+    ///         The signer derives the nonce from the intended beneficiary when
+    ///         signing; the escrow recomputes it from the caller-supplied
+    ///         `account` and `salt`. A relayer that substitutes a different
+    ///         `account` produces a different nonce, and the token's signature
+    ///         check fails. Self-deposit is simply `account == from`.
+    /// @dev Uses `receiveWithAuthorization` (not `transferWithAuthorization`):
+    ///      the token enforces `msg.sender == to == this escrow`, so the
+    ///      authorization cannot be front-run directly against the token to
+    ///      strand funds. Replay protection is the token's own (from, nonce)
+    ///      tracking; the token reverts on reuse, expiry, or bad signature.
+    ///      Balance-diff accounting credits only what actually arrived.
+    /// @param account     Escrow account to credit (committed via the nonce).
+    /// @param from        Token owner who signed the EIP-3009 authorization.
+    /// @param token       Whitelisted EIP-3009 token to deposit.
+    /// @param value       Amount authorized for transfer.
+    /// @param validAfter  Authorization not valid before this unix time.
+    /// @param validBefore Authorization not valid at/after this unix time.
+    /// @param salt        Signer-chosen entropy making the nonce unique per
+    ///                    deposit; reuse with the same `account` collides in the
+    ///                    token's (from, nonce) replay state and reverts.
+    /// @param v           Signature v.
+    /// @param r           Signature r.
+    /// @param s           Signature s.
+    function depositTokenWithAuthorization(
+        address account,
+        address from,
+        address token,
+        uint256 value,
+        uint256 validAfter,
+        uint256 validBefore,
+        bytes32 salt,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external;
+
     // ====================== Facilitator ops ======================
 
     /// @notice Debit `from`'s in-escrow balance and transfer the funds to external address `to`.
-    function settle(address from, address to, address asset, uint256 amount, OpKind opKind) external;
+    /// @param ref Correlation id — see `SettleOp.ref` for the per-OpKind convention.
+    function settle(
+        address from,
+        address to,
+        address asset,
+        uint256 amount,
+        OpKind opKind,
+        bytes32 ref
+    ) external;
 
     /// @notice Batched variant of `settle`.
     function settleBatch(SettleOp[] calldata ops) external;

--- a/contracts/dataPortability/dataPortabilityEscrow/interfaces/IDataPortabilityEscrow.sol
+++ b/contracts/dataPortability/dataPortabilityEscrow/interfaces/IDataPortabilityEscrow.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.24;
 
 import "../../dataPortabilityPermissionsV2/interfaces/IDataPortabilityPermissionsV2.sol";
+import "../../../data/dataRegistryV2/interfaces/IDataRegistryV2.sol";
 
 /**
  * @title IDataPortabilityEscrow
@@ -55,6 +56,7 @@ interface IDataPortabilityEscrow {
     error NativeTransferFailed();
     error UnexpectedNativeValue();
     error PermissionsNotSet();
+    error DataRegistryNotSet();
 
     // ====================== Events ======================
 
@@ -90,6 +92,9 @@ interface IDataPortabilityEscrow {
     /// @notice Emitted when the admin updates the cross-referenced permissions contract.
     event PermissionsUpdated(address indexed previous, address indexed current);
 
+    /// @notice Emitted when the admin updates the cross-referenced data-registry contract.
+    event DataRegistryUpdated(address indexed previous, address indexed current);
+
     // ====================== Views ======================
 
     function version() external pure returns (uint256);
@@ -102,12 +107,19 @@ interface IDataPortabilityEscrow {
     ///         Settable post-deploy via `setPermissions` (admin-only).
     function permissions() external view returns (IDataPortabilityPermissionsV2);
 
+    /// @notice Cross-referenced data-registry contract used by `recordAccessAndSettle`.
+    ///         Settable post-deploy via `setDataRegistry` (admin-only).
+    function dataRegistry() external view returns (IDataRegistryV2);
+
     // ====================== Admin ======================
 
     function setTokenWhitelisted(address token, bool whitelisted) external;
 
     /// @notice Set or update the permissions contract used by `registerAndSettle`.
     function setPermissions(address newPermissions) external;
+
+    /// @notice Set or update the data-registry contract used by `recordAccessAndSettle`.
+    function setDataRegistry(address newDataRegistry) external;
 
     function pause() external;
 
@@ -132,6 +144,29 @@ interface IDataPortabilityEscrow {
 
     /// @notice Debit `account`'s in-escrow balance and return the funds to `account` itself.
     function withdraw(address account, address asset, uint256 amount, bytes32 ref) external;
+
+    /// @notice Atomically record a data access and execute associated payouts.
+    ///         Both succeed or both revert.
+    /// @dev Order: record first (via `dataRegistry.recordDataAccess`), then loop
+    ///      the ops calling `_payout` + emitting `Settled`. The inner record
+    ///      reverts on duplicate recordId, untrusted server, unknown version,
+    ///      etc. — bundle-level idempotency falls out of EVM atomicity.
+    /// @param ownerAddress    Data point owner whose counter is incremented.
+    /// @param scope           Data point scope.
+    /// @param version_        Version against which the access is recorded.
+    /// @param accessor        Address that performed the access.
+    /// @param recordId        Caller-chosen unique id; reverts if reused.
+    /// @param serverSignature EIP-712 signature by a personal server trusted by `ownerAddress`.
+    /// @param ops             Payouts to execute after a successful record; may be empty.
+    function recordAccessAndSettle(
+        address ownerAddress,
+        string calldata scope,
+        uint256 version_,
+        address accessor,
+        bytes32 recordId,
+        bytes calldata serverSignature,
+        SettleOp[] calldata ops
+    ) external;
 
     /// @notice Atomically register a permission and execute associated payouts.
     ///         Both succeed or both revert.

--- a/contracts/dataPortability/dataPortabilityEscrow/interfaces/IERC3009.sol
+++ b/contracts/dataPortability/dataPortabilityEscrow/interfaces/IERC3009.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+/**
+ * @title IERC3009
+ * @notice Minimal interface for EIP-3009 "Transfer With Authorization" tokens
+ *         (e.g. USDC / Circle FiatTokenV2+). Only the surface the escrow needs.
+ *
+ *         `receiveWithAuthorization` is used instead of
+ *         `transferWithAuthorization` deliberately: the token enforces
+ *         `msg.sender == to`, so a third party cannot submit the user's
+ *         authorization directly against the token and move funds into the
+ *         escrow outside the deposit flow (which would burn the nonce and
+ *         strand the tokens uncredited).
+ */
+interface IERC3009 {
+    function receiveWithAuthorization(
+        address from,
+        address to,
+        uint256 value,
+        uint256 validAfter,
+        uint256 validBefore,
+        bytes32 nonce,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external;
+
+    /// @notice True if the (authorizer, nonce) pair has been consumed.
+    function authorizationState(address authorizer, bytes32 nonce) external view returns (bool);
+}

--- a/contracts/dataPortability/dataPortabilityPermissionsV2/DataPortabilityPermissionsV2Implementation.sol
+++ b/contracts/dataPortability/dataPortabilityPermissionsV2/DataPortabilityPermissionsV2Implementation.sol
@@ -30,12 +30,6 @@ contract DataPortabilityPermissionsV2Implementation is
             "GrantRegistration(address grantorAddress,bytes32 granteeId,string[] scopes,uint256 grantVersion,uint256 expiresAt)"
         );
 
-    /// @dev Typehash for the custom domain used to derive `grantId`. Not the
-    ///      same as the EIP-712 domain — this one is purely for content-addressed
-    ///      ids, so anyone can recompute them off-chain from public inputs.
-    bytes32 private constant DOMAIN_TYPEHASH =
-        keccak256("DataPortabilityDomain(uint256 chainId,address verifyingContract)");
-
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
         _disableInitializers();
@@ -82,7 +76,7 @@ contract DataPortabilityPermissionsV2Implementation is
     }
 
     function domainSeparator() public view override returns (bytes32) {
-        return keccak256(abi.encode(DOMAIN_TYPEHASH, block.chainid, address(this)));
+        return _domainSeparatorV4();
     }
 
     function grantId(address grantorAddress, bytes32 granteeId) public view override returns (bytes32) {

--- a/contracts/dataPortability/dataPortabilityPermissionsV2/DataPortabilityPermissionsV2Implementation.sol
+++ b/contracts/dataPortability/dataPortabilityPermissionsV2/DataPortabilityPermissionsV2Implementation.sol
@@ -62,6 +62,17 @@ contract DataPortabilityPermissionsV2Implementation is
         _unpause();
     }
 
+    function setDataPortabilityServers(address newDataPortabilityServers)
+        external
+        override
+        onlyRole(DEFAULT_ADMIN_ROLE)
+    {
+        if (newDataPortabilityServers == address(0)) revert ZeroAddress();
+        address previous = address(dataPortabilityServers);
+        dataPortabilityServers = IDataPortabilityServersV2(newDataPortabilityServers);
+        emit DataPortabilityServersUpdated(previous, newDataPortabilityServers);
+    }
+
     // ====================== Views ======================
 
     function permissions(bytes32 id) external view override returns (Permission memory) {
@@ -116,11 +127,26 @@ contract DataPortabilityPermissionsV2Implementation is
 
         address signer = ECDSA.recover(digest, signature);
         if (signer == address(0)) revert InvalidSignature();
-        if (signer != input.grantorAddress) revert GrantorMismatch(input.grantorAddress, signer);
+
+        // Two accepted authorities, in order:
+        //   1. Grantor self-signed — original V2 behavior.
+        //   2. Delegate — a personal server currently registered to the grantor
+        //      in `dataPortabilityServers`. Same trust model as
+        //      DataRegistryV2.recordDataAccess: revocation in the servers
+        //      registry immediately removes signing authority.
+        // If the servers registry is unset, only path 1 is accepted; behavior
+        // matches the pre-upgrade contract exactly.
+        bool isGrantor = signer == input.grantorAddress;
+        bool isDelegate = !isGrantor
+            && address(dataPortabilityServers) != address(0)
+            && _isTrustedServer(input.grantorAddress, signer);
+        if (!isGrantor && !isDelegate) revert GrantorMismatch(input.grantorAddress, signer);
 
         // No nonce check here — `grantVersion` monotonicity in `_addPermission`
         // gives replay + rollback protection per (grantor, grantee) slot.
-        return _addPermission(input);
+        bytes32 id = _addPermission(input);
+        if (isDelegate) emit PermissionSignedByDelegate(id, input.grantorAddress, signer);
+        return id;
     }
 
     // ====================== Internals ======================
@@ -169,6 +195,17 @@ contract DataPortabilityPermissionsV2Implementation is
 
     function _computeGrantId(address grantorAddress, bytes32 granteeId) internal view returns (bytes32) {
         return keccak256(abi.encode(domainSeparator(), grantorAddress, granteeId));
+    }
+
+    /// @dev Mirrors DataRegistryV2._isTrustedServer: a personal server is
+    ///      currently trusted by `ownerAddress` iff it has an active (non-
+    ///      revoked) registration whose stored owner matches. In V2 a server
+    ///      address has at most one active owner at a time.
+    function _isTrustedServer(address ownerAddress, address server) internal view returns (bool) {
+        bytes32 sId = dataPortabilityServers.activeServerId(server);
+        if (sId == bytes32(0)) return false;
+        IDataPortabilityServersV2.ServerInfo memory info = dataPortabilityServers.getServer(sId);
+        return info.ownerAddress == ownerAddress;
     }
 
     /// @dev Canonical EIP-712 hash of a `string[]`: hash each string, then

--- a/contracts/dataPortability/dataPortabilityPermissionsV2/DataPortabilityPermissionsV2Implementation.sol
+++ b/contracts/dataPortability/dataPortabilityPermissionsV2/DataPortabilityPermissionsV2Implementation.sol
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol";
+import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import "./interfaces/DataPortabilityPermissionsV2StorageV1.sol";
+
+/**
+ * @title DataPortabilityPermissionsV2Implementation
+ * @notice New-shape permission registry. UUPS upgradeable. Permissions are
+ *         immutable after creation; expiry is enforced via `expiresAt`.
+ */
+contract DataPortabilityPermissionsV2Implementation is
+    UUPSUpgradeable,
+    PausableUpgradeable,
+    AccessControlUpgradeable,
+    EIP712Upgradeable,
+    DataPortabilityPermissionsV2StorageV1
+{
+    using ECDSA for bytes32;
+
+    string private constant SIGNING_DOMAIN = "Vana Data Portability";
+    string private constant SIGNATURE_VERSION = "1";
+
+    bytes32 public constant override GRANT_REGISTRATION_TYPEHASH =
+        keccak256(
+            "GrantRegistration(address grantorAddress,bytes32 granteeId,string[] scopes,uint256 grantVersion,uint256 expiresAt)"
+        );
+
+    /// @dev Typehash for the custom domain used to derive `grantId`. Not the
+    ///      same as the EIP-712 domain — this one is purely for content-addressed
+    ///      ids, so anyone can recompute them off-chain from public inputs.
+    bytes32 private constant DOMAIN_TYPEHASH =
+        keccak256("DataPortabilityDomain(uint256 chainId,address verifyingContract)");
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    function initialize(address ownerAddress) external initializer {
+        if (ownerAddress == address(0)) revert ZeroAddress();
+
+        __AccessControl_init();
+        __UUPSUpgradeable_init();
+        __Pausable_init();
+        __EIP712_init(SIGNING_DOMAIN, SIGNATURE_VERSION);
+
+        _grantRole(DEFAULT_ADMIN_ROLE, ownerAddress);
+    }
+
+    function _authorizeUpgrade(address newImplementation) internal virtual override onlyRole(DEFAULT_ADMIN_ROLE) {}
+
+    function version() external pure virtual override returns (uint256) {
+        return 1;
+    }
+
+    // ====================== Admin ======================
+
+    function pause() external override onlyRole(DEFAULT_ADMIN_ROLE) {
+        _pause();
+    }
+
+    function unpause() external override onlyRole(DEFAULT_ADMIN_ROLE) {
+        _unpause();
+    }
+
+    // ====================== Views ======================
+
+    function permissions(bytes32 id) external view override returns (Permission memory) {
+        return _permissions[id];
+    }
+
+    function isActive(bytes32 id) external view override returns (bool) {
+        Permission storage p = _permissions[id];
+        if (p.grantorAddress == address(0)) return false;
+        if (p.expiresAt == 0) return true;
+        return block.timestamp <= p.expiresAt;
+    }
+
+    function domainSeparator() public view override returns (bytes32) {
+        return keccak256(abi.encode(DOMAIN_TYPEHASH, block.chainid, address(this)));
+    }
+
+    function grantId(address grantorAddress, bytes32 granteeId) public view override returns (bytes32) {
+        return _computeGrantId(grantorAddress, granteeId);
+    }
+
+    // ====================== Registration ======================
+
+    function addPermission(AddPermissionInput calldata input)
+        external
+        override
+        whenNotPaused
+        returns (bytes32)
+    {
+        if (input.grantorAddress != msg.sender) revert GrantorMismatch(input.grantorAddress, msg.sender);
+        return _addPermission(input);
+    }
+
+    function addPermissionWithSignature(AddPermissionInput calldata input, bytes calldata signature)
+        external
+        override
+        whenNotPaused
+        returns (bytes32)
+    {
+        bytes32 digest = _hashTypedDataV4(
+            keccak256(
+                abi.encode(
+                    GRANT_REGISTRATION_TYPEHASH,
+                    input.grantorAddress,
+                    input.granteeId,
+                    _hashScopes(input.scopes),
+                    input.grantVersion,
+                    input.expiresAt
+                )
+            )
+        );
+
+        address signer = ECDSA.recover(digest, signature);
+        if (signer == address(0)) revert InvalidSignature();
+        if (signer != input.grantorAddress) revert GrantorMismatch(input.grantorAddress, signer);
+
+        // No nonce check here — `grantVersion` monotonicity in `_addPermission`
+        // gives replay + rollback protection per (grantor, grantee) slot.
+        return _addPermission(input);
+    }
+
+    // ====================== Internals ======================
+
+    function _addPermission(AddPermissionInput calldata input) internal returns (bytes32) {
+        if (input.grantorAddress == address(0)) revert ZeroAddress();
+        if (input.granteeId == bytes32(0)) revert ZeroGranteeId();
+        if (input.scopes.length == 0) revert EmptyScopes();
+        // expiresAt == 0 is allowed and means perpetual.
+
+        bytes32 id = _computeGrantId(input.grantorAddress, input.granteeId);
+        Permission storage p = _permissions[id];
+
+        // `grantVersion` acts as a per-grant monotonic nonce: every update must
+        // be strictly larger than the stored value. First write has stored = 0,
+        // so any input >= 1 passes. Prevents replay and rollback in one check.
+        if (input.grantVersion <= p.grantVersion) {
+            revert InvalidGrantVersion(p.grantVersion, input.grantVersion);
+        }
+
+        p.grantorAddress = input.grantorAddress;
+        p.granteeId = input.granteeId;
+        p.grantVersion = input.grantVersion;
+        p.expiresAt = input.expiresAt;
+
+        // Upsert: reset the existing scopes array before writing the new entries.
+        delete p.scopes;
+        uint256 sLen = input.scopes.length;
+        for (uint256 i = 0; i < sLen; ) {
+            p.scopes.push(input.scopes[i]);
+            unchecked {
+                ++i;
+            }
+        }
+
+        emit PermissionSet(
+            id,
+            input.grantorAddress,
+            input.granteeId,
+            input.scopes,
+            input.grantVersion,
+            input.expiresAt
+        );
+        return id;
+    }
+
+    function _computeGrantId(address grantorAddress, bytes32 granteeId) internal view returns (bytes32) {
+        return keccak256(abi.encode(domainSeparator(), grantorAddress, granteeId));
+    }
+
+    /// @dev Canonical EIP-712 hash of a `string[]`: hash each string, then
+    ///      keccak256 the concatenation of those hashes.
+    function _hashScopes(string[] calldata scopes) internal pure returns (bytes32) {
+        uint256 len = scopes.length;
+        bytes32[] memory hashes = new bytes32[](len);
+        for (uint256 i = 0; i < len; ) {
+            hashes[i] = keccak256(bytes(scopes[i]));
+            unchecked {
+                ++i;
+            }
+        }
+        return keccak256(abi.encodePacked(hashes));
+    }
+}

--- a/contracts/dataPortability/dataPortabilityPermissionsV2/DataPortabilityPermissionsV2Proxy.sol
+++ b/contracts/dataPortability/dataPortabilityPermissionsV2/DataPortabilityPermissionsV2Proxy.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+contract DataPortabilityPermissionsV2Proxy is ERC1967Proxy {
+    constructor(address logic, bytes memory data) ERC1967Proxy(logic, data) {}
+}

--- a/contracts/dataPortability/dataPortabilityPermissionsV2/interfaces/DataPortabilityPermissionsV2StorageV1.sol
+++ b/contracts/dataPortability/dataPortabilityPermissionsV2/interfaces/DataPortabilityPermissionsV2StorageV1.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import "./IDataPortabilityPermissionsV2.sol";
+
+/**
+ * @title Storage for DataPortabilityPermissionsV2
+ * @notice For future upgrades, do not change DataPortabilityPermissionsV2StorageV1.
+ * Create a new contract which implements DataPortabilityPermissionsV2StorageV1.
+ */
+abstract contract DataPortabilityPermissionsV2StorageV1 is IDataPortabilityPermissionsV2 {
+    /// @dev Permissions keyed by deterministic grant id (keccak256(domain, grantor, granteeId)).
+    /// @dev Replay/rollback protection is via `grantVersion` monotonicity per id —
+    ///      no separate nonce counter is needed.
+    mapping(bytes32 id => Permission) internal _permissions;
+}

--- a/contracts/dataPortability/dataPortabilityPermissionsV2/interfaces/DataPortabilityPermissionsV2StorageV1.sol
+++ b/contracts/dataPortability/dataPortabilityPermissionsV2/interfaces/DataPortabilityPermissionsV2StorageV1.sol
@@ -13,4 +13,11 @@ abstract contract DataPortabilityPermissionsV2StorageV1 is IDataPortabilityPermi
     /// @dev Replay/rollback protection is via `grantVersion` monotonicity per id —
     ///      no separate nonce counter is needed.
     mapping(bytes32 id => Permission) internal _permissions;
+
+    /// @dev Cross-referenced DataPortabilityServersV2 used to resolve a personal
+    ///      server's current trust for its owner when verifying delegated
+    ///      signatures inside `addPermissionWithSignature`. Set post-deploy via
+    ///      `setDataPortabilityServers`. If unset, only grantor-self-signed
+    ///      signatures are accepted (existing behavior is preserved).
+    IDataPortabilityServersV2 public override dataPortabilityServers;
 }

--- a/contracts/dataPortability/dataPortabilityPermissionsV2/interfaces/IDataPortabilityPermissionsV2.sol
+++ b/contracts/dataPortability/dataPortabilityPermissionsV2/interfaces/IDataPortabilityPermissionsV2.sol
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+/**
+ * @title IDataPortabilityPermissionsV2
+ * @author Vana Network
+ * @notice Registry of data-access permissions, content-addressed by a
+ *         deterministic id derived from (domain, grantor, grantee):
+ *
+ *           grantId = keccak256(abi.encode(domainSeparator, grantorAddress, granteeId))
+ *
+ *         where
+ *
+ *           domainSeparator = keccak256(abi.encode(
+ *             keccak256("DataPortabilityDomain(uint256 chainId,address verifyingContract)"),
+ *             chainId,
+ *             address(this)
+ *           ))
+ *
+ *         This domain is separate from the EIP-712 domain used for the
+ *         signature in `addPermissionWithSignature` — it is purely for id
+ *         derivation, so anyone can compute the id off-chain.
+ *
+ *         Each Permission records:
+ *           - grantorAddress: address that granted the permission
+ *           - granteeId: opaque bytes32 identifier of the grantee
+ *           - scopes: free-form scope strings agreed off-chain
+ *           - grantVersion: schema/format version of this grant
+ *           - expiresAt: unix timestamp after which the grant is invalid;
+ *             `0` means perpetual
+ *
+ *         Semantics: each (grantor, grantee) pair has exactly one slot.
+ *         Re-registration by the same grantor for the same grantee OVERWRITES
+ *         the existing permission (upsert).
+ *
+ *         Replay & rollback protection: `grantVersion` doubles as a monotonic
+ *         per-grant nonce. Every update must use a strictly larger
+ *         `grantVersion` than the currently stored one — so signatures can't
+ *         be replayed, and updates can't roll back the grant. First write
+ *         requires `grantVersion >= 1`.
+ *
+ *         Two registration paths:
+ *           - `addPermission`: direct call by the grantor (msg.sender)
+ *           - `addPermissionWithSignature`: any submitter; the grantor's EIP-712
+ *             signature authorizes the action
+ *
+ *         "Revocation" is achieved by upserting with `expiresAt` set to a past
+ *         timestamp (and a higher `grantVersion`).
+ *
+ * @custom:security-contact security@vana.org
+ */
+interface IDataPortabilityPermissionsV2 {
+    /// @notice On-chain permission record.
+    struct Permission {
+        address grantorAddress;
+        bytes32 granteeId;
+        string[] scopes;
+        uint256 grantVersion;
+        uint256 expiresAt;
+    }
+
+    /// @notice Caller-supplied input for registering a permission. Field order
+    ///         matches the EIP-712 `GrantRegistration` type — see
+    ///         `GRANT_REGISTRATION_TYPEHASH`.
+    /// @dev `grantorAddress` is included in the signed payload (wallets display
+    ///      it; the contract verifies that the recovered signer matches it).
+    struct AddPermissionInput {
+        address grantorAddress;
+        bytes32 granteeId;
+        string[] scopes;
+        uint256 grantVersion;
+        uint256 expiresAt;
+    }
+
+    // ====================== Errors ======================
+
+    error ZeroAddress();
+    error ZeroGranteeId();
+    error EmptyScopes();
+    /// @dev Reverts when `providedVersion <= currentVersion`. For the first
+    ///      write, `currentVersion` is 0 so `providedVersion` must be >= 1.
+    error InvalidGrantVersion(uint256 currentVersion, uint256 providedVersion);
+    error InvalidSignature();
+    /// @dev Reverts when the claimed `grantorAddress` does not match the
+    ///      actual authority (msg.sender for direct calls, recovered signer
+    ///      for signature-based calls).
+    error GrantorMismatch(address claimed, address actual);
+
+    // ====================== Events ======================
+
+    /// @notice Emitted when a permission is created OR updated (upsert).
+    /// @dev Indexers can distinguish "new" from "update" by tracking whether the id
+    ///      has been seen before in this event stream.
+    event PermissionSet(
+        bytes32 indexed id,
+        address indexed grantorAddress,
+        bytes32 indexed granteeId,
+        string[] scopes,
+        uint256 grantVersion,
+        uint256 expiresAt
+    );
+
+    // ====================== Views ======================
+
+    function version() external pure returns (uint256);
+
+    function permissions(bytes32 id) external view returns (Permission memory);
+
+    /// @notice Returns true if the permission exists and has not expired.
+    function isActive(bytes32 id) external view returns (bool);
+
+    /// @notice The EIP-712 typehash used by `addPermissionWithSignature`.
+    ///         Type: GrantRegistration(address grantorAddress,bytes32 granteeId,
+    ///         string[] scopes,uint256 grantVersion,uint256 expiresAt)
+    function GRANT_REGISTRATION_TYPEHASH() external view returns (bytes32);
+
+    /// @notice The custom domain separator used to derive `grantId`. Different
+    ///         from the EIP-712 domain separator used for signatures.
+    function domainSeparator() external view returns (bytes32);
+
+    /// @notice Deterministic id for a (grantor, grantee) pair.
+    function grantId(address grantorAddress, bytes32 granteeId) external view returns (bytes32);
+
+    // ====================== Admin ======================
+
+    function pause() external;
+
+    function unpause() external;
+
+    // ====================== Registration ======================
+
+    /// @notice Create or update a permission. `msg.sender` becomes the grantor.
+    /// @return id The deterministic grant id.
+    function addPermission(AddPermissionInput calldata input) external returns (bytes32 id);
+
+    /// @notice Create or update a permission on behalf of the EIP-712 signer.
+    ///         The submitter (msg.sender) pays gas; authority comes from the signature.
+    /// @param input The permission data. `grantVersion` must be strictly greater
+    ///        than the currently stored version for this (grantor, grantee) pair,
+    ///        which doubles as nonce and rollback protection.
+    /// @param signature EIP-712 signature over `input` by the grantor.
+    /// @return id The deterministic grant id.
+    function addPermissionWithSignature(
+        AddPermissionInput calldata input,
+        bytes calldata signature
+    ) external returns (bytes32 id);
+}

--- a/contracts/dataPortability/dataPortabilityPermissionsV2/interfaces/IDataPortabilityPermissionsV2.sol
+++ b/contracts/dataPortability/dataPortabilityPermissionsV2/interfaces/IDataPortabilityPermissionsV2.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.24;
 
+import "../../dataPortabilityServersV2/interfaces/IDataPortabilityServersV2.sol";
+
 /**
  * @title IDataPortabilityPermissionsV2
  * @author Vana Network
@@ -87,7 +89,9 @@ interface IDataPortabilityPermissionsV2 {
     error InvalidSignature();
     /// @dev Reverts when the claimed `grantorAddress` does not match the
     ///      actual authority (msg.sender for direct calls, recovered signer
-    ///      for signature-based calls).
+    ///      for signature-based calls). Also raised on the signature path when
+    ///      the recovered signer is neither the grantor nor a personal server
+    ///      currently trusted by the grantor.
     error GrantorMismatch(address claimed, address actual);
 
     // ====================== Events ======================
@@ -103,6 +107,20 @@ interface IDataPortabilityPermissionsV2 {
         uint256 grantVersion,
         uint256 expiresAt
     );
+
+    /// @notice Emitted alongside `PermissionSet` when the EIP-712 signature was
+    ///         produced by a delegate (personal server currently trusted by the
+    ///         grantor) rather than the grantor itself. Not emitted on direct
+    ///         calls or grantor-self-signed calls.
+    event PermissionSignedByDelegate(
+        bytes32 indexed id,
+        address indexed grantorAddress,
+        address indexed delegate
+    );
+
+    /// @notice Emitted when the admin updates the cross-referenced
+    ///         DataPortabilityServersV2 contract.
+    event DataPortabilityServersUpdated(address indexed previous, address indexed current);
 
     // ====================== Views ======================
 
@@ -127,11 +145,20 @@ interface IDataPortabilityPermissionsV2 {
     /// @notice Deterministic id for a (grantor, grantee) pair.
     function grantId(address grantorAddress, bytes32 granteeId) external view returns (bytes32);
 
+    /// @notice Cross-referenced personal-servers registry used by
+    ///         `addPermissionWithSignature` for delegated signing. If unset,
+    ///         only grantor-self-signed signatures are accepted.
+    function dataPortabilityServers() external view returns (IDataPortabilityServersV2);
+
     // ====================== Admin ======================
 
     function pause() external;
 
     function unpause() external;
+
+    /// @notice Set or update the DataPortabilityServersV2 contract used to
+    ///         resolve trusted personal servers for delegated signing.
+    function setDataPortabilityServers(address newDataPortabilityServers) external;
 
     // ====================== Registration ======================
 
@@ -141,10 +168,20 @@ interface IDataPortabilityPermissionsV2 {
 
     /// @notice Create or update a permission on behalf of the EIP-712 signer.
     ///         The submitter (msg.sender) pays gas; authority comes from the signature.
+    /// @dev Accepts a signature from EITHER:
+    ///         (a) the grantor itself, OR
+    ///         (b) a personal server currently registered to the grantor in the
+    ///             configured `dataPortabilityServers` registry — server-as-delegate.
+    ///      If the servers registry is unset (zero address), only (a) is accepted.
+    ///      In case (b), `PermissionSignedByDelegate` is emitted alongside the
+    ///      standard `PermissionSet`. Trust is determined at execution time:
+    ///      revoking the server before submission causes this call to revert
+    ///      with `GrantorMismatch`.
     /// @param input The permission data. `grantVersion` must be strictly greater
     ///        than the currently stored version for this (grantor, grantee) pair,
     ///        which doubles as nonce and rollback protection.
-    /// @param signature EIP-712 signature over `input` by the grantor.
+    /// @param signature EIP-712 signature over `input` by the grantor OR by a
+    ///        currently-trusted personal server for the grantor.
     /// @return id The deterministic grant id.
     function addPermissionWithSignature(
         AddPermissionInput calldata input,

--- a/contracts/dataPortability/dataPortabilityPermissionsV2/interfaces/IDataPortabilityPermissionsV2.sol
+++ b/contracts/dataPortability/dataPortabilityPermissionsV2/interfaces/IDataPortabilityPermissionsV2.sol
@@ -7,19 +7,23 @@ pragma solidity 0.8.24;
  * @notice Registry of data-access permissions, content-addressed by a
  *         deterministic id derived from (domain, grantor, grantee):
  *
- *           grantId = keccak256(abi.encode(domainSeparator, grantorAddress, granteeId))
+ *           grantId = keccak256(abi.encode(domainSeparator(), grantorAddress, granteeId))
  *
- *         where
+ *         where `domainSeparator()` is the EIP-712 domain separator returned
+ *         by OpenZeppelin's `_domainSeparatorV4`:
  *
  *           domainSeparator = keccak256(abi.encode(
- *             keccak256("DataPortabilityDomain(uint256 chainId,address verifyingContract)"),
+ *             keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
+ *             keccak256("Vana Data Portability"),
+ *             keccak256("1"),
  *             chainId,
  *             address(this)
  *           ))
  *
- *         This domain is separate from the EIP-712 domain used for the
- *         signature in `addPermissionWithSignature` — it is purely for id
- *         derivation, so anyone can compute the id off-chain.
+ *         The same domain separator is used for both the `addPermissionWithSignature`
+ *         EIP-712 signature and the content-addressed `grantId`. Off-chain code
+ *         that constructs the standard EIP-712 domain (e.g. viem's `hashDomain`)
+ *         produces the same value.
  *
  *         Each Permission records:
  *           - grantorAddress: address that granted the permission
@@ -114,8 +118,10 @@ interface IDataPortabilityPermissionsV2 {
     ///         string[] scopes,uint256 grantVersion,uint256 expiresAt)
     function GRANT_REGISTRATION_TYPEHASH() external view returns (bytes32);
 
-    /// @notice The custom domain separator used to derive `grantId`. Different
-    ///         from the EIP-712 domain separator used for signatures.
+    /// @notice EIP-712 domain separator. Used both as the signing-domain for
+    ///         `addPermissionWithSignature` and as the namespace tag baked into
+    ///         every `grantId`. Computed from the standard EIP-712 fields
+    ///         (name, version, chainId, verifyingContract).
     function domainSeparator() external view returns (bytes32);
 
     /// @notice Deterministic id for a (grantor, grantee) pair.

--- a/contracts/dataPortability/dataPortabilityServersV2/DataPortabilityServersV2Implementation.sol
+++ b/contracts/dataPortability/dataPortabilityServersV2/DataPortabilityServersV2Implementation.sol
@@ -1,0 +1,305 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/metatx/ERC2771ContextUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol";
+import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import "./interfaces/DataPortabilityServersV2StorageV1.sol";
+
+/**
+ * @title DataPortabilityServersV2Implementation
+ * @notice Gateway-compatible server registry. See `IDataPortabilityServersV2`
+ *         for the full contract surface and design rationale.
+ */
+contract DataPortabilityServersV2Implementation is
+    UUPSUpgradeable,
+    PausableUpgradeable,
+    AccessControlUpgradeable,
+    ERC2771ContextUpgradeable,
+    EIP712Upgradeable,
+    DataPortabilityServersV2StorageV1
+{
+    using ECDSA for bytes32;
+
+    string private constant SIGNING_DOMAIN = "Vana Data Portability";
+    string private constant SIGNATURE_VERSION = "1";
+
+    bytes32 public constant MAINTAINER_ROLE = keccak256("MAINTAINER_ROLE");
+
+    bytes32 public constant override SERVER_REGISTRATION_TYPEHASH =
+        keccak256(
+            "ServerRegistration(address ownerAddress,address serverAddress,string publicKey,string serverUrl)"
+        );
+
+    bytes32 public constant override SERVER_DEREGISTRATION_TYPEHASH =
+        keccak256(
+            "ServerDeregistration(address ownerAddress,address serverAddress,bytes32 serverId,uint256 deadline)"
+        );
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() ERC2771ContextUpgradeable(address(0)) {
+        _disableInitializers();
+    }
+
+    function initialize(address trustedForwarderAddress, address ownerAddress) external initializer {
+        if (ownerAddress == address(0)) revert ZeroAddress();
+
+        __AccessControl_init();
+        __UUPSUpgradeable_init();
+        __Pausable_init();
+        __EIP712_init(SIGNING_DOMAIN, SIGNATURE_VERSION);
+
+        _trustedForwarder = trustedForwarderAddress;
+
+        _grantRole(DEFAULT_ADMIN_ROLE, ownerAddress);
+        _grantRole(MAINTAINER_ROLE, ownerAddress);
+    }
+
+    function _authorizeUpgrade(address newImplementation) internal virtual override onlyRole(DEFAULT_ADMIN_ROLE) {}
+
+    // ====================== ERC-2771 plumbing ======================
+
+    function _msgSender()
+        internal
+        view
+        override(ContextUpgradeable, ERC2771ContextUpgradeable)
+        returns (address)
+    {
+        return ERC2771ContextUpgradeable._msgSender();
+    }
+
+    function _msgData()
+        internal
+        view
+        override(ContextUpgradeable, ERC2771ContextUpgradeable)
+        returns (bytes calldata)
+    {
+        return ERC2771ContextUpgradeable._msgData();
+    }
+
+    function _contextSuffixLength()
+        internal
+        view
+        override(ContextUpgradeable, ERC2771ContextUpgradeable)
+        returns (uint256)
+    {
+        return ERC2771ContextUpgradeable._contextSuffixLength();
+    }
+
+    function trustedForwarder()
+        public
+        view
+        virtual
+        override(ERC2771ContextUpgradeable, IDataPortabilityServersV2)
+        returns (address)
+    {
+        return _trustedForwarder;
+    }
+
+    // ====================== Admin ======================
+
+    function pause() external override onlyRole(MAINTAINER_ROLE) {
+        _pause();
+    }
+
+    function unpause() external override onlyRole(MAINTAINER_ROLE) {
+        _unpause();
+    }
+
+    function updateTrustedForwarder(address trustedForwarderAddress)
+        external
+        override
+        onlyRole(MAINTAINER_ROLE)
+    {
+        _trustedForwarder = trustedForwarderAddress;
+    }
+
+    // ====================== Pure / view helpers ======================
+
+    function version() external pure virtual override returns (uint256) {
+        return 1;
+    }
+
+    function domainSeparator() public view override returns (bytes32) {
+        return _domainSeparatorV4();
+    }
+
+    function computeServerId(
+        address serverAddress,
+        string calldata publicKey,
+        string calldata serverUrl
+    ) external view override returns (bytes32) {
+        return _computeServerId(serverAddress, publicKey, serverUrl);
+    }
+
+    // ====================== Views ======================
+
+    function getServer(bytes32 serverId) external view override returns (ServerInfo memory) {
+        Server storage s = _servers[serverId];
+        if (s.registeredAtBlock == 0) revert ServerNotFound(serverId);
+        return _toServerInfo(serverId, s);
+    }
+
+    function getActiveServerByAddress(address serverAddress)
+        external
+        view
+        override
+        returns (ServerInfo memory)
+    {
+        bytes32 sId = activeServerId[serverAddress];
+        if (sId == bytes32(0)) revert ServerNotFound(bytes32(0));
+        Server storage s = _servers[sId];
+        return _toServerInfo(sId, s);
+    }
+
+    function ownerServers(address ownerAddress)
+        external
+        view
+        override
+        returns (ServerInfo[] memory)
+    {
+        bytes32[] storage ids = _ownerToServerIds[ownerAddress];
+        uint256 len = ids.length;
+        ServerInfo[] memory result = new ServerInfo[](len);
+        for (uint256 i = 0; i < len; ) {
+            bytes32 sId = ids[i];
+            result[i] = _toServerInfo(sId, _servers[sId]);
+            unchecked {
+                ++i;
+            }
+        }
+        return result;
+    }
+
+    // ====================== Writes ======================
+
+    function registerServerWithSignature(
+        ServerRegistration calldata input,
+        bytes calldata signature
+    ) external override whenNotPaused returns (bytes32 serverId) {
+        if (input.ownerAddress == address(0) || input.serverAddress == address(0)) revert ZeroAddress();
+        if (bytes(input.publicKey).length == 0) revert EmptyPublicKey();
+        if (bytes(input.serverUrl).length == 0) revert EmptyUrl();
+        if (activeServerId[input.serverAddress] != bytes32(0)) {
+            revert ServerAlreadyRegistered(input.serverAddress);
+        }
+
+        // Verify owner's signature.
+        bytes32 digest = _hashTypedDataV4(
+            keccak256(
+                abi.encode(
+                    SERVER_REGISTRATION_TYPEHASH,
+                    input.ownerAddress,
+                    input.serverAddress,
+                    keccak256(bytes(input.publicKey)),
+                    keccak256(bytes(input.serverUrl))
+                )
+            )
+        );
+        address signer = ECDSA.recover(digest, signature);
+        if (signer == address(0)) revert InvalidSignature();
+        if (signer != input.ownerAddress) revert OwnerMismatch(input.ownerAddress, signer);
+
+        serverId = _computeServerId(input.serverAddress, input.publicKey, input.serverUrl);
+
+        // The same `(serverAddress, publicKey, serverUrl)` could in principle
+        // collide with a previously revoked registration. That's allowed — it
+        // would just resurrect the same id. Reject explicitly so callers know.
+        // (In practice this means the owner is re-registering an identical
+        // server after revoke, which they probably don't want.)
+        if (_servers[serverId].registeredAtBlock != 0) {
+            revert ServerAlreadyRegistered(input.serverAddress);
+        }
+
+        Server storage s = _servers[serverId];
+        s.ownerAddress = input.ownerAddress;
+        s.serverAddress = input.serverAddress;
+        s.publicKey = input.publicKey;
+        s.serverUrl = input.serverUrl;
+        s.registeredAtBlock = block.number;
+        // s.revokedAtBlock = 0 by default
+
+        activeServerId[input.serverAddress] = serverId;
+        _ownerToServerIds[input.ownerAddress].push(serverId);
+        unchecked {
+            ++serversCount;
+        }
+
+        emit ServerRegistered(
+            serverId,
+            input.ownerAddress,
+            input.serverAddress,
+            input.publicKey,
+            input.serverUrl
+        );
+    }
+
+    function deregisterServerWithSignature(
+        ServerDeregistration calldata input,
+        bytes calldata signature
+    ) external override whenNotPaused {
+        if (block.timestamp > input.deadline) revert DeadlineExpired(input.deadline, block.timestamp);
+
+        // Verify owner's signature.
+        bytes32 digest = _hashTypedDataV4(
+            keccak256(
+                abi.encode(
+                    SERVER_DEREGISTRATION_TYPEHASH,
+                    input.ownerAddress,
+                    input.serverAddress,
+                    input.serverId,
+                    input.deadline
+                )
+            )
+        );
+        address signer = ECDSA.recover(digest, signature);
+        if (signer == address(0)) revert InvalidSignature();
+        if (signer != input.ownerAddress) revert OwnerMismatch(input.ownerAddress, signer);
+
+        // The signed `serverId` must match the currently active registration
+        // for this server address. This prevents a replayed deregistration sig
+        // from revoking a future re-registration that reuses the address.
+        bytes32 activeId = activeServerId[input.serverAddress];
+        if (activeId == bytes32(0)) revert ServerNotFound(input.serverId);
+        if (activeId != input.serverId) revert StaleServerId(activeId, input.serverId);
+
+        Server storage s = _servers[input.serverId];
+        if (s.revokedAtBlock != 0) revert AlreadyRevoked(input.serverId);
+        if (s.ownerAddress != input.ownerAddress) {
+            revert NotServerOwner(input.serverId, input.ownerAddress, s.ownerAddress);
+        }
+
+        s.revokedAtBlock = block.number;
+        // Free the address so it can be re-registered with a different
+        // (publicKey, serverUrl) producing a fresh serverId.
+        activeServerId[input.serverAddress] = bytes32(0);
+
+        emit ServerDeregistered(input.serverId, input.ownerAddress, input.serverAddress);
+    }
+
+    // ====================== Internals ======================
+
+    function _computeServerId(
+        address serverAddress,
+        string memory publicKey,
+        string memory serverUrl
+    ) internal view returns (bytes32) {
+        return keccak256(abi.encode(_domainSeparatorV4(), serverAddress, publicKey, serverUrl));
+    }
+
+    function _toServerInfo(bytes32 serverId, Server storage s) internal view returns (ServerInfo memory) {
+        return
+            ServerInfo({
+                id: serverId,
+                ownerAddress: s.ownerAddress,
+                serverAddress: s.serverAddress,
+                publicKey: s.publicKey,
+                serverUrl: s.serverUrl,
+                registeredAtBlock: s.registeredAtBlock,
+                revokedAtBlock: s.revokedAtBlock
+            });
+    }
+}

--- a/contracts/dataPortability/dataPortabilityServersV2/DataPortabilityServersV2Proxy.sol
+++ b/contracts/dataPortability/dataPortabilityServersV2/DataPortabilityServersV2Proxy.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+contract DataPortabilityServersV2Proxy is ERC1967Proxy {
+    constructor(address logic, bytes memory data) ERC1967Proxy(logic, data) {}
+}

--- a/contracts/dataPortability/dataPortabilityServersV2/interfaces/DataPortabilityServersV2StorageV1.sol
+++ b/contracts/dataPortability/dataPortabilityServersV2/interfaces/DataPortabilityServersV2StorageV1.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import "./IDataPortabilityServersV2.sol";
+
+/**
+ * @title Storage for DataPortabilityServersV2
+ * @notice For future upgrades, do not change DataPortabilityServersV2StorageV1.
+ * Create a new contract which implements DataPortabilityServersV2StorageV1.
+ */
+abstract contract DataPortabilityServersV2StorageV1 is IDataPortabilityServersV2 {
+    /// @dev Storage shape for a server record. Returned externally as `ServerInfo`.
+    struct Server {
+        address ownerAddress;
+        address serverAddress;
+        string publicKey;
+        string serverUrl;
+        uint256 registeredAtBlock;
+        uint256 revokedAtBlock; // 0 while active
+    }
+
+    /// @dev Trusted forwarder for ERC-2771 meta-transactions.
+    address internal _trustedForwarder;
+
+    /// @dev Monotonic count of every server ever registered.
+    uint256 public override serversCount;
+
+    /// @dev Server records keyed by deterministic id.
+    mapping(bytes32 serverId => Server) internal _servers;
+
+    /// @dev Active `serverId` per `serverAddress`. `bytes32(0)` if no active
+    ///      registration. Cleared on revoke so the address can be re-registered.
+    mapping(address serverAddress => bytes32) public override activeServerId;
+
+    /// @dev All server ids ever registered by an owner, in registration order
+    ///      (append-only, includes revoked entries).
+    mapping(address ownerAddress => bytes32[]) internal _ownerToServerIds;
+}

--- a/contracts/dataPortability/dataPortabilityServersV2/interfaces/IDataPortabilityServersV2.sol
+++ b/contracts/dataPortability/dataPortabilityServersV2/interfaces/IDataPortabilityServersV2.sol
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+/**
+ * @title IDataPortabilityServersV2
+ * @author Vana Network
+ * @notice Gateway-compatible server registry. Replaces the V1
+ *         DataPortabilityServers model (auto-incrementing IDs, per-user trust
+ *         windows, per-user nonces) with:
+ *
+ *           - **Deterministic bytes32 serverId** computed off-chain from
+ *             (domainSeparator, serverAddress, publicKey, serverUrl) so the
+ *             gateway can predict it at signing time.
+ *           - **Single-owner servers**: a server address is owned by exactly
+ *             one address per active registration. Registration and trust
+ *             are the same event.
+ *           - **One-shot revocation**: deregistering is terminal for that
+ *             registration record, but the same serverAddress can be
+ *             re-registered later with different (publicKey, serverUrl) to
+ *             produce a fresh serverId.
+ *           - **EIP-712-only writes**: no `*ByManager`, no separate
+ *             trust/untrust, no `updateServer`. Identity is content-addressed,
+ *             so updates would change the id.
+ *
+ *         EIP-712 signing domain is `"Vana Data Portability"`, version `"1"` —
+ *         shared with the other Vana data-portability contracts.
+ *
+ * @custom:security-contact security@vana.org
+ */
+interface IDataPortabilityServersV2 {
+    // ====================== Structs ======================
+
+    /// @notice EIP-712 payload for registering a new server.
+    ///         Signed by `ownerAddress` and verified inside
+    ///         `registerServerWithSignature`.
+    struct ServerRegistration {
+        address ownerAddress;
+        address serverAddress;
+        string publicKey;
+        string serverUrl;
+    }
+
+    /// @notice EIP-712 payload for revoking a previously registered server.
+    ///         Signed by `ownerAddress`. `serverId` binds the revocation to
+    ///         a specific registration instance so a replayed sig cannot
+    ///         revoke a future re-registration that reuses `serverAddress`.
+    struct ServerDeregistration {
+        address ownerAddress;
+        address serverAddress;
+        bytes32 serverId;
+        uint256 deadline;
+    }
+
+    /// @notice External view of a server record.
+    struct ServerInfo {
+        bytes32 id;
+        address ownerAddress;
+        address serverAddress;
+        string publicKey;
+        string serverUrl;
+        uint256 registeredAtBlock;
+        uint256 revokedAtBlock; // 0 while active
+    }
+
+    // ====================== Errors ======================
+
+    error ZeroAddress();
+    error EmptyPublicKey();
+    error EmptyUrl();
+    error ServerAlreadyRegistered(address serverAddress);
+    error InvalidSignature();
+    error OwnerMismatch(address claimed, address recovered);
+    error ServerNotFound(bytes32 serverId);
+    error NotServerOwner(bytes32 serverId, address claimed, address actual);
+    error StaleServerId(bytes32 expected, bytes32 provided);
+    error DeadlineExpired(uint256 deadline, uint256 currentTime);
+    error AlreadyRevoked(bytes32 serverId);
+
+    // ====================== Events ======================
+
+    /// @notice Emitted when a new server is registered and trusted by an owner.
+    /// @dev `publicKey` and `serverUrl` are unindexed so external indexers can
+    ///      reconstruct the full record from logs alone, even though both can
+    ///      exceed 32 bytes.
+    event ServerRegistered(
+        bytes32 indexed serverId,
+        address indexed ownerAddress,
+        address indexed serverAddress,
+        string publicKey,
+        string serverUrl
+    );
+
+    /// @notice Emitted when a server registration is revoked. Terminal per
+    ///         registration instance; the owner can register the same
+    ///         `serverAddress` again afterward to produce a new `serverId`.
+    event ServerDeregistered(
+        bytes32 indexed serverId,
+        address indexed ownerAddress,
+        address indexed serverAddress
+    );
+
+    // ====================== Pure / view helpers ======================
+
+    function version() external pure returns (uint256);
+
+    /// @notice EIP-712 domain separator. Exposed so off-chain code can predict
+    ///         `serverId` ahead of submission.
+    function domainSeparator() external view returns (bytes32);
+
+    /// @notice Typehash for `ServerRegistration`.
+    function SERVER_REGISTRATION_TYPEHASH() external view returns (bytes32);
+
+    /// @notice Typehash for `ServerDeregistration`.
+    function SERVER_DEREGISTRATION_TYPEHASH() external view returns (bytes32);
+
+    /// @notice Deterministic id for a server. Anyone can compute this off-chain
+    ///         with the same formula:
+    ///         `keccak256(abi.encode(domainSeparator, serverAddress, publicKey, serverUrl))`.
+    function computeServerId(
+        address serverAddress,
+        string calldata publicKey,
+        string calldata serverUrl
+    ) external view returns (bytes32);
+
+    // ====================== Views ======================
+
+    /// @notice Look up a server record by its deterministic id.
+    /// @dev Reverts with `ServerNotFound` if no record exists for `serverId`.
+    function getServer(bytes32 serverId) external view returns (ServerInfo memory);
+
+    /// @notice The currently-active `serverId` for a given `serverAddress`,
+    ///         or `bytes32(0)` if no active registration exists.
+    function activeServerId(address serverAddress) external view returns (bytes32);
+
+    /// @notice Look up the active registration for a server address.
+    /// @dev Reverts with `ServerNotFound` if no non-revoked registration exists.
+    function getActiveServerByAddress(address serverAddress)
+        external
+        view
+        returns (ServerInfo memory);
+
+    /// @notice Enumerate every server an owner has ever registered, in
+    ///         registration order (active + revoked).
+    function ownerServers(address ownerAddress) external view returns (ServerInfo[] memory);
+
+    /// @notice Total number of server records ever registered.
+    function serversCount() external view returns (uint256);
+
+    function trustedForwarder() external view returns (address);
+
+    // ====================== Admin ======================
+
+    function pause() external;
+
+    function unpause() external;
+
+    function updateTrustedForwarder(address trustedForwarderAddress) external;
+
+    // ====================== Writes ======================
+
+    /// @notice Register a server with an EIP-712 signature from the owner.
+    ///         The recovered signer must equal `input.ownerAddress`.
+    ///         Computes `serverId`, stores the record, emits
+    ///         `ServerRegistered`. Reverts if a server with the same
+    ///         `serverAddress` is already active.
+    function registerServerWithSignature(
+        ServerRegistration calldata input,
+        bytes calldata signature
+    ) external returns (bytes32 serverId);
+
+    /// @notice Deregister a server with an EIP-712 signature from the owner.
+    ///         The recovered signer must equal `input.ownerAddress` AND match
+    ///         the server's stored owner. `input.serverId` must equal the
+    ///         stored id (ties revocation to a specific registration instance).
+    ///         Reverts if `block.timestamp > input.deadline` or if the server
+    ///         is already revoked.
+    function deregisterServerWithSignature(
+        ServerDeregistration calldata input,
+        bytes calldata signature
+    ) external;
+}

--- a/contracts/dataPortability/mocks/ERC20FeeOnTransferMock.sol
+++ b/contracts/dataPortability/mocks/ERC20FeeOnTransferMock.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+/**
+ * @title ERC20FeeOnTransferMock
+ * @notice ERC20 that burns a configurable fee (in basis points) on every
+ *         transfer, so the recipient receives less than the sent amount.
+ *         Used to verify balance-diff accounting in the escrow deposits.
+ */
+contract ERC20FeeOnTransferMock is ERC20 {
+    uint256 public feeBps;
+
+    constructor(uint256 feeBps_) ERC20("Fee Token", "FEE") {
+        feeBps = feeBps_;
+    }
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+
+    function setFeeBps(uint256 feeBps_) external {
+        feeBps = feeBps_;
+    }
+
+    function _update(address from, address to, uint256 value) internal override {
+        // Fee applies only to real transfers, not mint/burn.
+        if (from != address(0) && to != address(0)) {
+            uint256 fee = (value * feeBps) / 10_000;
+            if (fee > 0) {
+                super._update(from, address(0), fee);
+                value -= fee;
+            }
+        }
+        super._update(from, to, value);
+    }
+}

--- a/contracts/dataPortability/mocks/ERC3009Mock.sol
+++ b/contracts/dataPortability/mocks/ERC3009Mock.sol
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/utils/cryptography/EIP712.sol";
+import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+
+/**
+ * @title ERC3009Mock
+ * @notice Minimal EIP-3009 token mirroring Circle FiatTokenV2 semantics for
+ *         `receiveWithAuthorization`: EIP-712 signature check, (from, nonce)
+ *         replay state, validity window, and the `msg.sender == to` payee guard.
+ */
+contract ERC3009Mock is ERC20, EIP712 {
+    bytes32 public constant RECEIVE_WITH_AUTHORIZATION_TYPEHASH =
+        keccak256(
+            "ReceiveWithAuthorization(address from,address to,uint256 value,uint256 validAfter,uint256 validBefore,bytes32 nonce)"
+        );
+
+    mapping(address => mapping(bytes32 => bool)) private _authorizationStates;
+
+    /// @notice Basis points burned from the recipient after an authorized
+    ///         transfer — simulates a token where less than `value` arrives,
+    ///         to exercise the escrow's balance-diff crediting.
+    uint256 public skimBps;
+
+    error AuthorizationNotYetValid();
+    error AuthorizationExpired();
+    error AuthorizationAlreadyUsed();
+    error CallerMustBePayee();
+    error InvalidAuthorizationSignature();
+
+    event AuthorizationUsed(address indexed authorizer, bytes32 indexed nonce);
+
+    constructor() ERC20("Mock USDC", "mUSDC") EIP712("Mock USDC", "1") {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+
+    function setSkimBps(uint256 skimBps_) external {
+        skimBps = skimBps_;
+    }
+
+    function authorizationState(address authorizer, bytes32 nonce) external view returns (bool) {
+        return _authorizationStates[authorizer][nonce];
+    }
+
+    function receiveWithAuthorization(
+        address from,
+        address to,
+        uint256 value,
+        uint256 validAfter,
+        uint256 validBefore,
+        bytes32 nonce,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external {
+        if (msg.sender != to) revert CallerMustBePayee();
+        if (block.timestamp <= validAfter) revert AuthorizationNotYetValid();
+        if (block.timestamp >= validBefore) revert AuthorizationExpired();
+        if (_authorizationStates[from][nonce]) revert AuthorizationAlreadyUsed();
+
+        bytes32 digest = _hashTypedDataV4(
+            keccak256(
+                abi.encode(RECEIVE_WITH_AUTHORIZATION_TYPEHASH, from, to, value, validAfter, validBefore, nonce)
+            )
+        );
+        if (ECDSA.recover(digest, v, r, s) != from) revert InvalidAuthorizationSignature();
+
+        _authorizationStates[from][nonce] = true;
+        emit AuthorizationUsed(from, nonce);
+
+        _transfer(from, to, value);
+
+        uint256 skim = (value * skimBps) / 10_000;
+        if (skim > 0) {
+            _burn(to, skim);
+        }
+    }
+}

--- a/contracts/dataPortability/mocks/NativeRejecterMock.sol
+++ b/contracts/dataPortability/mocks/NativeRejecterMock.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+/**
+ * @title NativeRejecterMock
+ * @notice Contract with no receive/fallback — any plain native transfer to it
+ *         fails. Used to exercise the escrow's NativeTransferFailed path.
+ */
+contract NativeRejecterMock {
+    // Intentionally empty: no receive(), no payable fallback.
+}

--- a/contracts/dataPortability/mocks/OpTargetMock.sol
+++ b/contracts/dataPortability/mocks/OpTargetMock.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+/**
+ * @title OpTargetMock
+ * @notice Simple allowlistable target for DataPortabilityEscrow.runOpAndSettle
+ *         tests: one succeeding call that returns data, one that reverts with
+ *         a typed error (to verify revert bubbling), and one payable probe.
+ */
+contract OpTargetMock {
+    error TypedFailure(uint256 code);
+
+    event Poked(address indexed caller, uint256 value, uint256 x);
+
+    uint256 public lastX;
+
+    function poke(uint256 x) external payable returns (uint256) {
+        lastX = x;
+        emit Poked(msg.sender, msg.value, x);
+        return x + 1;
+    }
+
+    function fail(uint256 code) external pure {
+        revert TypedFailure(code);
+    }
+}

--- a/contracts/protocol/feeRegistry/FeeRegistryImplementation.sol
+++ b/contracts/protocol/feeRegistry/FeeRegistryImplementation.sol
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
+import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+import "./interfaces/FeeRegistryStorageV1.sol";
+
+/**
+ * @title FeeRegistryImplementation
+ * @notice Single source of truth for protocol fees. UUPS upgradeable.
+ *
+ *         The registry does not collect or move funds — it just answers
+ *         "what fee should I charge for operation X?". Consumers
+ *         (escrow, permissions, etc.) read the current fee and charge it
+ *         themselves via their own settlement path.
+ */
+contract FeeRegistryImplementation is
+    UUPSUpgradeable,
+    PausableUpgradeable,
+    AccessControlUpgradeable,
+    FeeRegistryStorageV1
+{
+    using EnumerableSet for EnumerableSet.Bytes32Set;
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    function initialize(address ownerAddress) external initializer {
+        if (ownerAddress == address(0)) revert ZeroAddress();
+
+        __AccessControl_init();
+        __UUPSUpgradeable_init();
+        __Pausable_init();
+
+        _grantRole(DEFAULT_ADMIN_ROLE, ownerAddress);
+    }
+
+    function _authorizeUpgrade(address newImplementation) internal virtual override onlyRole(DEFAULT_ADMIN_ROLE) {}
+
+    function version() external pure virtual override returns (uint256) {
+        return 1;
+    }
+
+    // ====================== Admin ======================
+
+    function pause() external override onlyRole(DEFAULT_ADMIN_ROLE) {
+        _pause();
+    }
+
+    function unpause() external override onlyRole(DEFAULT_ADMIN_ROLE) {
+        _unpause();
+    }
+
+    function setFee(
+        bytes32 operation,
+        uint256 amount,
+        address asset,
+        address payee,
+        bool enabled
+    ) public override whenNotPaused onlyRole(DEFAULT_ADMIN_ROLE) {
+        if (enabled && payee == address(0)) revert InvalidPayee();
+
+        _fees[operation] = Fee({amount: amount, asset: asset, payee: payee, enabled: enabled});
+        _registeredOperations.add(operation);
+
+        emit FeeSet(operation, amount, asset, payee, enabled);
+    }
+
+    function setFeeByName(
+        string calldata name,
+        uint256 amount,
+        address asset,
+        address payee,
+        bool enabled
+    ) external override returns (bytes32 operation) {
+        operation = keccak256(bytes(name));
+        setFee(operation, amount, asset, payee, enabled);
+    }
+
+    function clearFee(bytes32 operation) external override whenNotPaused onlyRole(DEFAULT_ADMIN_ROLE) {
+        if (!_registeredOperations.contains(operation)) revert FeeNotSet(operation);
+
+        delete _fees[operation];
+        _registeredOperations.remove(operation);
+
+        emit FeeCleared(operation);
+    }
+
+    // ====================== Pure helpers ======================
+
+    function operationKey(string calldata name) external pure override returns (bytes32) {
+        return keccak256(bytes(name));
+    }
+
+    // ====================== Views ======================
+
+    function fees(bytes32 operation) external view override returns (Fee memory) {
+        return _fees[operation];
+    }
+
+    function isFeeRegistered(bytes32 operation) external view override returns (bool) {
+        return _registeredOperations.contains(operation);
+    }
+
+    function feeAmount(bytes32 operation) external view override returns (uint256) {
+        Fee storage f = _fees[operation];
+        return f.enabled ? f.amount : 0;
+    }
+}

--- a/contracts/protocol/feeRegistry/FeeRegistryProxy.sol
+++ b/contracts/protocol/feeRegistry/FeeRegistryProxy.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+contract FeeRegistryProxy is ERC1967Proxy {
+    constructor(address logic, bytes memory data) ERC1967Proxy(logic, data) {}
+}

--- a/contracts/protocol/feeRegistry/interfaces/FeeRegistryStorageV1.sol
+++ b/contracts/protocol/feeRegistry/interfaces/FeeRegistryStorageV1.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+import "./IFeeRegistry.sol";
+
+/**
+ * @title Storage for FeeRegistry
+ * @notice For future upgrades, do not change FeeRegistryStorageV1. Create a new
+ * contract which implements FeeRegistryStorageV1.
+ */
+abstract contract FeeRegistryStorageV1 is IFeeRegistry {
+    /// @dev Fee config keyed by `operation`. Unregistered operations return the zero-valued struct.
+    mapping(bytes32 operation => Fee) internal _fees;
+
+    /// @dev Set of all operations ever registered. An entry persists across
+    ///      enable/disable toggles; it's only removed by `clearFee`.
+    EnumerableSet.Bytes32Set internal _registeredOperations;
+}

--- a/contracts/protocol/feeRegistry/interfaces/IFeeRegistry.sol
+++ b/contracts/protocol/feeRegistry/interfaces/IFeeRegistry.sol
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+/**
+ * @title IFeeRegistry
+ * @author Vana Network
+ * @notice Single source of truth for protocol fees, keyed by an opaque
+ *         `bytes32 operation` identifier.
+ *
+ *         Other contracts read this registry to look up "what's the current
+ *         fee for operation X?". The registry does not collect or move funds
+ *         itself — it just answers questions. Charging happens in the
+ *         contract performing the operation (escrow, permissions, etc.).
+ *
+ *         Operation keys are caller-defined. Convention: use
+ *         `keccak256(bytes(name))` where `name` is a stable upper-snake string
+ *         like `"GRANT_REGISTRATION"` or `"DATA_ACCESS_RECORD"`. The pure
+ *         helper `operationKey(string)` does this for off-chain consumers
+ *         that want a canonical derivation.
+ *
+ *         A fee with `enabled == false` is treated as "no charge", regardless
+ *         of `amount`. A fee with `enabled == true` and `amount == 0` is a
+ *         free operation that the registry still tracks (useful for
+ *         distinguishing "free" from "not configured").
+ *
+ * @custom:security-contact security@vana.org
+ */
+interface IFeeRegistry {
+    /// @notice Fee configuration for a single operation.
+    /// @param amount  Fee amount in the smallest unit of `asset`.
+    /// @param asset   ERC-20 token address; `address(0)` for native VANA.
+    /// @param payee   Address that receives the fee.
+    /// @param enabled If false, callers should treat the fee as absent regardless of `amount`.
+    struct Fee {
+        uint256 amount;
+        address asset;
+        address payee;
+        bool enabled;
+    }
+
+    // ====================== Errors ======================
+
+    error ZeroAddress();
+    error InvalidPayee(); // setting an enabled fee without a payee
+    error FeeNotSet(bytes32 operation);
+
+    // ====================== Events ======================
+
+    event FeeSet(
+        bytes32 indexed operation,
+        uint256 amount,
+        address indexed asset,
+        address indexed payee,
+        bool enabled
+    );
+
+    event FeeCleared(bytes32 indexed operation);
+
+    // ====================== Pure helpers ======================
+
+    function version() external pure returns (uint256);
+
+    /// @notice Canonical derivation of an operation key from a human-readable name.
+    ///         keccak256(bytes(name)).
+    function operationKey(string calldata name) external pure returns (bytes32);
+
+    // ====================== Views ======================
+
+    /// @notice Full fee configuration for an operation. Returns the zero-valued
+    ///         struct (`enabled: false`) if no fee has been set.
+    function fees(bytes32 operation) external view returns (Fee memory);
+
+    /// @notice True if a fee has ever been set (registered) for this operation,
+    ///         even if currently disabled. Useful for distinguishing "configured
+    ///         but disabled" from "never configured".
+    function isFeeRegistered(bytes32 operation) external view returns (bool);
+
+    /// @notice Convenience: the effective amount that a caller should charge.
+    ///         Returns 0 if the fee is unregistered or disabled.
+    function feeAmount(bytes32 operation) external view returns (uint256);
+
+    // ====================== Admin ======================
+
+    function pause() external;
+
+    function unpause() external;
+
+    /// @notice Create or update a fee for `operation`. If `enabled` is true,
+    ///         `payee` must be non-zero.
+    function setFee(
+        bytes32 operation,
+        uint256 amount,
+        address asset,
+        address payee,
+        bool enabled
+    ) external;
+
+    /// @notice Convenience that hashes `name` and forwards to `setFee`.
+    function setFeeByName(
+        string calldata name,
+        uint256 amount,
+        address asset,
+        address payee,
+        bool enabled
+    ) external returns (bytes32 operation);
+
+    /// @notice Remove all configuration for `operation`. After this call
+    ///         `isFeeRegistered(operation)` returns false and `fees(operation)`
+    ///         returns the zero struct.
+    function clearFee(bytes32 operation) external;
+}

--- a/deploy/dataPortability/dataPortabilityEscrow-setAllowedOps.ts
+++ b/deploy/dataPortability/dataPortabilityEscrow-setAllowedOps.ts
@@ -1,0 +1,105 @@
+import { deployments, ethers } from "hardhat";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { DeployFunction } from "hardhat-deploy/types";
+
+/**
+ * Seeds the DataPortabilityEscrow.allowlist with the two canonical bundles:
+ *   - PermissionsV2.addPermissionWithSignature   (replaces direct registerAndSettle)
+ *   - DataRegistryV2.recordDataAccess            (replaces direct recordAccessAndSettle)
+ *
+ * Run only after the runOpAndSettle upgrade is live.
+ * `setOpAllowed` is idempotent — re-running is a no-op.
+ */
+const ESCROW_PROXY = "0x07d7769081adc3a3DBe91f5E4B98E9A5a6B292e3";
+
+const ALLOWED_OPS_BY_CHAIN: Record<number, { name: string; target: string; signature: string }[]> = {
+  // Moksha
+  14800: [
+    {
+      name: "PermissionsV2.addPermissionWithSignature",
+      target: "0x4d3FA76064D88e0454cFc4CaD7e5FeC3e3124011",
+      signature: "addPermissionWithSignature((address,bytes32,string[],uint256,uint256),bytes)",
+    },
+    {
+      name: "DataRegistryV2.recordDataAccess",
+      target: "0x8f1eFCdff3d0d5BB535e32620721c7EBed151867",
+      signature: "recordDataAccess(address,string,uint256,address,bytes32,bytes)",
+    },
+  ],
+  // Vana mainnet — same canonical addresses
+  1480: [
+    {
+      name: "PermissionsV2.addPermissionWithSignature",
+      target: "0x4d3FA76064D88e0454cFc4CaD7e5FeC3e3124011",
+      signature: "addPermissionWithSignature((address,bytes32,string[],uint256,uint256),bytes)",
+    },
+    {
+      name: "DataRegistryV2.recordDataAccess",
+      target: "0x8f1eFCdff3d0d5BB535e32620721c7EBed151867",
+      signature: "recordDataAccess(address,string,uint256,address,bytes32,bytes)",
+    },
+  ],
+};
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const [deployer] = await ethers.getSigners();
+  const chainId = Number(hre.network.config.chainId ?? (await ethers.provider.getNetwork()).chainId);
+
+  console.log("Deployer:     ", deployer.address);
+  console.log("Chain:        ", hre.network.name, `(chainId=${chainId})`);
+  console.log("Escrow proxy: ", ESCROW_PROXY);
+
+  const ops = ALLOWED_OPS_BY_CHAIN[chainId];
+  if (!ops) throw new Error(`No allowlist seed defined for chainId ${chainId}`);
+
+  const escrow = await ethers.getContractAt("DataPortabilityEscrowImplementation", ESCROW_PROXY);
+
+  const DEFAULT_ADMIN_ROLE = "0x" + "00".repeat(32);
+  const canAdmin = await escrow.hasRole(DEFAULT_ADMIN_ROLE, deployer.address);
+  if (!canAdmin) {
+    console.log("\nDeployer is NOT admin — generating calldata for the admin wallet instead.\n");
+  }
+
+  const iface = new ethers.Interface([
+    "function setOpAllowed(address target, bytes4 selector, bool allowed)",
+  ]);
+
+  for (const op of ops) {
+    const selector = ethers.dataSlice(ethers.id(op.signature), 0, 4); // ethers.id == keccak256(toUtf8Bytes(...))
+    console.log("\n---", op.name, "---");
+    console.log("  target:  ", op.target);
+    console.log("  sig:     ", op.signature);
+    console.log("  selector:", selector);
+
+    const alreadyAllowed: boolean = await escrow.isAllowedOp(op.target, selector);
+    if (alreadyAllowed) {
+      console.log("  status:   already allowed (no-op)");
+      continue;
+    }
+
+    if (canAdmin) {
+      const tx = await escrow.connect(deployer).setOpAllowed(op.target, selector, true);
+      console.log("  tx:      ", tx.hash);
+      await tx.wait();
+      const nowAllowed: boolean = await escrow.isAllowedOp(op.target, selector);
+      if (!nowAllowed) throw new Error("setOpAllowed did not take effect");
+      console.log("  status:   ALLOWED");
+    } else {
+      const data = iface.encodeFunctionData("setOpAllowed", [op.target, selector, true]);
+      console.log("  CALLDATA (admin to sign):");
+      console.log("    to:    " + ESCROW_PROXY);
+      console.log("    data:  " + data);
+      console.log("    value: 0");
+    }
+  }
+
+  console.log("\n=== Final allowlist on chain ===");
+  const targets: string[] = await escrow.getAllowedTargets();
+  for (const t of targets) {
+    const sels: string[] = await escrow.getAllowedSelectors(t);
+    console.log(`  ${t}: ${sels.join(", ")}`);
+  }
+};
+
+export default func;
+func.tags = ["DataPortabilityEscrowSetAllowedOps"];

--- a/deploy/dataPortability/dataPortabilityEscrow-upgrade-depositWithAuthorization.ts
+++ b/deploy/dataPortability/dataPortabilityEscrow-upgrade-depositWithAuthorization.ts
@@ -1,0 +1,92 @@
+import { deployments, ethers } from "hardhat";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { DeployFunction } from "hardhat-deploy/types";
+import { verifyContract } from "../helpers";
+
+/**
+ * Upgrades DataPortabilityEscrow to add `depositTokenWithAuthorization`:
+ * gasless-for-the-user ERC-20 deposits via EIP-3009
+ * `receiveWithAuthorization` (USDC-style). The credited account is always the
+ * authorization signer — a relayer cannot misdirect the deposit.
+ *
+ * No storage change. Safe UUPS upgrade.
+ *
+ * Per chain:
+ *   - Moksha:  deployer has DEFAULT_ADMIN_ROLE -> performs upgradeToAndCall
+ *   - Mainnet: deployer has no admin -> deploys impl only, prints calldata
+ *              for the canonical admin (0x5ECA…3BaF4)
+ */
+const ESCROW_PROXY = "0x07d7769081adc3a3DBe91f5E4B98E9A5a6B292e3";
+const MAINNET_ADMIN = "0x5ECA5208F29e32879a711467916965B2D753bAf4";
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const [deployer] = await ethers.getSigners();
+  const chainId = Number(hre.network.config.chainId ?? (await ethers.provider.getNetwork()).chainId);
+
+  console.log("Deployer:     ", deployer.address);
+  console.log("Chain:        ", hre.network.name, `(chainId=${chainId})`);
+  console.log("Escrow proxy: ", ESCROW_PROXY);
+
+  console.log("\n=== Deploying new DataPortabilityEscrowImplementation ===");
+  const implDeploy = await deployments.deploy("DataPortabilityEscrowImplementation", {
+    from: deployer.address,
+    args: [],
+    log: true,
+  });
+  console.log("New impl:     ", implDeploy.address);
+
+  const IMPL_SLOT = "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc";
+  const beforeRaw = await ethers.provider.getStorage(ESCROW_PROXY, IMPL_SLOT);
+  const beforeImpl = ethers.getAddress("0x" + beforeRaw.slice(-40));
+  console.log("Current impl: ", beforeImpl);
+  if (beforeImpl.toLowerCase() === implDeploy.address.toLowerCase()) {
+    console.log("Already at this implementation — nothing to do.");
+    return;
+  }
+
+  const DEFAULT_ADMIN_ROLE = "0x" + "00".repeat(32);
+  const proxyAsImpl = await ethers.getContractAt(
+    "DataPortabilityEscrowImplementation",
+    ESCROW_PROXY,
+  );
+  const canUpgrade: boolean = await proxyAsImpl.hasRole(DEFAULT_ADMIN_ROLE, deployer.address);
+
+  if (canUpgrade) {
+    console.log("\n=== Deployer has admin — performing upgradeToAndCall ===");
+    const tx = await proxyAsImpl.connect(deployer).upgradeToAndCall(implDeploy.address, "0x");
+    console.log("upgrade tx:   ", tx.hash);
+    await tx.wait();
+
+    const afterRaw = await ethers.provider.getStorage(ESCROW_PROXY, IMPL_SLOT);
+    const afterImpl = ethers.getAddress("0x" + afterRaw.slice(-40));
+    if (afterImpl.toLowerCase() !== implDeploy.address.toLowerCase()) {
+      throw new Error(`Upgrade did not take effect: ${afterImpl}`);
+    }
+    console.log("Confirmed: proxy now at", afterImpl);
+
+    // Sanity: allowlist state must have survived the upgrade untouched.
+    const targets: string[] = await proxyAsImpl.getAllowedTargets();
+    console.log("getAllowedTargets() (must be preserved):", targets);
+  } else {
+    const admin = await proxyAsImpl.hasRole(DEFAULT_ADMIN_ROLE, MAINNET_ADMIN);
+    console.log("\n=== Deployer does NOT have admin on this chain ===");
+    if (admin) console.log(`Confirmed: ${MAINNET_ADMIN} has DEFAULT_ADMIN_ROLE.`);
+    console.log("Calldata for admin wallet:");
+    const iface = new ethers.Interface(["function upgradeToAndCall(address,bytes)"]);
+    const data = iface.encodeFunctionData("upgradeToAndCall", [implDeploy.address, "0x"]);
+    console.log("  to:    " + ESCROW_PROXY);
+    console.log("  data:  " + data);
+    console.log("  value: 0");
+  }
+
+  console.log("\n=== Verifying new impl on Blockscout ===");
+  await verifyContract(implDeploy.address, []);
+
+  console.log("\n=== Summary ===");
+  console.log("Proxy:        ", ESCROW_PROXY);
+  console.log("Previous impl:", beforeImpl);
+  console.log("New impl:     ", implDeploy.address);
+};
+
+export default func;
+func.tags = ["DataPortabilityEscrowUpgradeDepositWithAuthorization"];

--- a/deploy/dataPortability/dataPortabilityEscrow-upgrade-opkinds.ts
+++ b/deploy/dataPortability/dataPortabilityEscrow-upgrade-opkinds.ts
@@ -1,0 +1,96 @@
+import { deployments, ethers } from "hardhat";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { DeployFunction } from "hardhat-deploy/types";
+import { verifyContract } from "../helpers";
+
+/**
+ * Upgrades DataPortabilityEscrow to expand the OpKind enum:
+ *   Unspecified, DataRegistration, ServerRegistration,
+ *   BuilderRegistration, GrantRegistration (was: Registration), DataAccess.
+ *
+ * No storage layout change (enum is type-only). Safe UUPS upgrade.
+ *
+ * Behavior on each chain:
+ *   - Moksha:  deployer holds DEFAULT_ADMIN_ROLE -> performs full upgrade
+ *   - Mainnet: admin renounced from deployer -> only deploys new impl;
+ *              the canonical admin (0x5ECA…3BaF4) must call upgradeToAndCall
+ *              separately.
+ */
+const ESCROW_PROXY = "0x07d7769081adc3a3DBe91f5E4B98E9A5a6B292e3";
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const [deployer] = await ethers.getSigners();
+  const chainId = Number(hre.network.config.chainId ?? (await ethers.provider.getNetwork()).chainId);
+
+  console.log("Deployer:     ", deployer.address);
+  console.log("Chain:        ", hre.network.name, `(chainId=${chainId})`);
+  console.log("Escrow proxy: ", ESCROW_PROXY);
+
+  // 1. Deploy new impl
+  console.log("\n=== Deploying new DataPortabilityEscrowImplementation ===");
+  const implDeploy = await deployments.deploy("DataPortabilityEscrowImplementation", {
+    from: deployer.address,
+    args: [],
+    log: true,
+  });
+  console.log("New impl:     ", implDeploy.address);
+
+  // 2. Snapshot current impl
+  const IMPL_SLOT = "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc";
+  const beforeRaw = await ethers.provider.getStorage(ESCROW_PROXY, IMPL_SLOT);
+  const beforeImpl = ethers.getAddress("0x" + beforeRaw.slice(-40));
+  console.log("Current impl: ", beforeImpl);
+  if (beforeImpl.toLowerCase() === implDeploy.address.toLowerCase()) {
+    console.log("Already at this implementation — nothing to do.");
+    return;
+  }
+
+  // 3. Authorization check
+  const DEFAULT_ADMIN_ROLE = "0x" + "00".repeat(32);
+  const proxyAsImpl = await ethers.getContractAt(
+    "DataPortabilityEscrowImplementation",
+    ESCROW_PROXY,
+  );
+  const canUpgrade: boolean = await proxyAsImpl.hasRole(DEFAULT_ADMIN_ROLE, deployer.address);
+
+  if (canUpgrade) {
+    console.log("\n=== Deployer has admin — performing upgradeToAndCall ===");
+    const tx = await proxyAsImpl.connect(deployer).upgradeToAndCall(implDeploy.address, "0x");
+    console.log("upgrade tx:   ", tx.hash);
+    await tx.wait();
+
+    const afterRaw = await ethers.provider.getStorage(ESCROW_PROXY, IMPL_SLOT);
+    const afterImpl = ethers.getAddress("0x" + afterRaw.slice(-40));
+    if (afterImpl.toLowerCase() !== implDeploy.address.toLowerCase()) {
+      throw new Error(`Upgrade did not take effect: ${afterImpl}`);
+    }
+    console.log("Confirmed: proxy now at", afterImpl);
+  } else {
+    const admin = await proxyAsImpl.hasRole(DEFAULT_ADMIN_ROLE, "0x5ECA5208F29e32879a711467916965B2D753bAf4");
+    console.log("\n=== Deployer does NOT have admin on this chain ===");
+    console.log("Mainnet admin holds DEFAULT_ADMIN_ROLE — must sign the upgrade.");
+    if (admin) console.log("Confirmed: 0x5ECA5208F29e32879a711467916965B2D753bAf4 has DEFAULT_ADMIN_ROLE.");
+    console.log("");
+    console.log("Action required from the admin wallet:");
+    console.log(`  await escrow.upgradeToAndCall("${implDeploy.address}", "0x");`);
+    console.log("");
+    console.log("Calldata for a multisig / manual tx:");
+    const iface = new ethers.Interface(["function upgradeToAndCall(address,bytes)"]);
+    const data = iface.encodeFunctionData("upgradeToAndCall", [implDeploy.address, "0x"]);
+    console.log("  to:    " + ESCROW_PROXY);
+    console.log("  data:  " + data);
+    console.log("  value: 0");
+  }
+
+  // 4. Best-effort verification
+  console.log("\n=== Verifying new impl on Blockscout ===");
+  await verifyContract(implDeploy.address, []);
+
+  console.log("\n=== Summary ===");
+  console.log("Proxy:        ", ESCROW_PROXY);
+  console.log("Previous impl:", beforeImpl);
+  console.log("New impl:     ", implDeploy.address);
+};
+
+export default func;
+func.tags = ["DataPortabilityEscrowUpgradeOpKinds"];

--- a/deploy/dataPortability/dataPortabilityEscrow-upgrade-recordAccessAndSettle.ts
+++ b/deploy/dataPortability/dataPortabilityEscrow-upgrade-recordAccessAndSettle.ts
@@ -1,0 +1,104 @@
+import { deployments, ethers } from "hardhat";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { DeployFunction } from "hardhat-deploy/types";
+import { verifyContract } from "../helpers";
+
+/**
+ * Upgrades DataPortabilityEscrow to add `recordAccessAndSettle` and the
+ * `dataRegistry` storage pointer / setter / event / error.
+ *
+ * Storage layout extends StorageV1 by appending a single new variable
+ * (`IDataRegistryV2 dataRegistry`) — safe UUPS upgrade.
+ *
+ * After upgrade, wires the pointer at DataRegistryV2 proxy.
+ */
+const ESCROW_PROXY_DEFAULT = "0xcF50fAb402e2025a92e1bF811049820b6428910A";
+const DATA_REGISTRY_PROXY_DEFAULT = "0x0850226E939A5C949633200cf0b1F4665CA74931";
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const [deployer] = await ethers.getSigners();
+  const proxyAddress = process.env.DATA_PORTABILITY_ESCROW_PROXY ?? ESCROW_PROXY_DEFAULT;
+  const dataRegistryAddress =
+    process.env.DATA_REGISTRY_V2_PROXY ?? DATA_REGISTRY_PROXY_DEFAULT;
+
+  console.log("Deployer:               ", deployer.address);
+  console.log("Escrow proxy:           ", proxyAddress);
+  console.log("DataRegistryV2 to wire: ", dataRegistryAddress);
+
+  // 1. Deploy new implementation
+  console.log("\n=== Deploying new DataPortabilityEscrowImplementation ===");
+  const implDeploy = await deployments.deploy("DataPortabilityEscrowImplementation", {
+    from: deployer.address,
+    args: [],
+    log: true,
+  });
+  console.log("New implementation:     ", implDeploy.address);
+
+  // 2. Snapshot previous impl
+  const IMPL_SLOT = "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc";
+  const beforeImplRaw = await ethers.provider.getStorage(proxyAddress, IMPL_SLOT);
+  const beforeImpl = ethers.getAddress("0x" + beforeImplRaw.slice(-40));
+  console.log("Previous impl:          ", beforeImpl);
+
+  // 3. Upgrade
+  if (beforeImpl.toLowerCase() === implDeploy.address.toLowerCase()) {
+    console.log("Already at this implementation.");
+  } else {
+    console.log("\n=== Calling upgradeToAndCall on proxy ===");
+    const proxyAsUUPS = await ethers.getContractAt(
+      "DataPortabilityEscrowImplementation",
+      proxyAddress,
+    );
+    const tx = await proxyAsUUPS.connect(deployer).upgradeToAndCall(implDeploy.address, "0x");
+    console.log("upgrade tx:            ", tx.hash);
+    await tx.wait();
+
+    const afterImplRaw = await ethers.provider.getStorage(proxyAddress, IMPL_SLOT);
+    const afterImpl = ethers.getAddress("0x" + afterImplRaw.slice(-40));
+    if (afterImpl.toLowerCase() !== implDeploy.address.toLowerCase()) {
+      throw new Error(`Upgrade did not take effect: ${afterImpl}`);
+    }
+    console.log("New impl in proxy:      ", afterImpl);
+  }
+
+  // 4. Wire dataRegistry pointer
+  console.log("\n=== Wiring escrow.setDataRegistry ===");
+  const escrow = await ethers.getContractAt(
+    "DataPortabilityEscrowImplementation",
+    proxyAddress,
+  );
+  const currentDR: string = await escrow.dataRegistry();
+  if (currentDR.toLowerCase() === dataRegistryAddress.toLowerCase()) {
+    console.log("Already wired.");
+  } else {
+    const tx = await escrow.connect(deployer).setDataRegistry(dataRegistryAddress);
+    await tx.wait();
+    console.log("setDataRegistry tx:     ", tx.hash);
+  }
+
+  const verifyDR: string = await escrow.dataRegistry();
+  if (verifyDR.toLowerCase() !== dataRegistryAddress.toLowerCase()) {
+    throw new Error(`setDataRegistry failed: ${verifyDR}`);
+  }
+  console.log("dataRegistry pointer:   ", verifyDR);
+
+  // 5. Sanity-check the existing permissions pointer is intact
+  const permissionsPtr: string = await escrow.permissions();
+  console.log("permissions pointer:    ", permissionsPtr, "(unchanged)");
+
+  // 6. Verify on Blockscout
+  console.log("\n=== Verifying new impl on Blockscout ===");
+  await verifyContract(implDeploy.address, []);
+
+  console.log("\n=== Upgrade summary ===");
+  console.log("Proxy:                       ", proxyAddress);
+  console.log("Previous impl:               ", beforeImpl);
+  console.log("New impl:                    ", implDeploy.address);
+  console.log("dataRegistry:                ", verifyDR);
+  console.log("Note: ACCESS_RECORDER_ROLE on DataRegistryV2 was already granted");
+  console.log("      to the escrow proxy in an earlier setup tx, so the bundle");
+  console.log("      flow is fully wired and callable.");
+};
+
+export default func;
+func.tags = ["DataPortabilityEscrowUpgradeRecordAccessAndSettle"];

--- a/deploy/dataPortability/dataPortabilityEscrow-upgrade-runOpAndSettle.ts
+++ b/deploy/dataPortability/dataPortabilityEscrow-upgrade-runOpAndSettle.ts
@@ -1,0 +1,102 @@
+import { deployments, ethers } from "hardhat";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { DeployFunction } from "hardhat-deploy/types";
+import { verifyContract } from "../helpers";
+
+/**
+ * Upgrades DataPortabilityEscrow to add the generalized `runOpAndSettle` flow:
+ *
+ *   - new admin: setOpAllowed(target, selector, allowed)
+ *   - new views: isAllowedOp / getAllowedTargets / getAllowedSelectors
+ *   - new facilitator op: runOpAndSettle(target, callData, ops)
+ *
+ * Storage extension: two enumerable-set fields appended to V1 (UUPS-safe).
+ *
+ * Behavior per chain:
+ *   - Moksha:  deployer holds DEFAULT_ADMIN_ROLE -> performs upgradeToAndCall.
+ *   - Mainnet: admin renounced from deployer -> deploys impl only and prints
+ *              calldata for the canonical admin (0x5ECA…3BaF4) to sign.
+ */
+const ESCROW_PROXY = "0x07d7769081adc3a3DBe91f5E4B98E9A5a6B292e3";
+const MAINNET_ADMIN = "0x5ECA5208F29e32879a711467916965B2D753bAf4";
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const [deployer] = await ethers.getSigners();
+  const chainId = Number(hre.network.config.chainId ?? (await ethers.provider.getNetwork()).chainId);
+
+  console.log("Deployer:     ", deployer.address);
+  console.log("Chain:        ", hre.network.name, `(chainId=${chainId})`);
+  console.log("Escrow proxy: ", ESCROW_PROXY);
+
+  // 1. Deploy new impl
+  console.log("\n=== Deploying new DataPortabilityEscrowImplementation ===");
+  const implDeploy = await deployments.deploy("DataPortabilityEscrowImplementation", {
+    from: deployer.address,
+    args: [],
+    log: true,
+  });
+  console.log("New impl:     ", implDeploy.address);
+
+  // 2. Snapshot current impl
+  const IMPL_SLOT = "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc";
+  const beforeRaw = await ethers.provider.getStorage(ESCROW_PROXY, IMPL_SLOT);
+  const beforeImpl = ethers.getAddress("0x" + beforeRaw.slice(-40));
+  console.log("Current impl: ", beforeImpl);
+  if (beforeImpl.toLowerCase() === implDeploy.address.toLowerCase()) {
+    console.log("Already at this implementation — nothing to do.");
+    return;
+  }
+
+  // 3. Authorization check
+  const DEFAULT_ADMIN_ROLE = "0x" + "00".repeat(32);
+  const proxyAsImpl = await ethers.getContractAt(
+    "DataPortabilityEscrowImplementation",
+    ESCROW_PROXY,
+  );
+  const canUpgrade: boolean = await proxyAsImpl.hasRole(DEFAULT_ADMIN_ROLE, deployer.address);
+
+  if (canUpgrade) {
+    console.log("\n=== Deployer has admin — performing upgradeToAndCall ===");
+    const tx = await proxyAsImpl.connect(deployer).upgradeToAndCall(implDeploy.address, "0x");
+    console.log("upgrade tx:   ", tx.hash);
+    await tx.wait();
+
+    const afterRaw = await ethers.provider.getStorage(ESCROW_PROXY, IMPL_SLOT);
+    const afterImpl = ethers.getAddress("0x" + afterRaw.slice(-40));
+    if (afterImpl.toLowerCase() !== implDeploy.address.toLowerCase()) {
+      throw new Error(`Upgrade did not take effect: ${afterImpl}`);
+    }
+    console.log("Confirmed: proxy now at", afterImpl);
+
+    // Sanity-check the new surface — call the new views.
+    const targets: string[] = await proxyAsImpl.getAllowedTargets();
+    console.log("getAllowedTargets():", targets);
+  } else {
+    const admin = await proxyAsImpl.hasRole(DEFAULT_ADMIN_ROLE, MAINNET_ADMIN);
+    console.log("\n=== Deployer does NOT have admin on this chain ===");
+    console.log("Mainnet admin holds DEFAULT_ADMIN_ROLE — must sign the upgrade.");
+    if (admin) console.log(`Confirmed: ${MAINNET_ADMIN} has DEFAULT_ADMIN_ROLE.`);
+    console.log("");
+    console.log("Action required from the admin wallet:");
+    console.log(`  await escrow.upgradeToAndCall("${implDeploy.address}", "0x");`);
+    console.log("");
+    console.log("Calldata for a multisig / manual tx:");
+    const iface = new ethers.Interface(["function upgradeToAndCall(address,bytes)"]);
+    const data = iface.encodeFunctionData("upgradeToAndCall", [implDeploy.address, "0x"]);
+    console.log("  to:    " + ESCROW_PROXY);
+    console.log("  data:  " + data);
+    console.log("  value: 0");
+  }
+
+  // 4. Best-effort verification on Blockscout
+  console.log("\n=== Verifying new impl on Blockscout ===");
+  await verifyContract(implDeploy.address, []);
+
+  console.log("\n=== Summary ===");
+  console.log("Proxy:        ", ESCROW_PROXY);
+  console.log("Previous impl:", beforeImpl);
+  console.log("New impl:     ", implDeploy.address);
+};
+
+export default func;
+func.tags = ["DataPortabilityEscrowUpgradeRunOpAndSettle"];

--- a/deploy/dataPortability/dataPortabilityEscrow-upgrade-settleRef.ts
+++ b/deploy/dataPortability/dataPortabilityEscrow-upgrade-settleRef.ts
@@ -1,0 +1,97 @@
+import { deployments, ethers } from "hardhat";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { DeployFunction } from "hardhat-deploy/types";
+import { verifyContract } from "../helpers";
+
+/**
+ * Upgrades DataPortabilityEscrow to add a `bytes32 ref` correlation id to
+ * SettleOp and the Settled event (now `Settled(from, to, ref, asset, amount,
+ * opKind)` with `ref` indexed in place of `asset`).
+ *
+ * Ref convention by OpKind (caller-asserted, indexer hint):
+ *   DataRegistration    — dataPointId
+ *   ServerRegistration  — serverId
+ *   BuilderRegistration — granteeId
+ *   GrantRegistration   — grantId
+ *   DataAccess          — grantId under which the access was authorized
+ *
+ * BREAKING ABI: settle/settleBatch/registerAndSettle/recordAccessAndSettle/
+ * runOpAndSettle selectors all change (SettleOp struct changed). The gateway
+ * must update its ABI in lockstep. The escrow's runOpAndSettle ALLOWLIST is
+ * unaffected (it stores TARGET contracts' selectors, which are unchanged).
+ *
+ * No storage change. Safe UUPS upgrade.
+ */
+const ESCROW_PROXY = "0x07d7769081adc3a3DBe91f5E4B98E9A5a6B292e3";
+const MAINNET_ADMIN = "0x5ECA5208F29e32879a711467916965B2D753bAf4";
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const [deployer] = await ethers.getSigners();
+  const chainId = Number(hre.network.config.chainId ?? (await ethers.provider.getNetwork()).chainId);
+
+  console.log("Deployer:     ", deployer.address);
+  console.log("Chain:        ", hre.network.name, `(chainId=${chainId})`);
+  console.log("Escrow proxy: ", ESCROW_PROXY);
+
+  console.log("\n=== Deploying new DataPortabilityEscrowImplementation ===");
+  const implDeploy = await deployments.deploy("DataPortabilityEscrowImplementation", {
+    from: deployer.address,
+    args: [],
+    log: true,
+  });
+  console.log("New impl:     ", implDeploy.address);
+
+  const IMPL_SLOT = "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc";
+  const beforeRaw = await ethers.provider.getStorage(ESCROW_PROXY, IMPL_SLOT);
+  const beforeImpl = ethers.getAddress("0x" + beforeRaw.slice(-40));
+  console.log("Current impl: ", beforeImpl);
+  if (beforeImpl.toLowerCase() === implDeploy.address.toLowerCase()) {
+    console.log("Already at this implementation — nothing to do.");
+    return;
+  }
+
+  const DEFAULT_ADMIN_ROLE = "0x" + "00".repeat(32);
+  const proxyAsImpl = await ethers.getContractAt(
+    "DataPortabilityEscrowImplementation",
+    ESCROW_PROXY,
+  );
+  const canUpgrade: boolean = await proxyAsImpl.hasRole(DEFAULT_ADMIN_ROLE, deployer.address);
+
+  if (canUpgrade) {
+    console.log("\n=== Deployer has admin — performing upgradeToAndCall ===");
+    const tx = await proxyAsImpl.connect(deployer).upgradeToAndCall(implDeploy.address, "0x");
+    console.log("upgrade tx:   ", tx.hash);
+    await tx.wait();
+
+    const afterRaw = await ethers.provider.getStorage(ESCROW_PROXY, IMPL_SLOT);
+    const afterImpl = ethers.getAddress("0x" + afterRaw.slice(-40));
+    if (afterImpl.toLowerCase() !== implDeploy.address.toLowerCase()) {
+      throw new Error(`Upgrade did not take effect: ${afterImpl}`);
+    }
+    console.log("Confirmed: proxy now at", afterImpl);
+
+    const targets: string[] = await proxyAsImpl.getAllowedTargets();
+    console.log("getAllowedTargets() (must be preserved):", targets);
+  } else {
+    const admin = await proxyAsImpl.hasRole(DEFAULT_ADMIN_ROLE, MAINNET_ADMIN);
+    console.log("\n=== Deployer does NOT have admin on this chain ===");
+    if (admin) console.log(`Confirmed: ${MAINNET_ADMIN} has DEFAULT_ADMIN_ROLE.`);
+    console.log("Calldata for admin wallet:");
+    const iface = new ethers.Interface(["function upgradeToAndCall(address,bytes)"]);
+    const data = iface.encodeFunctionData("upgradeToAndCall", [implDeploy.address, "0x"]);
+    console.log("  to:    " + ESCROW_PROXY);
+    console.log("  data:  " + data);
+    console.log("  value: 0");
+  }
+
+  console.log("\n=== Verifying new impl on Blockscout ===");
+  await verifyContract(implDeploy.address, []);
+
+  console.log("\n=== Summary ===");
+  console.log("Proxy:        ", ESCROW_PROXY);
+  console.log("Previous impl:", beforeImpl);
+  console.log("New impl:     ", implDeploy.address);
+};
+
+export default func;
+func.tags = ["DataPortabilityEscrowUpgradeSettleRef"];

--- a/deploy/dataPortability/dataPortabilityEscrow-upgrade.ts
+++ b/deploy/dataPortability/dataPortabilityEscrow-upgrade.ts
@@ -1,0 +1,93 @@
+import { deployments, ethers } from "hardhat";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { DeployFunction } from "hardhat-deploy/types";
+import { verifyContract } from "../helpers";
+
+/**
+ * Upgrades the deployed DataPortabilityEscrow UUPS proxy to a freshly compiled
+ * implementation. Storage layout is unchanged in this upgrade (SettleOp.ref ->
+ * SettleOp.opKind is calldata-only; OpKind enum is type-only; Settled event
+ * topic shape changes are off-chain).
+ *
+ * Env vars used:
+ *   DATA_PORTABILITY_ESCROW_PROXY  - proxy address (override default)
+ */
+const ESCROW_PROXY_DEFAULT = "0xcF50fAb402e2025a92e1bF811049820b6428910A";
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const [deployer] = await ethers.getSigners();
+  const proxyAddress =
+    process.env.DATA_PORTABILITY_ESCROW_PROXY ?? ESCROW_PROXY_DEFAULT;
+
+  console.log("Deployer:           ", deployer.address);
+  console.log("Escrow proxy:       ", proxyAddress);
+
+  // 1. Deploy the new implementation (no constructor args).
+  console.log("\n=== Deploying new DataPortabilityEscrowImplementation ===");
+  const implDeploy = await deployments.deploy("DataPortabilityEscrowImplementation", {
+    from: deployer.address,
+    args: [],
+    log: true,
+  });
+  console.log("New implementation:  ", implDeploy.address);
+
+  // 2. Read the current impl slot on the proxy for the before snapshot.
+  const IMPL_SLOT =
+    "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc";
+  const beforeImplRaw = await ethers.provider.getStorage(proxyAddress, IMPL_SLOT);
+  const beforeImpl = ethers.getAddress("0x" + beforeImplRaw.slice(-40));
+  console.log("Previous impl:       ", beforeImpl);
+
+  if (beforeImpl.toLowerCase() === implDeploy.address.toLowerCase()) {
+    console.log("Already at this implementation — nothing to do.");
+  } else {
+    // 3. Call upgradeToAndCall(newImpl, "") on the proxy (UUPS).
+    console.log("\n=== Calling upgradeToAndCall on proxy ===");
+    const proxyAsUUPS = await ethers.getContractAt(
+      "DataPortabilityEscrowImplementation",
+      proxyAddress,
+    );
+
+    const tx = await proxyAsUUPS
+      .connect(deployer)
+      .upgradeToAndCall(implDeploy.address, "0x");
+    console.log("upgrade tx:         ", tx.hash);
+    const receipt = await tx.wait();
+    console.log("upgrade mined in:   ", receipt?.blockNumber);
+
+    // 4. Confirm the slot moved.
+    const afterImplRaw = await ethers.provider.getStorage(proxyAddress, IMPL_SLOT);
+    const afterImpl = ethers.getAddress("0x" + afterImplRaw.slice(-40));
+    console.log("New impl in proxy:  ", afterImpl);
+
+    if (afterImpl.toLowerCase() !== implDeploy.address.toLowerCase()) {
+      throw new Error(
+        `Upgrade did not take effect: proxy impl is ${afterImpl}, expected ${implDeploy.address}`,
+      );
+    }
+  }
+
+  // 5. Sanity-check: round-trip a view through the proxy to confirm the new
+  //    impl is wired and not bricked.
+  const escrow = await ethers.getContractAt(
+    "DataPortabilityEscrowImplementation",
+    proxyAddress,
+  );
+  const v = await escrow.version();
+  const permissionsPtr = await escrow.permissions();
+  console.log("\n=== Post-upgrade sanity ===");
+  console.log("escrow.version():           ", v.toString());
+  console.log("escrow.permissions():       ", permissionsPtr);
+
+  // 6. Blockscout verification (best-effort).
+  console.log("\n=== Verifying new impl on Blockscout (may 403 from Cloudflare) ===");
+  await verifyContract(implDeploy.address, []);
+
+  console.log("\n=== Upgrade summary ===");
+  console.log("Proxy:                  ", proxyAddress);
+  console.log("Previous impl:          ", beforeImpl);
+  console.log("New impl:               ", implDeploy.address);
+};
+
+export default func;
+func.tags = ["DataPortabilityEscrowUpgrade"];

--- a/deploy/dataPortability/dataPortabilityFullStack-deploy.ts
+++ b/deploy/dataPortability/dataPortabilityFullStack-deploy.ts
@@ -1,0 +1,296 @@
+import { ethers } from "hardhat";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { DeployFunction } from "hardhat-deploy/types";
+import { deterministicDeployProxy, verifyProxy } from "../helpers";
+
+/**
+ * Cross-chain matching deploy for the full data-portability stack.
+ *
+ * Strategy: bootstrap-then-transfer.
+ *   1. Every proxy is initialize'd with the DEPLOYER address as bootstrap
+ *      admin. Since DEPLOYER_PRIVATE_KEY yields the same address on every
+ *      chain, init data is byte-identical → CREATE2 proxy addresses match.
+ *   2. Cross-contract pointers + role grants happen while the deployer
+ *      still has DEFAULT_ADMIN_ROLE.
+ *   3. Last step: hand DEFAULT_ADMIN_ROLE (and MAINTAINER_ROLE on ServersV2)
+ *      to the chain-specific owner, then renounce from deployer.
+ *      Skipped entirely on chains where deployer == owner (e.g. Moksha
+ *      using 0x2AC9…).
+ *
+ * Contracts:
+ *   - FeeRegistry
+ *   - DataPortabilityServersV2
+ *   - DataPortabilityPermissionsV2
+ *   - DataRegistryV2
+ *   - DataPortabilityEscrow
+ *
+ * Wiring:
+ *   - DataRegistryV2.setDataPortabilityServers → ServersV2 proxy
+ *   - Escrow.setPermissions → PermissionsV2 proxy
+ *   - Escrow.setDataRegistry → DataRegistryV2 proxy
+ *
+ * Roles:
+ *   - DataRegistryV2.grantRole(ACCESS_RECORDER_ROLE, Escrow proxy)
+ *   - Escrow.grantRole(FACILITATOR_ROLE, FACILITATOR) + revoke from deployer
+ */
+
+const FACILITATOR = "0x80534af0b80ae88d653Cae0a8f5d2667439538a0";
+
+/// Bump this to land at a fresh CREATE2 address set (e.g., when admin policy
+/// changes and the prior deployment can't be reused). All proxies use
+/// `proxyContractName + SALT_SUFFIX` as the salt — change in lockstep so
+/// every contract lands at a new address.
+const SALT_SUFFIX = "/Canonical";
+
+/// Per-chain admin handoff target. On Moksha we deliberately leave the
+/// admin as the deployer (chain owner === deployer.address); the script
+/// detects equality and skips the admin transfer. On mainnet we hand off
+/// to the designated multisig / EOA below.
+const CHAIN_OWNERS: Record<number, string | "DEPLOYER"> = {
+  14800: "DEPLOYER", // Moksha — deployer is the admin (no transfer)
+  1480: "0x5ECA5208F29e32879a711467916965B2D753bAf4", // Vana mainnet
+};
+
+const DEFAULT_ADMIN_ROLE = "0x" + "00".repeat(32);
+const MAINTAINER_ROLE = ethers.keccak256(ethers.toUtf8Bytes("MAINTAINER_ROLE"));
+const ACCESS_RECORDER_ROLE = ethers.keccak256(ethers.toUtf8Bytes("ACCESS_RECORDER_ROLE"));
+const FACILITATOR_ROLE = ethers.keccak256(ethers.toUtf8Bytes("FACILITATOR_ROLE"));
+
+interface DeployResult {
+  proxyAddress: string;
+  implementationAddress: string;
+}
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const [deployer] = await ethers.getSigners();
+  const chainId = Number(hre.network.config.chainId ?? (await ethers.provider.getNetwork()).chainId);
+  const ownerSpec = CHAIN_OWNERS[chainId];
+  if (!ownerSpec) throw new Error(`No CHAIN_OWNER configured for chainId=${chainId}`);
+  const chainOwner = ownerSpec === "DEPLOYER" ? deployer.address : ownerSpec;
+
+  console.log("=================================================");
+  console.log("Chain:                 ", hre.network.name, `(chainId=${chainId})`);
+  console.log("Deployer (bootstrap):  ", deployer.address);
+  console.log("Final chain owner:     ", chainOwner);
+  console.log("Facilitator (FACILITATOR_ROLE):", FACILITATOR);
+  console.log("=================================================");
+
+  // ============================================================
+  // 1. Deploy proxies (init data is byte-identical across chains)
+  // ============================================================
+
+  const feeReg = await deployOne(
+    deployer,
+    "FeeRegistryProxy",
+    "FeeRegistryImplementation",
+    [deployer.address],
+    "contracts/protocol/feeRegistry/FeeRegistryProxy.sol:FeeRegistryProxy",
+  );
+
+  const serversV2 = await deployOne(
+    deployer,
+    "DataPortabilityServersV2Proxy",
+    "DataPortabilityServersV2Implementation",
+    [ethers.ZeroAddress, deployer.address],
+    "contracts/dataPortability/dataPortabilityServersV2/DataPortabilityServersV2Proxy.sol:DataPortabilityServersV2Proxy",
+  );
+
+  const permissionsV2 = await deployOne(
+    deployer,
+    "DataPortabilityPermissionsV2Proxy",
+    "DataPortabilityPermissionsV2Implementation",
+    [deployer.address],
+    "contracts/dataPortability/dataPortabilityPermissionsV2/DataPortabilityPermissionsV2Proxy.sol:DataPortabilityPermissionsV2Proxy",
+  );
+
+  const dataRegistryV2 = await deployOne(
+    deployer,
+    "DataRegistryV2Proxy",
+    "DataRegistryV2Implementation",
+    [deployer.address],
+    "contracts/data/dataRegistryV2/DataRegistryV2Proxy.sol:DataRegistryV2Proxy",
+  );
+
+  const escrow = await deployOne(
+    deployer,
+    "DataPortabilityEscrowProxy",
+    "DataPortabilityEscrowImplementation",
+    [deployer.address, deployer.address],
+    "contracts/dataPortability/dataPortabilityEscrow/DataPortabilityEscrowProxy.sol:DataPortabilityEscrowProxy",
+  );
+
+  // ============================================================
+  // 2. Wire cross-contract pointers
+  // ============================================================
+  console.log("\n=== Wiring cross-contract pointers ===");
+
+  const dataRegistry = await ethers.getContractAt(
+    "DataRegistryV2Implementation",
+    dataRegistryV2.proxyAddress,
+  );
+  await ensureWired(
+    "dataRegistry.dataPortabilityServers",
+    async () => await dataRegistry.dataPortabilityServers(),
+    async () => await dataRegistry.connect(deployer).setDataPortabilityServers(serversV2.proxyAddress),
+    serversV2.proxyAddress,
+  );
+
+  const escrowContract = await ethers.getContractAt(
+    "DataPortabilityEscrowImplementation",
+    escrow.proxyAddress,
+  );
+  await ensureWired(
+    "escrow.permissions",
+    async () => await escrowContract.permissions(),
+    async () => await escrowContract.connect(deployer).setPermissions(permissionsV2.proxyAddress),
+    permissionsV2.proxyAddress,
+  );
+  await ensureWired(
+    "escrow.dataRegistry",
+    async () => await escrowContract.dataRegistry(),
+    async () => await escrowContract.connect(deployer).setDataRegistry(dataRegistryV2.proxyAddress),
+    dataRegistryV2.proxyAddress,
+  );
+
+  // ============================================================
+  // 3. Grant operational roles
+  // ============================================================
+  console.log("\n=== Granting operational roles ===");
+
+  await ensureGranted(
+    "dataRegistry.ACCESS_RECORDER_ROLE → escrow proxy",
+    dataRegistry,
+    ACCESS_RECORDER_ROLE,
+    escrow.proxyAddress,
+    deployer,
+  );
+
+  await ensureGranted(
+    "escrow.FACILITATOR_ROLE → " + FACILITATOR,
+    escrowContract,
+    FACILITATOR_ROLE,
+    FACILITATOR,
+    deployer,
+  );
+
+  // Revoke FACILITATOR_ROLE from deployer (granted during init when we passed deployer as facilitator)
+  if (await escrowContract.hasRole(FACILITATOR_ROLE, deployer.address)) {
+    const tx = await escrowContract.connect(deployer).revokeRole(FACILITATOR_ROLE, deployer.address);
+    await tx.wait();
+    console.log("  revokeRole(FACILITATOR_ROLE, deployer) tx:", tx.hash);
+  } else {
+    console.log("  Deployer already lacks FACILITATOR_ROLE.");
+  }
+
+  // ============================================================
+  // 4. Hand DEFAULT_ADMIN_ROLE (and MAINTAINER_ROLE on ServersV2) to the chain owner.
+  //    Done LAST so deployer can complete every setting first.
+  //    No-op on chains where deployer == chain owner.
+  // ============================================================
+  if (chainOwner.toLowerCase() !== deployer.address.toLowerCase()) {
+    console.log(`\n=== Transferring admin role(s) to ${chainOwner} ===`);
+
+    const adminTargets = [
+      { name: "FeeRegistry", addr: feeReg.proxyAddress, abi: "FeeRegistryImplementation", extraRoles: [] as string[] },
+      { name: "ServersV2", addr: serversV2.proxyAddress, abi: "DataPortabilityServersV2Implementation", extraRoles: [MAINTAINER_ROLE] },
+      { name: "PermissionsV2", addr: permissionsV2.proxyAddress, abi: "DataPortabilityPermissionsV2Implementation", extraRoles: [] },
+      { name: "DataRegistryV2", addr: dataRegistryV2.proxyAddress, abi: "DataRegistryV2Implementation", extraRoles: [] },
+      { name: "Escrow", addr: escrow.proxyAddress, abi: "DataPortabilityEscrowImplementation", extraRoles: [] },
+    ];
+
+    for (const t of adminTargets) {
+      const inst = await ethers.getContractAt(t.abi, t.addr);
+
+      // Grant chain owner ALL relevant roles first, then renounce deployer's.
+      for (const role of [DEFAULT_ADMIN_ROLE, ...t.extraRoles]) {
+        if (!(await inst.hasRole(role, chainOwner))) {
+          const tx = await inst.connect(deployer).grantRole(role, chainOwner);
+          await tx.wait();
+          console.log(`  ${t.name}.grantRole(${roleLabel(role)}, owner) tx: ${tx.hash}`);
+        }
+      }
+      for (const role of [...t.extraRoles, DEFAULT_ADMIN_ROLE]) {
+        // Renounce DEFAULT_ADMIN_ROLE LAST among the contract's roles, so we
+        // retain admin while renouncing the others.
+        if (await inst.hasRole(role, deployer.address)) {
+          const tx = await inst.connect(deployer).renounceRole(role, deployer.address);
+          await tx.wait();
+          console.log(`  ${t.name}.renounceRole(${roleLabel(role)}, deployer) tx: ${tx.hash}`);
+        }
+      }
+    }
+  } else {
+    console.log("\n(Skipping admin-role transfer: deployer is already the chain owner.)");
+  }
+
+  // ============================================================
+  // Summary
+  // ============================================================
+  console.log("\n=================================================");
+  console.log("=== Deployment summary ===");
+  console.log("=================================================");
+  console.log("FeeRegistry proxy:                ", feeReg.proxyAddress);
+  console.log("  impl:                           ", feeReg.implementationAddress);
+  console.log("DataPortabilityServersV2 proxy:   ", serversV2.proxyAddress);
+  console.log("  impl:                           ", serversV2.implementationAddress);
+  console.log("DataPortabilityPermissionsV2 proxy:", permissionsV2.proxyAddress);
+  console.log("  impl:                           ", permissionsV2.implementationAddress);
+  console.log("DataRegistryV2 proxy:             ", dataRegistryV2.proxyAddress);
+  console.log("  impl:                           ", dataRegistryV2.implementationAddress);
+  console.log("DataPortabilityEscrow proxy:      ", escrow.proxyAddress);
+  console.log("  impl:                           ", escrow.implementationAddress);
+};
+
+// ----- helpers -----
+
+async function deployOne(
+  deployer: any,
+  proxyContractName: string,
+  implContractName: string,
+  initParams: any[],
+  proxyPath: string,
+): Promise<DeployResult> {
+  console.log(`\n--- Deploying ${proxyContractName} ---`);
+  const salt = proxyContractName + SALT_SUFFIX;
+  const result = await deterministicDeployProxy(deployer, proxyContractName, implContractName, initParams, salt);
+  await verifyProxy(result.proxyAddress, result.implementationAddress, result.initializeData, proxyPath);
+  console.log(`${proxyContractName} -> ${result.proxyAddress}  (impl ${result.implementationAddress})`);
+  return { proxyAddress: result.proxyAddress, implementationAddress: result.implementationAddress };
+}
+
+async function ensureWired(
+  label: string,
+  reader: () => Promise<string>,
+  setter: () => Promise<any>,
+  expected: string,
+) {
+  const current = (await reader()) as string;
+  if (current.toLowerCase() === expected.toLowerCase()) {
+    console.log(`  ${label} already wired.`);
+    return;
+  }
+  const tx = await setter();
+  await tx.wait();
+  console.log(`  ${label} tx: ${tx.hash}`);
+}
+
+async function ensureGranted(label: string, contract: any, role: string, recipient: string, deployer: any) {
+  if (await contract.hasRole(role, recipient)) {
+    console.log(`  ${label} already granted.`);
+    return;
+  }
+  const tx = await contract.connect(deployer).grantRole(role, recipient);
+  await tx.wait();
+  console.log(`  ${label} tx: ${tx.hash}`);
+}
+
+function roleLabel(role: string): string {
+  if (role === DEFAULT_ADMIN_ROLE) return "DEFAULT_ADMIN_ROLE";
+  if (role === MAINTAINER_ROLE) return "MAINTAINER_ROLE";
+  if (role === ACCESS_RECORDER_ROLE) return "ACCESS_RECORDER_ROLE";
+  if (role === FACILITATOR_ROLE) return "FACILITATOR_ROLE";
+  return role;
+}
+
+export default func;
+func.tags = ["DataPortabilityFullStackDeploy"];

--- a/deploy/dataPortability/dataPortabilityPermissionsV2-upgrade-delegatedSigning.ts
+++ b/deploy/dataPortability/dataPortabilityPermissionsV2-upgrade-delegatedSigning.ts
@@ -1,0 +1,142 @@
+import { deployments, ethers } from "hardhat";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { DeployFunction } from "hardhat-deploy/types";
+import { verifyContract } from "../helpers";
+
+/**
+ * Upgrades DataPortabilityPermissionsV2 to accept a delegated signature from a
+ * personal server currently registered to the grantor in DataPortabilityServersV2.
+ *
+ * Adds:
+ *   - storage field `dataPortabilityServers`
+ *   - admin `setDataPortabilityServers(address)`
+ *   - new event `PermissionSignedByDelegate`, `DataPortabilityServersUpdated`
+ *   - delegation branch in `addPermissionWithSignature` (selector unchanged)
+ *
+ * Selector preserved: `addPermissionWithSignature((address,bytes32,string[],uint256,uint256),bytes)`
+ * → `0xdb503733`. The escrow runOpAndSettle allowlist entry stays valid.
+ *
+ * Per chain:
+ *   - Moksha:  deployer has admin → upgrade + wire servers.
+ *   - Mainnet: deployer has no admin → deploys impl only, prints calldata
+ *              for the admin and a follow-up `setDataPortabilityServers` call.
+ */
+const PERMISSIONS_PROXY = "0x4d3FA76064D88e0454cFc4CaD7e5FeC3e3124011";
+const SERVERS_PROXY = "0xCae2CE0e9caa6643ed28186cF57bd40Bd9E17Eab";
+const MAINNET_ADMIN = "0x5ECA5208F29e32879a711467916965B2D753bAf4";
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const [deployer] = await ethers.getSigners();
+  const chainId = Number(hre.network.config.chainId ?? (await ethers.provider.getNetwork()).chainId);
+
+  console.log("Deployer:           ", deployer.address);
+  console.log("Chain:              ", hre.network.name, `(chainId=${chainId})`);
+  console.log("Permissions proxy:  ", PERMISSIONS_PROXY);
+  console.log("Servers proxy:      ", SERVERS_PROXY);
+
+  // 1. Deploy new impl
+  console.log("\n=== Deploying new DataPortabilityPermissionsV2Implementation ===");
+  const implDeploy = await deployments.deploy("DataPortabilityPermissionsV2Implementation", {
+    from: deployer.address,
+    args: [],
+    log: true,
+  });
+  console.log("New impl:           ", implDeploy.address);
+
+  // 2. Snapshot current impl
+  const IMPL_SLOT = "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc";
+  const beforeRaw = await ethers.provider.getStorage(PERMISSIONS_PROXY, IMPL_SLOT);
+  const beforeImpl = ethers.getAddress("0x" + beforeRaw.slice(-40));
+  console.log("Current impl:       ", beforeImpl);
+
+  const proxyAsImpl = await ethers.getContractAt(
+    "DataPortabilityPermissionsV2Implementation",
+    PERMISSIONS_PROXY,
+  );
+
+  const DEFAULT_ADMIN_ROLE = "0x" + "00".repeat(32);
+  const canAdmin: boolean = await proxyAsImpl.hasRole(DEFAULT_ADMIN_ROLE, deployer.address);
+
+  // ---------- Upgrade ----------
+  if (beforeImpl.toLowerCase() !== implDeploy.address.toLowerCase()) {
+    if (canAdmin) {
+      console.log("\n=== Deployer has admin — performing upgradeToAndCall ===");
+      const tx = await proxyAsImpl.connect(deployer).upgradeToAndCall(implDeploy.address, "0x");
+      console.log("upgrade tx:         ", tx.hash);
+      await tx.wait();
+
+      const afterRaw = await ethers.provider.getStorage(PERMISSIONS_PROXY, IMPL_SLOT);
+      const afterImpl = ethers.getAddress("0x" + afterRaw.slice(-40));
+      if (afterImpl.toLowerCase() !== implDeploy.address.toLowerCase()) {
+        throw new Error(`Upgrade did not take effect: ${afterImpl}`);
+      }
+      console.log("Confirmed: proxy now at", afterImpl);
+    } else {
+      console.log("\n=== Deployer does NOT have admin — printing upgrade calldata ===");
+      const iface = new ethers.Interface(["function upgradeToAndCall(address,bytes)"]);
+      const data = iface.encodeFunctionData("upgradeToAndCall", [implDeploy.address, "0x"]);
+      console.log("Admin wallet must send:");
+      console.log("  to:    " + PERMISSIONS_PROXY);
+      console.log("  data:  " + data);
+      console.log("  value: 0");
+    }
+  } else {
+    console.log("Proxy already on this impl — skipping upgradeToAndCall.");
+  }
+
+  // ---------- Wire servers ----------
+  console.log("\n=== Wiring dataPortabilityServers ===");
+  let currentServers: string;
+  try {
+    currentServers = await proxyAsImpl.dataPortabilityServers();
+  } catch (e) {
+    // Function not yet present (proxy still on old impl on mainnet). That's fine.
+    currentServers = ethers.ZeroAddress;
+    console.log("Note: dataPortabilityServers() not callable yet (proxy still on old impl).");
+  }
+  console.log("Current servers:    ", currentServers);
+
+  if (currentServers.toLowerCase() === SERVERS_PROXY.toLowerCase()) {
+    console.log("Already wired — no-op.");
+  } else if (canAdmin && beforeImpl.toLowerCase() !== implDeploy.address.toLowerCase()) {
+    // Only run live setter if we actually have admin AND the new impl is live now.
+    const tx = await proxyAsImpl
+      .connect(deployer)
+      .setDataPortabilityServers(SERVERS_PROXY);
+    console.log("setDataPortabilityServers tx:", tx.hash);
+    await tx.wait();
+    const after = await proxyAsImpl.dataPortabilityServers();
+    if (after.toLowerCase() !== SERVERS_PROXY.toLowerCase()) {
+      throw new Error(`Wiring did not take effect: ${after}`);
+    }
+    console.log("Confirmed: dataPortabilityServers ->", after);
+  } else if (canAdmin) {
+    // Edge: deployer is admin but proxy was already on this impl (re-run).
+    const tx = await proxyAsImpl
+      .connect(deployer)
+      .setDataPortabilityServers(SERVERS_PROXY);
+    console.log("setDataPortabilityServers tx:", tx.hash);
+    await tx.wait();
+    console.log("Confirmed.");
+  } else {
+    console.log("Deployer is NOT admin — printing follow-up calldata for admin:");
+    const iface = new ethers.Interface(["function setDataPortabilityServers(address)"]);
+    const data = iface.encodeFunctionData("setDataPortabilityServers", [SERVERS_PROXY]);
+    console.log("Admin wallet must send (AFTER upgrade goes through):");
+    console.log("  to:    " + PERMISSIONS_PROXY);
+    console.log("  data:  " + data);
+    console.log("  value: 0");
+  }
+
+  // ---------- Verify ----------
+  console.log("\n=== Verifying new impl on Blockscout ===");
+  await verifyContract(implDeploy.address, []);
+
+  console.log("\n=== Summary ===");
+  console.log("Permissions proxy:  ", PERMISSIONS_PROXY);
+  console.log("Previous impl:      ", beforeImpl);
+  console.log("New impl:           ", implDeploy.address);
+};
+
+export default func;
+func.tags = ["DataPortabilityPermissionsV2UpgradeDelegatedSigning"];

--- a/deploy/dataPortability/dataPortabilityPermissionsV2-upgrade.ts
+++ b/deploy/dataPortability/dataPortabilityPermissionsV2-upgrade.ts
@@ -1,0 +1,94 @@
+import { deployments, ethers } from "hardhat";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { DeployFunction } from "hardhat-deploy/types";
+import { verifyContract } from "../helpers";
+
+/**
+ * Upgrades DataPortabilityPermissionsV2 to use OZ's `_domainSeparatorV4()`
+ * for both EIP-712 signatures and `grantId` derivation.
+ *
+ * Storage layout is unchanged (the removed `DOMAIN_TYPEHASH` was a constant,
+ * not a storage slot). Safe upgrade.
+ *
+ * BEHAVIOR CHANGE: the returned `domainSeparator()` value differs from before,
+ * so every `grantId(grantor, granteeId)` now derives a different bytes32.
+ * Off-chain code that predicted/stored grantIds against the old impl needs
+ * to recompute against the EIP-712 standard domain separator.
+ */
+const PROXY_DEFAULT = "0x8D489bEE1e35cc214F0d9D0F4610905d231218A0";
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const [deployer] = await ethers.getSigners();
+  const proxyAddress = process.env.DATA_PORTABILITY_PERMISSIONS_V2_PROXY ?? PROXY_DEFAULT;
+
+  console.log("Deployer:                  ", deployer.address);
+  console.log("PermissionsV2 proxy:       ", proxyAddress);
+
+  // 1. Deploy new impl
+  console.log("\n=== Deploying new DataPortabilityPermissionsV2Implementation ===");
+  const implDeploy = await deployments.deploy("DataPortabilityPermissionsV2Implementation", {
+    from: deployer.address,
+    args: [],
+    log: true,
+  });
+  console.log("New implementation:        ", implDeploy.address);
+
+  // 2. Snapshot previous impl
+  const IMPL_SLOT = "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc";
+  const beforeImplRaw = await ethers.provider.getStorage(proxyAddress, IMPL_SLOT);
+  const beforeImpl = ethers.getAddress("0x" + beforeImplRaw.slice(-40));
+  console.log("Previous impl:             ", beforeImpl);
+
+  // 3. Snapshot a sample grantId BEFORE upgrade so we can show the value change.
+  const sampleGrantor = "0x2AC93684679a5bdA03C6160def908CdB8D46792f";
+  const sampleGranteeId = "0x" + "00".repeat(31) + "01";
+  const proxyOld = await ethers.getContractAt(
+    "DataPortabilityPermissionsV2Implementation",
+    proxyAddress,
+  );
+  const grantIdBefore = await proxyOld.grantId(sampleGrantor, sampleGranteeId);
+  const domainBefore = await proxyOld.domainSeparator();
+  console.log("Pre-upgrade  domainSeparator():", domainBefore);
+  console.log("Pre-upgrade  grantId(sample):  ", grantIdBefore);
+
+  // 4. Upgrade
+  if (beforeImpl.toLowerCase() === implDeploy.address.toLowerCase()) {
+    console.log("Already at this implementation — skipping upgrade.");
+  } else {
+    console.log("\n=== Calling upgradeToAndCall on proxy ===");
+    const tx = await proxyOld.connect(deployer).upgradeToAndCall(implDeploy.address, "0x");
+    console.log("upgrade tx:                ", tx.hash);
+    await tx.wait();
+
+    const afterImplRaw = await ethers.provider.getStorage(proxyAddress, IMPL_SLOT);
+    const afterImpl = ethers.getAddress("0x" + afterImplRaw.slice(-40));
+    console.log("New impl in proxy:         ", afterImpl);
+    if (afterImpl.toLowerCase() !== implDeploy.address.toLowerCase()) {
+      throw new Error(
+        `Upgrade did not take effect: proxy impl is ${afterImpl}, expected ${implDeploy.address}`,
+      );
+    }
+  }
+
+  // 5. Snapshot after upgrade
+  const grantIdAfter = await proxyOld.grantId(sampleGrantor, sampleGranteeId);
+  const domainAfter = await proxyOld.domainSeparator();
+  console.log("\n=== Post-upgrade sanity ===");
+  console.log("Post-upgrade domainSeparator():", domainAfter);
+  console.log("Post-upgrade grantId(sample):  ", grantIdAfter);
+  if (domainBefore === domainAfter) {
+    console.log("WARNING: domainSeparator unchanged after upgrade — did the new impl land?");
+  }
+
+  // 6. Verify on Blockscout (also catches the original impl that was unverified)
+  console.log("\n=== Verifying new impl on Blockscout ===");
+  await verifyContract(implDeploy.address, []);
+
+  console.log("\n=== Upgrade summary ===");
+  console.log("Proxy:                          ", proxyAddress);
+  console.log("Previous impl:                  ", beforeImpl);
+  console.log("New impl:                       ", implDeploy.address);
+};
+
+export default func;
+func.tags = ["DataPortabilityPermissionsV2Upgrade"];

--- a/deploy/dataPortability/dataPortabilityV2-deploy.ts
+++ b/deploy/dataPortability/dataPortabilityV2-deploy.ts
@@ -1,0 +1,116 @@
+import { ethers } from "hardhat";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { DeployFunction } from "hardhat-deploy/types";
+import { deterministicDeployProxy, verifyProxy } from "../helpers";
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const [deployer] = await ethers.getSigners();
+
+  const ownerAddress = process.env.OWNER_ADDRESS ?? deployer.address;
+  // Default to ownerAddress for the initial facilitator; can be rotated later
+  // via grantRole(FACILITATOR_ROLE, ...).
+  const facilitatorAddress = process.env.FACILITATOR_ADDRESS ?? ownerAddress;
+
+  console.log("Deployer address:    ", deployer.address);
+  console.log("Owner address:       ", ownerAddress);
+  console.log("Facilitator address: ", facilitatorAddress);
+
+  // ----------------------------------------------------------------
+  // 1. DataPortabilityPermissionsV2
+  // ----------------------------------------------------------------
+  console.log("\n=== Deploying DataPortabilityPermissionsV2 ===");
+  const permissionsImpl = "DataPortabilityPermissionsV2Implementation";
+  const permissionsProxy = "DataPortabilityPermissionsV2Proxy";
+  const permissionsProxyPath =
+    "contracts/dataPortability/dataPortabilityPermissionsV2/DataPortabilityPermissionsV2Proxy.sol:DataPortabilityPermissionsV2Proxy";
+  const permissionsSalt = process.env.CREATE2_SALT ?? permissionsProxy;
+
+  const permissionsInitParams = [ownerAddress];
+
+  const permissionsDeploy = await deterministicDeployProxy(
+    deployer,
+    permissionsProxy,
+    permissionsImpl,
+    permissionsInitParams,
+    permissionsSalt,
+  );
+
+  await verifyProxy(
+    permissionsDeploy.proxyAddress,
+    permissionsDeploy.implementationAddress,
+    permissionsDeploy.initializeData,
+    permissionsProxyPath,
+  );
+
+  console.log("DataPortabilityPermissionsV2 deployed at:", permissionsDeploy.proxyAddress);
+
+  // ----------------------------------------------------------------
+  // 2. DataPortabilityEscrow
+  // ----------------------------------------------------------------
+  console.log("\n=== Deploying DataPortabilityEscrow ===");
+  const escrowImpl = "DataPortabilityEscrowImplementation";
+  const escrowProxy = "DataPortabilityEscrowProxy";
+  const escrowProxyPath =
+    "contracts/dataPortability/dataPortabilityEscrow/DataPortabilityEscrowProxy.sol:DataPortabilityEscrowProxy";
+  const escrowSalt = process.env.CREATE2_SALT ?? escrowProxy;
+
+  const escrowInitParams = [ownerAddress, facilitatorAddress];
+
+  const escrowDeploy = await deterministicDeployProxy(
+    deployer,
+    escrowProxy,
+    escrowImpl,
+    escrowInitParams,
+    escrowSalt,
+  );
+
+  await verifyProxy(
+    escrowDeploy.proxyAddress,
+    escrowDeploy.implementationAddress,
+    escrowDeploy.initializeData,
+    escrowProxyPath,
+  );
+
+  console.log("DataPortabilityEscrow deployed at:", escrowDeploy.proxyAddress);
+
+  // ----------------------------------------------------------------
+  // 3. Wire escrow -> permissions
+  // ----------------------------------------------------------------
+  console.log("\n=== Wiring escrow.setPermissions(permissions) ===");
+  const escrowContract = await ethers.getContractAt(
+    "DataPortabilityEscrowImplementation",
+    escrowDeploy.proxyAddress,
+  );
+
+  const currentPermissions: string = await escrowContract.permissions();
+  if (currentPermissions.toLowerCase() === permissionsDeploy.proxyAddress.toLowerCase()) {
+    console.log("Already wired.");
+  } else {
+    const tx = await escrowContract
+      .connect(deployer)
+      .setPermissions(permissionsDeploy.proxyAddress);
+    await tx.wait();
+    console.log("setPermissions tx:", tx.hash);
+  }
+
+  const verifyPermissions: string = await escrowContract.permissions();
+  if (verifyPermissions.toLowerCase() !== permissionsDeploy.proxyAddress.toLowerCase()) {
+    throw new Error(
+      `setPermissions failed: expected ${permissionsDeploy.proxyAddress}, got ${verifyPermissions}`,
+    );
+  }
+  console.log("Wiring verified.");
+
+  // ----------------------------------------------------------------
+  // Summary
+  // ----------------------------------------------------------------
+  console.log("\n=== Deployment summary ===");
+  console.log("DataPortabilityPermissionsV2:", permissionsDeploy.proxyAddress);
+  console.log("  - implementation:          ", permissionsDeploy.implementationAddress);
+  console.log("DataPortabilityEscrow:       ", escrowDeploy.proxyAddress);
+  console.log("  - implementation:          ", escrowDeploy.implementationAddress);
+  console.log("  - permissions ptr:         ", verifyPermissions);
+};
+
+export default func;
+func.tags = ["DataPortabilityV2Deploy"];

--- a/deploy/dataPortability/dataRegistryAndServersV2-deploy.ts
+++ b/deploy/dataPortability/dataRegistryAndServersV2-deploy.ts
@@ -1,0 +1,153 @@
+import { ethers } from "hardhat";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { DeployFunction } from "hardhat-deploy/types";
+import { deterministicDeployProxy, verifyProxy } from "../helpers";
+
+/**
+ * Deploys DataPortabilityServersV2 + DataRegistryV2 on Moksha and wires them:
+ *  - DataPortabilityServersV2: initialize(trustedForwarder=0, owner)
+ *  - DataRegistryV2:           initialize(owner)
+ *  - DataRegistryV2.setDataPortabilityServers(serversV2 proxy)
+ *  - DataRegistryV2.grantRole(FACILITATOR_ROLE, owner)
+ *
+ * Env vars used:
+ *   OWNER_ADDRESS               - admin / facilitator address (defaults to deployer)
+ *   DATA_REGISTRY_FACILITATOR   - optional; address to grant FACILITATOR_ROLE on DataRegistryV2.
+ *                                 Defaults to OWNER_ADDRESS. Can be the gateway / escrow proxy later.
+ *   CREATE2_SALT                - optional; defaults to each proxy's contract name.
+ */
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const [deployer] = await ethers.getSigners();
+  const ownerAddress = process.env.OWNER_ADDRESS ?? deployer.address;
+  const facilitatorAddress = process.env.DATA_REGISTRY_FACILITATOR ?? ownerAddress;
+
+  console.log("Deployer:                ", deployer.address);
+  console.log("Owner (admin):           ", ownerAddress);
+  console.log("DataRegistry facilitator:", facilitatorAddress);
+
+  // ---------------------------------------------------------------
+  // 1. DataPortabilityServersV2
+  // ---------------------------------------------------------------
+  console.log("\n=== Deploying DataPortabilityServersV2 ===");
+  const serversImpl = "DataPortabilityServersV2Implementation";
+  const serversProxy = "DataPortabilityServersV2Proxy";
+  const serversProxyPath =
+    "contracts/dataPortability/dataPortabilityServersV2/DataPortabilityServersV2Proxy.sol:DataPortabilityServersV2Proxy";
+  const serversSalt = process.env.CREATE2_SALT ?? serversProxy;
+
+  // initialize(trustedForwarderAddress, ownerAddress)
+  const serversInitParams = [ethers.ZeroAddress, ownerAddress];
+
+  const serversDeploy = await deterministicDeployProxy(
+    deployer,
+    serversProxy,
+    serversImpl,
+    serversInitParams,
+    serversSalt,
+  );
+
+  await verifyProxy(
+    serversDeploy.proxyAddress,
+    serversDeploy.implementationAddress,
+    serversDeploy.initializeData,
+    serversProxyPath,
+  );
+
+  console.log("DataPortabilityServersV2 proxy:", serversDeploy.proxyAddress);
+
+  // ---------------------------------------------------------------
+  // 2. DataRegistryV2
+  // ---------------------------------------------------------------
+  console.log("\n=== Deploying DataRegistryV2 ===");
+  const registryImpl = "DataRegistryV2Implementation";
+  const registryProxy = "DataRegistryV2Proxy";
+  const registryProxyPath =
+    "contracts/data/dataRegistryV2/DataRegistryV2Proxy.sol:DataRegistryV2Proxy";
+  const registrySalt = process.env.CREATE2_SALT ?? registryProxy;
+
+  // initialize(ownerAddress)
+  const registryInitParams = [ownerAddress];
+
+  const registryDeploy = await deterministicDeployProxy(
+    deployer,
+    registryProxy,
+    registryImpl,
+    registryInitParams,
+    registrySalt,
+  );
+
+  await verifyProxy(
+    registryDeploy.proxyAddress,
+    registryDeploy.implementationAddress,
+    registryDeploy.initializeData,
+    registryProxyPath,
+  );
+
+  console.log("DataRegistryV2 proxy:", registryDeploy.proxyAddress);
+
+  // ---------------------------------------------------------------
+  // 3. Wire DataRegistryV2 -> DataPortabilityServersV2
+  // ---------------------------------------------------------------
+  console.log("\n=== Wiring DataRegistryV2.setDataPortabilityServers ===");
+  const registryContract = await ethers.getContractAt(
+    "DataRegistryV2Implementation",
+    registryDeploy.proxyAddress,
+  );
+
+  const currentServers: string = await registryContract.dataPortabilityServers();
+  if (currentServers.toLowerCase() === serversDeploy.proxyAddress.toLowerCase()) {
+    console.log("Already wired.");
+  } else {
+    const tx = await registryContract
+      .connect(deployer)
+      .setDataPortabilityServers(serversDeploy.proxyAddress);
+    await tx.wait();
+    console.log("setDataPortabilityServers tx:", tx.hash);
+  }
+
+  const verifyServers: string = await registryContract.dataPortabilityServers();
+  if (verifyServers.toLowerCase() !== serversDeploy.proxyAddress.toLowerCase()) {
+    throw new Error(
+      `setDataPortabilityServers failed: expected ${serversDeploy.proxyAddress}, got ${verifyServers}`,
+    );
+  }
+  console.log("Wiring verified.");
+
+  // ---------------------------------------------------------------
+  // 4. Grant FACILITATOR_ROLE on DataRegistryV2
+  // ---------------------------------------------------------------
+  console.log("\n=== Granting FACILITATOR_ROLE on DataRegistryV2 ===");
+  const FACILITATOR_ROLE = ethers.keccak256(ethers.toUtf8Bytes("FACILITATOR_ROLE"));
+  const hasRole: boolean = await registryContract.hasRole(FACILITATOR_ROLE, facilitatorAddress);
+  if (hasRole) {
+    console.log("Facilitator already has FACILITATOR_ROLE.");
+  } else {
+    const grantTx = await registryContract
+      .connect(deployer)
+      .grantRole(FACILITATOR_ROLE, facilitatorAddress);
+    await grantTx.wait();
+    console.log("grantRole tx:", grantTx.hash);
+  }
+
+  const verifyRole: boolean = await registryContract.hasRole(FACILITATOR_ROLE, facilitatorAddress);
+  if (!verifyRole) {
+    throw new Error(
+      `grantRole failed: ${facilitatorAddress} does not have FACILITATOR_ROLE on DataRegistryV2`,
+    );
+  }
+  console.log("Role grant verified.");
+
+  // ---------------------------------------------------------------
+  // Summary
+  // ---------------------------------------------------------------
+  console.log("\n=== Deployment summary ===");
+  console.log("DataPortabilityServersV2 proxy:", serversDeploy.proxyAddress);
+  console.log("  - implementation:           ", serversDeploy.implementationAddress);
+  console.log("DataRegistryV2 proxy:         ", registryDeploy.proxyAddress);
+  console.log("  - implementation:           ", registryDeploy.implementationAddress);
+  console.log("  - dataPortabilityServers:   ", verifyServers);
+  console.log("  - FACILITATOR_ROLE granted: ", facilitatorAddress);
+};
+
+export default func;
+func.tags = ["DataRegistryAndServersV2Deploy"];

--- a/deploy/dataPortability/dataRegistryV2-grant-role.ts
+++ b/deploy/dataPortability/dataRegistryV2-grant-role.ts
@@ -1,0 +1,49 @@
+import { ethers } from "hardhat";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { DeployFunction } from "hardhat-deploy/types";
+
+/**
+ * Grants ACCESS_RECORDER_ROLE on DataRegistryV2 to a recipient. Defaults to
+ * the DataPortabilityEscrow proxy so the future recordAccessAndSettle flow
+ * works once it ships.
+ *
+ * Env vars:
+ *   DATA_REGISTRY_V2_PROXY      default: 0x0850226E939A5C949633200cf0b1F4665CA74931
+ *   ACCESS_RECORDER_RECIPIENT   default: DataPortabilityEscrow proxy (0xcF50fAb402e2025a92e1bF811049820b6428910A)
+ */
+const DATA_REGISTRY_DEFAULT = "0x0850226E939A5C949633200cf0b1F4665CA74931";
+const ESCROW_PROXY_DEFAULT = "0xcF50fAb402e2025a92e1bF811049820b6428910A";
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const [admin] = await ethers.getSigners();
+  const proxyAddress = process.env.DATA_REGISTRY_V2_PROXY ?? DATA_REGISTRY_DEFAULT;
+  const recipient = process.env.ACCESS_RECORDER_RECIPIENT ?? ESCROW_PROXY_DEFAULT;
+
+  console.log("Admin signer:        ", admin.address);
+  console.log("DataRegistryV2 proxy:", proxyAddress);
+  console.log("Grant to:            ", recipient);
+
+  const ACCESS_RECORDER_ROLE = ethers.keccak256(ethers.toUtf8Bytes("ACCESS_RECORDER_ROLE"));
+  const registry = await ethers.getContractAt("DataRegistryV2Implementation", proxyAddress);
+
+  const already: boolean = await registry.hasRole(ACCESS_RECORDER_ROLE, recipient);
+  if (already) {
+    console.log("Recipient already has ACCESS_RECORDER_ROLE — nothing to do.");
+  } else {
+    const tx = await registry.connect(admin).grantRole(ACCESS_RECORDER_ROLE, recipient);
+    await tx.wait();
+    console.log("grantRole tx:        ", tx.hash);
+  }
+
+  const ok: boolean = await registry.hasRole(ACCESS_RECORDER_ROLE, recipient);
+  if (!ok) throw new Error("Role grant failed");
+
+  console.log("\nACCESS_RECORDER_ROLE holders (confirmed):");
+  // Existing owner address held the role from initial deploy.
+  const owner = process.env.OWNER_ADDRESS ?? admin.address;
+  console.log("  -", owner, await registry.hasRole(ACCESS_RECORDER_ROLE, owner) ? "✓" : "—");
+  console.log("  -", recipient, "✓ (just granted)");
+};
+
+export default func;
+func.tags = ["DataRegistryV2GrantAccessRecorder"];

--- a/deploy/dataPortability/dataRegistryV2-upgrade-delegatedSigning.ts
+++ b/deploy/dataPortability/dataRegistryV2-upgrade-delegatedSigning.ts
@@ -1,0 +1,92 @@
+import { deployments, ethers } from "hardhat";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { DeployFunction } from "hardhat-deploy/types";
+import { verifyContract } from "../helpers";
+
+/**
+ * Upgrades DataRegistryV2 to accept delegated signatures on `addDataWithSignature`
+ * from a personal server currently registered to the owner in
+ * DataPortabilityServersV2 (same trust model already used by `recordDataAccess`).
+ *
+ * No storage change (the `dataPortabilityServers` slot is already wired).
+ * Selector preserved: `addDataWithSignature(address,string,bytes32,bytes32,uint256,bytes)`.
+ *
+ * Per chain:
+ *   - Moksha:  deployer has admin → upgradeToAndCall.
+ *   - Mainnet: deployer has no admin → deploys impl only, prints calldata.
+ */
+const REGISTRY_PROXY = "0x8f1eFCdff3d0d5BB535e32620721c7EBed151867";
+const MAINNET_ADMIN = "0x5ECA5208F29e32879a711467916965B2D753bAf4";
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const [deployer] = await ethers.getSigners();
+  const chainId = Number(hre.network.config.chainId ?? (await ethers.provider.getNetwork()).chainId);
+
+  console.log("Deployer:        ", deployer.address);
+  console.log("Chain:           ", hre.network.name, `(chainId=${chainId})`);
+  console.log("Registry proxy:  ", REGISTRY_PROXY);
+
+  // 1. Deploy new impl
+  console.log("\n=== Deploying new DataRegistryV2Implementation ===");
+  const implDeploy = await deployments.deploy("DataRegistryV2Implementation", {
+    from: deployer.address,
+    args: [],
+    log: true,
+  });
+  console.log("New impl:        ", implDeploy.address);
+
+  // 2. Snapshot current impl
+  const IMPL_SLOT = "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc";
+  const beforeRaw = await ethers.provider.getStorage(REGISTRY_PROXY, IMPL_SLOT);
+  const beforeImpl = ethers.getAddress("0x" + beforeRaw.slice(-40));
+  console.log("Current impl:    ", beforeImpl);
+  if (beforeImpl.toLowerCase() === implDeploy.address.toLowerCase()) {
+    console.log("Already at this implementation — nothing to do.");
+    return;
+  }
+
+  // 3. Authorization check
+  const DEFAULT_ADMIN_ROLE = "0x" + "00".repeat(32);
+  const proxyAsImpl = await ethers.getContractAt("DataRegistryV2Implementation", REGISTRY_PROXY);
+  const canUpgrade: boolean = await proxyAsImpl.hasRole(DEFAULT_ADMIN_ROLE, deployer.address);
+
+  if (canUpgrade) {
+    console.log("\n=== Deployer has admin — performing upgradeToAndCall ===");
+    const tx = await proxyAsImpl.connect(deployer).upgradeToAndCall(implDeploy.address, "0x");
+    console.log("upgrade tx:      ", tx.hash);
+    await tx.wait();
+
+    const afterRaw = await ethers.provider.getStorage(REGISTRY_PROXY, IMPL_SLOT);
+    const afterImpl = ethers.getAddress("0x" + afterRaw.slice(-40));
+    if (afterImpl.toLowerCase() !== implDeploy.address.toLowerCase()) {
+      throw new Error(`Upgrade did not take effect: ${afterImpl}`);
+    }
+    console.log("Confirmed: proxy now at", afterImpl);
+
+    // Sanity check — already-wired servers contract is still set.
+    const servers = await proxyAsImpl.dataPortabilityServers();
+    console.log("dataPortabilityServers (unchanged):", servers);
+  } else {
+    const admin = await proxyAsImpl.hasRole(DEFAULT_ADMIN_ROLE, MAINNET_ADMIN);
+    console.log("\n=== Deployer does NOT have admin ===");
+    if (admin) console.log(`Confirmed: ${MAINNET_ADMIN} has DEFAULT_ADMIN_ROLE.`);
+    console.log("Calldata for admin wallet:");
+    const iface = new ethers.Interface(["function upgradeToAndCall(address,bytes)"]);
+    const data = iface.encodeFunctionData("upgradeToAndCall", [implDeploy.address, "0x"]);
+    console.log("  to:    " + REGISTRY_PROXY);
+    console.log("  data:  " + data);
+    console.log("  value: 0");
+  }
+
+  // 4. Blockscout verify
+  console.log("\n=== Verifying new impl on Blockscout ===");
+  await verifyContract(implDeploy.address, []);
+
+  console.log("\n=== Summary ===");
+  console.log("Proxy:           ", REGISTRY_PROXY);
+  console.log("Previous impl:   ", beforeImpl);
+  console.log("New impl:        ", implDeploy.address);
+};
+
+export default func;
+func.tags = ["DataRegistryV2UpgradeDelegatedSigning"];

--- a/deploy/dataPortability/dataRegistryV2-upgrade-idempotent-record.ts
+++ b/deploy/dataPortability/dataRegistryV2-upgrade-idempotent-record.ts
@@ -1,0 +1,63 @@
+import { deployments, ethers } from "hardhat";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { DeployFunction } from "hardhat-deploy/types";
+import { verifyContract } from "../helpers";
+
+/**
+ * Upgrades DataRegistryV2 to make `recordDataAccess` idempotent on `recordId`
+ * (silent return instead of revert when the recordId is already used).
+ * Storage layout unchanged — safe UUPS upgrade.
+ */
+const PROXY_DEFAULT = "0x0850226E939A5C949633200cf0b1F4665CA74931";
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const [deployer] = await ethers.getSigners();
+  const proxyAddress = process.env.DATA_REGISTRY_V2_PROXY ?? PROXY_DEFAULT;
+
+  console.log("Deployer:            ", deployer.address);
+  console.log("DataRegistryV2 proxy:", proxyAddress);
+
+  console.log("\n=== Deploying new DataRegistryV2Implementation ===");
+  const implDeploy = await deployments.deploy("DataRegistryV2Implementation", {
+    from: deployer.address,
+    args: [],
+    log: true,
+  });
+  console.log("New implementation:  ", implDeploy.address);
+
+  const IMPL_SLOT = "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc";
+  const beforeImplRaw = await ethers.provider.getStorage(proxyAddress, IMPL_SLOT);
+  const beforeImpl = ethers.getAddress("0x" + beforeImplRaw.slice(-40));
+  console.log("Previous impl:       ", beforeImpl);
+
+  if (beforeImpl.toLowerCase() === implDeploy.address.toLowerCase()) {
+    console.log("Already at this implementation.");
+  } else {
+    console.log("\n=== Calling upgradeToAndCall on proxy ===");
+    const proxyAsUUPS = await ethers.getContractAt(
+      "DataRegistryV2Implementation",
+      proxyAddress,
+    );
+    const tx = await proxyAsUUPS.connect(deployer).upgradeToAndCall(implDeploy.address, "0x");
+    console.log("upgrade tx:         ", tx.hash);
+    await tx.wait();
+
+    const afterImplRaw = await ethers.provider.getStorage(proxyAddress, IMPL_SLOT);
+    const afterImpl = ethers.getAddress("0x" + afterImplRaw.slice(-40));
+    console.log("New impl in proxy:  ", afterImpl);
+    if (afterImpl.toLowerCase() !== implDeploy.address.toLowerCase()) {
+      throw new Error(`Upgrade did not take effect`);
+    }
+  }
+
+  console.log("\n=== Verifying on Blockscout ===");
+  await verifyContract(implDeploy.address, []);
+
+  console.log("\n=== Upgrade summary ===");
+  console.log("Proxy:                  ", proxyAddress);
+  console.log("Previous impl:          ", beforeImpl);
+  console.log("New impl:               ", implDeploy.address);
+};
+
+export default func;
+func.tags = ["DataRegistryV2UpgradeIdempotentRecord"];

--- a/deploy/dataPortability/dataRegistryV2-upgrade-role-rename.ts
+++ b/deploy/dataPortability/dataRegistryV2-upgrade-role-rename.ts
@@ -1,0 +1,128 @@
+import { deployments, ethers } from "hardhat";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { DeployFunction } from "hardhat-deploy/types";
+import { verifyContract } from "../helpers";
+
+/**
+ * Upgrades DataRegistryV2 to rename FACILITATOR_ROLE -> ACCESS_RECORDER_ROLE.
+ *
+ * Role rename is a CONSTANT change, not a storage change — safe upgrade.
+ * However, the on-chain role hash differs (keccak256("FACILITATOR_ROLE") vs
+ * keccak256("ACCESS_RECORDER_ROLE")), so existing role grants do NOT carry
+ * over. Re-grant ACCESS_RECORDER_ROLE to the previous holder after the upgrade.
+ *
+ * Env vars used:
+ *   DATA_REGISTRY_V2_PROXY       - default 0x0850226E939A5C949633200cf0b1F4665CA74931
+ *   DATA_REGISTRY_FACILITATOR    - address to grant the renamed role to.
+ *                                  Defaults to OWNER_ADDRESS.
+ *   OWNER_ADDRESS                - fallback for the role grant
+ */
+const PROXY_DEFAULT = "0x0850226E939A5C949633200cf0b1F4665CA74931";
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const [deployer] = await ethers.getSigners();
+  const proxyAddress = process.env.DATA_REGISTRY_V2_PROXY ?? PROXY_DEFAULT;
+  const ownerAddress = process.env.OWNER_ADDRESS ?? deployer.address;
+  const recorderAddress = process.env.DATA_REGISTRY_FACILITATOR ?? ownerAddress;
+
+  console.log("Deployer:                       ", deployer.address);
+  console.log("DataRegistryV2 proxy:           ", proxyAddress);
+  console.log("Grant ACCESS_RECORDER_ROLE to:  ", recorderAddress);
+
+  // ----------------------------------------------------------------
+  // 1. Deploy new implementation
+  // ----------------------------------------------------------------
+  console.log("\n=== Deploying new DataRegistryV2Implementation ===");
+  const implDeploy = await deployments.deploy("DataRegistryV2Implementation", {
+    from: deployer.address,
+    args: [],
+    log: true,
+  });
+  console.log("New implementation:  ", implDeploy.address);
+
+  // ----------------------------------------------------------------
+  // 2. Read current impl slot for before snapshot
+  // ----------------------------------------------------------------
+  const IMPL_SLOT = "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc";
+  const beforeImplRaw = await ethers.provider.getStorage(proxyAddress, IMPL_SLOT);
+  const beforeImpl = ethers.getAddress("0x" + beforeImplRaw.slice(-40));
+  console.log("Previous impl:       ", beforeImpl);
+
+  // ----------------------------------------------------------------
+  // 3. Upgrade
+  // ----------------------------------------------------------------
+  if (beforeImpl.toLowerCase() === implDeploy.address.toLowerCase()) {
+    console.log("Already at this implementation — skipping upgrade.");
+  } else {
+    console.log("\n=== Calling upgradeToAndCall on proxy ===");
+    const proxyAsUUPS = await ethers.getContractAt(
+      "DataRegistryV2Implementation",
+      proxyAddress,
+    );
+    const tx = await proxyAsUUPS.connect(deployer).upgradeToAndCall(implDeploy.address, "0x");
+    console.log("upgrade tx:         ", tx.hash);
+    await tx.wait();
+
+    const afterImplRaw = await ethers.provider.getStorage(proxyAddress, IMPL_SLOT);
+    const afterImpl = ethers.getAddress("0x" + afterImplRaw.slice(-40));
+    console.log("New impl in proxy:  ", afterImpl);
+    if (afterImpl.toLowerCase() !== implDeploy.address.toLowerCase()) {
+      throw new Error(
+        `Upgrade did not take effect: proxy impl is ${afterImpl}, expected ${implDeploy.address}`,
+      );
+    }
+  }
+
+  // ----------------------------------------------------------------
+  // 4. Grant ACCESS_RECORDER_ROLE
+  // ----------------------------------------------------------------
+  console.log("\n=== Granting ACCESS_RECORDER_ROLE ===");
+  const ACCESS_RECORDER_ROLE = ethers.keccak256(ethers.toUtf8Bytes("ACCESS_RECORDER_ROLE"));
+  const registry = await ethers.getContractAt(
+    "DataRegistryV2Implementation",
+    proxyAddress,
+  );
+  const hasRole: boolean = await registry.hasRole(ACCESS_RECORDER_ROLE, recorderAddress);
+  if (hasRole) {
+    console.log("Already has ACCESS_RECORDER_ROLE.");
+  } else {
+    const grantTx = await registry
+      .connect(deployer)
+      .grantRole(ACCESS_RECORDER_ROLE, recorderAddress);
+    await grantTx.wait();
+    console.log("grantRole tx:", grantTx.hash);
+  }
+
+  const verifyRole: boolean = await registry.hasRole(ACCESS_RECORDER_ROLE, recorderAddress);
+  if (!verifyRole) {
+    throw new Error(`grantRole failed: ${recorderAddress} does not have ACCESS_RECORDER_ROLE`);
+  }
+  console.log("Role grant verified.");
+
+  // Inform about stale role (old grant on FACILITATOR_ROLE hash). Not removed
+  // automatically — it's harmless (dead storage; new code doesn't check this).
+  const STALE_FACILITATOR = ethers.keccak256(ethers.toUtf8Bytes("FACILITATOR_ROLE"));
+  const stillHasStale: boolean = await registry.hasRole(STALE_FACILITATOR, recorderAddress);
+  if (stillHasStale) {
+    console.log(
+      "Note: stale FACILITATOR_ROLE grant still in storage for",
+      recorderAddress,
+      "— harmless (no code checks it now). Revoke if you want a clean access-control table.",
+    );
+  }
+
+  // ----------------------------------------------------------------
+  // 5. Blockscout verification
+  // ----------------------------------------------------------------
+  console.log("\n=== Verifying new impl on Blockscout ===");
+  await verifyContract(implDeploy.address, []);
+
+  console.log("\n=== Upgrade summary ===");
+  console.log("Proxy:                            ", proxyAddress);
+  console.log("Previous impl:                    ", beforeImpl);
+  console.log("New impl:                         ", implDeploy.address);
+  console.log("ACCESS_RECORDER_ROLE holder:      ", recorderAddress);
+};
+
+export default func;
+func.tags = ["DataRegistryV2UpgradeRoleRename"];

--- a/deploy/dataPortability/dataRegistryV2-upgrade-setStatusWithSignature.ts
+++ b/deploy/dataPortability/dataRegistryV2-upgrade-setStatusWithSignature.ts
@@ -1,0 +1,92 @@
+import { deployments, ethers } from "hardhat";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { DeployFunction } from "hardhat-deploy/types";
+import { verifyContract } from "../helpers";
+
+/**
+ * Upgrades DataRegistryV2 to add `setStatusWithSignature`:
+ *   - new EIP-712 typehash: SET_STATUS_TYPEHASH
+ *   - new view: statusSequence(owner, scope)
+ *   - new write: setStatusWithSignature(owner, scope, newStatus, expectedSequence, signature)
+ *   - new event: StatusSignedByDelegate(id, ownerAddress, delegate)
+ *   - storage append: _statusSequences (UUPS-safe)
+ *
+ * Same dual-signer model as addDataWithSignature: owner OR trusted personal
+ * server. Sequence counter is independent of currentVersion so data writes
+ * and status flips don't invalidate each other's pending signatures.
+ *
+ * Per chain:
+ *   - Moksha:  deployer has admin -> upgradeToAndCall
+ *   - Mainnet: deployer has no admin -> deploys impl only, prints calldata
+ */
+const REGISTRY_PROXY = "0x8f1eFCdff3d0d5BB535e32620721c7EBed151867";
+const MAINNET_ADMIN = "0x5ECA5208F29e32879a711467916965B2D753bAf4";
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const [deployer] = await ethers.getSigners();
+  const chainId = Number(hre.network.config.chainId ?? (await ethers.provider.getNetwork()).chainId);
+
+  console.log("Deployer:        ", deployer.address);
+  console.log("Chain:           ", hre.network.name, `(chainId=${chainId})`);
+  console.log("Registry proxy:  ", REGISTRY_PROXY);
+
+  console.log("\n=== Deploying new DataRegistryV2Implementation ===");
+  const implDeploy = await deployments.deploy("DataRegistryV2Implementation", {
+    from: deployer.address,
+    args: [],
+    log: true,
+  });
+  console.log("New impl:        ", implDeploy.address);
+
+  const IMPL_SLOT = "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc";
+  const beforeRaw = await ethers.provider.getStorage(REGISTRY_PROXY, IMPL_SLOT);
+  const beforeImpl = ethers.getAddress("0x" + beforeRaw.slice(-40));
+  console.log("Current impl:    ", beforeImpl);
+  if (beforeImpl.toLowerCase() === implDeploy.address.toLowerCase()) {
+    console.log("Already at this implementation — nothing to do.");
+    return;
+  }
+
+  const DEFAULT_ADMIN_ROLE = "0x" + "00".repeat(32);
+  const proxyAsImpl = await ethers.getContractAt("DataRegistryV2Implementation", REGISTRY_PROXY);
+  const canUpgrade: boolean = await proxyAsImpl.hasRole(DEFAULT_ADMIN_ROLE, deployer.address);
+
+  if (canUpgrade) {
+    console.log("\n=== Deployer has admin — performing upgradeToAndCall ===");
+    const tx = await proxyAsImpl.connect(deployer).upgradeToAndCall(implDeploy.address, "0x");
+    console.log("upgrade tx:      ", tx.hash);
+    await tx.wait();
+
+    const afterRaw = await ethers.provider.getStorage(REGISTRY_PROXY, IMPL_SLOT);
+    const afterImpl = ethers.getAddress("0x" + afterRaw.slice(-40));
+    if (afterImpl.toLowerCase() !== implDeploy.address.toLowerCase()) {
+      throw new Error(`Upgrade did not take effect: ${afterImpl}`);
+    }
+    console.log("Confirmed: proxy now at", afterImpl);
+
+    // Sanity-check new surface.
+    const typehash = await proxyAsImpl.SET_STATUS_TYPEHASH();
+    console.log("SET_STATUS_TYPEHASH:", typehash);
+  } else {
+    const admin = await proxyAsImpl.hasRole(DEFAULT_ADMIN_ROLE, MAINNET_ADMIN);
+    console.log("\n=== Deployer does NOT have admin ===");
+    if (admin) console.log(`Confirmed: ${MAINNET_ADMIN} has DEFAULT_ADMIN_ROLE.`);
+    console.log("Calldata for admin wallet:");
+    const iface = new ethers.Interface(["function upgradeToAndCall(address,bytes)"]);
+    const data = iface.encodeFunctionData("upgradeToAndCall", [implDeploy.address, "0x"]);
+    console.log("  to:    " + REGISTRY_PROXY);
+    console.log("  data:  " + data);
+    console.log("  value: 0");
+  }
+
+  console.log("\n=== Verifying new impl on Blockscout ===");
+  await verifyContract(implDeploy.address, []);
+
+  console.log("\n=== Summary ===");
+  console.log("Proxy:           ", REGISTRY_PROXY);
+  console.log("Previous impl:   ", beforeImpl);
+  console.log("New impl:        ", implDeploy.address);
+};
+
+export default func;
+func.tags = ["DataRegistryV2UpgradeSetStatusWithSignature"];

--- a/scripts/check-data-access-fee.ts
+++ b/scripts/check-data-access-fee.ts
@@ -1,0 +1,31 @@
+import { ethers } from "hardhat";
+
+const FEE_REGISTRY = "0xb4FA18443E0FA6cdC0280D20b8cCDB2377D13Bf2";
+
+async function main() {
+  const chainId = Number((await ethers.provider.getNetwork()).chainId);
+  console.log("chainId:        ", chainId);
+  console.log("FeeRegistry:    ", FEE_REGISTRY);
+
+  const fr = await ethers.getContractAt("FeeRegistryImplementation", FEE_REGISTRY);
+
+  const candidates = ["DATA_ACCESS", "DataAccess", "data_access", "RECORD_DATA_ACCESS", "DATA_ACCESS_FEE"];
+  for (const name of candidates) {
+    const key = await fr.operationKey(name);
+    const registered: boolean = await fr.isFeeRegistered(key);
+    if (!registered) {
+      console.log(`\n${name}  →  ${key}  → not registered`);
+      continue;
+    }
+    const fee = await fr.fees(key);
+    const amount: bigint = await fr.feeAmount(key);
+    console.log(`\n${name}  →  ${key}`);
+    console.log(`  registered: true`);
+    console.log(`  amount:     ${amount} (${ethers.formatEther(amount)} VANA-equivalent)`);
+    console.log(`  asset:      ${fee.asset}${fee.asset === ethers.ZeroAddress ? "  (native VANA)" : ""}`);
+    console.log(`  payee:      ${fee.payee}`);
+    console.log(`  enabled:    ${fee.enabled}`);
+  }
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/check-dataregistry-moksha-parity.ts
+++ b/scripts/check-dataregistry-moksha-parity.ts
@@ -1,0 +1,126 @@
+import { ethers, artifacts } from "hardhat";
+
+/**
+ * Compare current DataRegistryV2Implementation source against the live impl
+ * deployed on Moksha (the proxy at 0x8f1e…1867). The live impl is whatever
+ * the ERC1967 IMPLEMENTATION_SLOT currently points at.
+ *
+ * Strategy:
+ *   1. Read live impl bytecode from Moksha.
+ *   2. Compile from current source -> deployedBytecode.
+ *   3. Strip the variable-length CBOR metadata trailer from both
+ *      (last 2 bytes encode metadata length).
+ *   4. Hash + compare. If they match: source == deployed. If they differ,
+ *      slide a window through both to find the first hex divergence so we
+ *      can tell whether the diff is metadata-only or substantive.
+ */
+
+const IMPL_SLOT = "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc";
+const REGISTRY_PROXY = "0x8f1eFCdff3d0d5BB535e32620721c7EBed151867";
+
+function stripMetadata(bc: string): { stripped: string; metaLen: number } {
+  if (!bc.startsWith("0x")) bc = "0x" + bc;
+  if (bc.length <= 6) return { stripped: bc.toLowerCase(), metaLen: 0 };
+  const metaLen = parseInt(bc.slice(-4), 16);
+  if (Number.isNaN(metaLen) || metaLen <= 0 || metaLen > 2048) {
+    return { stripped: bc.toLowerCase(), metaLen: 0 };
+  }
+  const trailerHex = (metaLen + 2) * 2;
+  if (bc.length - 2 <= trailerHex) return { stripped: bc.toLowerCase(), metaLen };
+  return { stripped: bc.slice(0, bc.length - trailerHex).toLowerCase(), metaLen };
+}
+
+function firstDivergence(a: string, b: string): number {
+  const n = Math.min(a.length, b.length);
+  for (let i = 0; i < n; i++) if (a[i] !== b[i]) return i;
+  return n;
+}
+
+async function main() {
+  const chainId = Number((await ethers.provider.getNetwork()).chainId);
+  if (chainId !== 14800) {
+    console.error("Run with --network moksha (chainId 14800). Got:", chainId);
+    process.exit(1);
+  }
+
+  // 1. Live impl pointer
+  const raw = await ethers.provider.getStorage(REGISTRY_PROXY, IMPL_SLOT);
+  const liveImpl = ethers.getAddress("0x" + raw.slice(-40));
+  console.log("Proxy:        ", REGISTRY_PROXY);
+  console.log("Live impl:    ", liveImpl);
+
+  // 2. Onchain bytecode
+  const liveBc = await ethers.provider.getCode(liveImpl);
+
+  // 3. Source compile
+  const art = await artifacts.readArtifact("DataRegistryV2Implementation");
+  const sourceBc = art.deployedBytecode;
+
+  console.log("\nBytecode lengths (hex chars):");
+  console.log("  live:    ", liveBc.length);
+  console.log("  source:  ", sourceBc.length);
+
+  const live = stripMetadata(liveBc);
+  const source = stripMetadata(sourceBc);
+
+  console.log("\nMetadata trailer lengths (bytes):");
+  console.log("  live:    ", live.metaLen);
+  console.log("  source:  ", source.metaLen);
+
+  console.log("\nStripped bytecode lengths (hex chars):");
+  console.log("  live:    ", live.stripped.length);
+  console.log("  source:  ", source.stripped.length);
+
+  console.log("\nHashes:");
+  console.log("  live   (raw     keccak):", ethers.keccak256(liveBc));
+  console.log("  source (raw     keccak):", ethers.keccak256(sourceBc));
+  console.log("  live   (stripped keccak):", ethers.keccak256(live.stripped));
+  console.log("  source (stripped keccak):", ethers.keccak256(source.stripped));
+
+  if (live.stripped === source.stripped) {
+    console.log("\n✓ MATCH — current source compiles to byte-for-byte the deployed runtime (modulo metadata).");
+    return;
+  }
+
+  // The UUPS __self immutable bakes `address(this)` (= the impl address) into
+  // the runtime bytecode at every reference site. Source bytecode has zeros
+  // where the immutable would go. To compare logical source, replace every
+  // occurrence of the impl address in live with zeros, then diff.
+  const a = live.stripped;
+  const b = source.stripped;
+  const implHex = liveImpl.slice(2).toLowerCase(); // 40 chars
+  const zeros = "0".repeat(40);
+
+  // Count occurrences of impl address in live bytecode.
+  const occurrences = (a.match(new RegExp(implHex, "g")) ?? []).length;
+  console.log(`\nImpl address (${implHex}) occurrences in live bytecode: ${occurrences}`);
+  console.log("(These are UUPS __self immutable references baked in by the constructor.)");
+
+  // Substitute and recompare.
+  const aNormalized = a.replaceAll(implHex, zeros);
+  const matches = aNormalized === b;
+  console.log("\nAfter substituting impl address with zeros in live bytecode:");
+  console.log("  normalized live keccak:", ethers.keccak256(aNormalized));
+  console.log("  source     keccak:    ", ethers.keccak256(b));
+  console.log("  match:                ", matches ? "✓ YES" : "✗ NO");
+
+  if (matches) {
+    console.log("\n✓ SOURCE MATCHES DEPLOYED — every byte of divergence is the UUPS __self immutable.");
+    console.log("  Conclusion: nothing was removed or altered in DataRegistryV2Implementation.sol.");
+    console.log("  The Moksha-deployed contract IS what the current source compiles to.");
+    return;
+  }
+
+  // If still not matching, find remaining divergences for inspection.
+  console.log("\n✗ Residual divergence after immutable substitution. Investigating…");
+  for (let i = 0; i < Math.min(aNormalized.length, b.length); i++) {
+    if (aNormalized[i] !== b[i]) {
+      console.log(`  First differing hex char at offset ${i}`);
+      console.log(`  live (normalized): ${aNormalized.slice(Math.max(0, i - 16), i + 64)}`);
+      console.log(`  source:            ${b.slice(Math.max(0, i - 16), i + 64)}`);
+      break;
+    }
+  }
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/check-grantees-admin.ts
+++ b/scripts/check-grantees-admin.ts
@@ -1,0 +1,29 @@
+import { ethers } from "hardhat";
+const GRANTEES_PROXY = "0x8325C0A0948483EdA023A1A2Fd895e62C5131234";
+const DEFAULT_ADMIN_ROLE = "0x" + "00".repeat(32);
+
+async function main() {
+  const c = await ethers.getContractAt("DataPortabilityGranteesImplementation", GRANTEES_PROXY);
+  // Try to identify admin holders via DEFAULT_ADMIN_ROLE
+  // (no Enumerable extension expected — just probe known candidates)
+  const candidates = [
+    "0x5ECA5208F29e32879a711467916965B2D753bAf4", // canonical mainnet admin
+    "0x247f35279A32d2A5aD2F4ca5dD81fc150f2355B3", // deployer
+    "0x2AC93684679a5bdA03C6160def908CdB8D46792f", // old Moksha admin
+  ];
+  for (const addr of candidates) {
+    try {
+      const ok = await c.hasRole(DEFAULT_ADMIN_ROLE, addr);
+      console.log(`${addr}: ${ok ? "✓ has DEFAULT_ADMIN_ROLE" : "—"}`);
+    } catch (e) {
+      console.log(`${addr}: error (${(e as Error).message.slice(0,50)})`);
+    }
+  }
+
+  // Also probe the iface version
+  try {
+    const v = await c.version();
+    console.log(`version(): ${v}`);
+  } catch {}
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/check-grantor.ts
+++ b/scripts/check-grantor.ts
@@ -1,0 +1,68 @@
+import { ethers } from "hardhat";
+
+const PERMISSIONS_PROXY = "0x4d3FA76064D88e0454cFc4CaD7e5FeC3e3124011";
+const SERVERS_PROXY = "0xCae2CE0e9caa6643ed28186cF57bd40Bd9E17Eab";
+const GRANTOR = "0x0eDE268f40B4c21D139E1B454C901C5B16E6cBFb";
+const SIGNATURE = "0x415cba2328d2eb8fdd224975eb5427568bf3b5265cc22c0b3ec0a78bf852bede3bec84bcc72527386ddd246cf22ca36e63346dd3ea016982d5bf849fd0fb0d5d1c";
+
+async function main() {
+  const chainId = Number((await ethers.provider.getNetwork()).chainId);
+  console.log("chainId:", chainId);
+
+  // 1. Confirm what the contract sees
+  const perms = await ethers.getContractAt("DataPortabilityPermissionsV2Implementation", PERMISSIONS_PROXY);
+  console.log("perms.dataPortabilityServers():", await perms.dataPortabilityServers());
+  console.log("perms.domainSeparator():       ", await perms.domainSeparator());
+
+  // 2. Recover the signer using the CONTRACT's domain separator
+  const typeHash = await perms.GRANT_REGISTRATION_TYPEHASH();
+  const input = {
+    grantorAddress: GRANTOR,
+    granteeId: "0xc9b8f9a587defe5aa07b029aac99efea5c63ac64004a3ae88e2d21b63da30ccf",
+    scopes: ["instagram.profile"],
+    grantVersion: 1n,
+    expiresAt: 0n,
+  };
+
+  const scopesHash = ethers.keccak256(
+    ethers.concat(input.scopes.map((s) => ethers.keccak256(ethers.toUtf8Bytes(s))))
+  );
+  const structHash = ethers.keccak256(
+    ethers.AbiCoder.defaultAbiCoder().encode(
+      ["bytes32", "address", "bytes32", "bytes32", "uint256", "uint256"],
+      [typeHash, input.grantorAddress, input.granteeId, scopesHash, input.grantVersion, input.expiresAt],
+    ),
+  );
+  const domainSeparator = await perms.domainSeparator();
+  const digest = ethers.keccak256(
+    ethers.concat(["0x1901", domainSeparator, structHash]),
+  );
+  const recovered = ethers.recoverAddress(digest, SIGNATURE);
+  console.log("\ndigest:    ", digest);
+  console.log("recovered: ", recovered);
+  console.log("grantor:   ", GRANTOR);
+  console.log("match grantor?", recovered.toLowerCase() === GRANTOR.toLowerCase());
+
+  // 3. Check the recovered address against the servers registry
+  const servers = await ethers.getContractAt("DataPortabilityServersV2Implementation", SERVERS_PROXY);
+  const activeId = await servers.activeServerId(recovered);
+  console.log("\nactiveServerId(recovered):", activeId);
+  if (activeId !== ethers.ZeroHash) {
+    const info = await servers.getServer(activeId);
+    console.log("server owner:             ", info.ownerAddress);
+    console.log("trusted for grantor?      ", info.ownerAddress.toLowerCase() === GRANTOR.toLowerCase());
+  }
+
+  // 4. Enumerate every server the grantor has registered
+  const owned = await servers.ownerServers(GRANTOR);
+  console.log("\nServers registered by grantor", GRANTOR + ":");
+  if (owned.length === 0) {
+    console.log("  <none>");
+  } else {
+    for (const s of owned) {
+      console.log(`  serverId=${s.id}  serverAddress=${s.serverAddress}  revokedAtBlock=${s.revokedAtBlock}`);
+    }
+  }
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/check-mainnet-impls.ts
+++ b/scripts/check-mainnet-impls.ts
@@ -1,0 +1,60 @@
+import { ethers } from "hardhat";
+
+const IMPL_SLOT = "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc";
+
+const CONTRACTS: { name: string; proxy: string; expectedImpl: string }[] = [
+  {
+    name: "Escrow",
+    proxy: "0x07d7769081adc3a3DBe91f5E4B98E9A5a6B292e3",
+    expectedImpl: "0x3d675c462B5DB6Ab2850901f008fE0b949eA7B5A",
+  },
+  {
+    name: "PermissionsV2",
+    proxy: "0x4d3FA76064D88e0454cFc4CaD7e5FeC3e3124011",
+    expectedImpl: "0x4E71094c8cd2065F1C0C85e978d7f53B79B1AA84",
+  },
+  {
+    name: "DataRegistryV2",
+    proxy: "0x8f1eFCdff3d0d5BB535e32620721c7EBed151867",
+    expectedImpl: "0xFa48B6E19B177C1c0A8E19Af7A2e0e8E64640C54",
+  },
+  {
+    name: "ServersV2",
+    proxy: "0xCae2CE0e9caa6643ed28186cF57bd40Bd9E17Eab",
+    expectedImpl: "0x97537454751eE1A649C92Ac1BA7D0E4a9E90D1fd",
+  },
+  {
+    name: "FeeRegistry",
+    proxy: "0xb4FA18443E0FA6cdC0280D20b8cCDB2377D13Bf2",
+    expectedImpl: "0x3A95fC4B4FE7Ca6e83dE71B4D9Afe6D2D92Afef8",
+  },
+];
+
+async function main() {
+  const chainId = Number((await ethers.provider.getNetwork()).chainId);
+  console.log("chainId:", chainId);
+  console.log();
+
+  for (const c of CONTRACTS) {
+    const raw = await ethers.provider.getStorage(c.proxy, IMPL_SLOT);
+    const live = ethers.getAddress("0x" + raw.slice(-40));
+    const matches = live.toLowerCase() === c.expectedImpl.toLowerCase();
+    console.log(c.name.padEnd(16), "live:", live, matches ? "  ✓ at latest" : "  ⚠ NEEDS UPGRADE");
+    if (!matches) console.log(" ".repeat(16), "want:", c.expectedImpl);
+  }
+
+  // Also check PermissionsV2.dataPortabilityServers wiring (matters even after the impl is live)
+  console.log();
+  const perms = await ethers.getContractAt(
+    "DataPortabilityPermissionsV2Implementation",
+    "0x4d3FA76064D88e0454cFc4CaD7e5FeC3e3124011",
+  );
+  try {
+    const wired = await perms.dataPortabilityServers();
+    console.log("PermissionsV2.dataPortabilityServers():", wired);
+  } catch (e) {
+    console.log("PermissionsV2.dataPortabilityServers(): function not callable (proxy still on old impl)");
+  }
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/check-three-contracts.ts
+++ b/scripts/check-three-contracts.ts
@@ -1,0 +1,117 @@
+import { ethers, artifacts } from "hardhat";
+
+/**
+ * Detailed up-to-date check for ServersV2, FeeRegistry, DataPortabilityGrantees on Vana mainnet.
+ *
+ * For each, compare:
+ *   - Live impl bytecode (onchain, at the proxy's IMPLEMENTATION_SLOT)
+ *   - "Latest tracked" impl bytecode (onchain, at the address stored in *Implementation.json)
+ *   - Current source compile (artifacts/.../*.sol/Implementation.json deployedBytecode)
+ *
+ * Metadata is stripped before comparison using the variable-length CBOR trailer
+ * convention (last 2 bytes encode metadata length).
+ */
+
+const IMPL_SLOT = "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc";
+
+const TARGETS = [
+  {
+    name: "DataPortabilityServersV2",
+    proxy: "0xCae2CE0e9caa6643ed28186cF57bd40Bd9E17Eab",
+    implContract: "DataPortabilityServersV2Implementation",
+  },
+  {
+    name: "FeeRegistry",
+    proxy: "0xb4FA18443E0FA6cdC0280D20b8cCDB2377D13Bf2",
+    implContract: "FeeRegistryImplementation",
+  },
+  {
+    name: "DataPortabilityGrantees",
+    proxy: "0x8325C0A0948483EdA023A1A2Fd895e62C5131234",
+    implContract: "DataPortabilityGranteesImplementation",
+  },
+];
+
+const TRACKED_IMPL: Record<string, string> = {
+  DataPortabilityServersV2: "0x97537454751eE1A649C92Ac1BA7D0E4a9E90D1fd",
+  FeeRegistry: "0x3A95fC4B4FE7Ca6e83dE71B4D9Afe6D2D92Afef8",
+  DataPortabilityGrantees: "0x69A1bEeee1aA8d7A4b853FF1001DF510e867b577",
+};
+
+function stripMetadata(bc: string): string {
+  if (!bc) return "";
+  if (!bc.startsWith("0x")) bc = "0x" + bc;
+  if (bc.length <= 6) return bc.toLowerCase();
+  const metadataLen = parseInt(bc.slice(-4), 16);
+  if (Number.isNaN(metadataLen) || metadataLen <= 0 || metadataLen > 2048) return bc.toLowerCase();
+  const totalTrailerHexChars = (metadataLen + 2) * 2;
+  if (bc.length - 2 <= totalTrailerHexChars) return bc.toLowerCase();
+  return bc.slice(0, bc.length - totalTrailerHexChars).toLowerCase();
+}
+
+async function main() {
+  const network = await ethers.provider.getNetwork();
+  if (Number(network.chainId) !== 1480) {
+    console.error("Run with --network vana");
+    process.exit(1);
+  }
+
+  for (const t of TARGETS) {
+    console.log("=".repeat(70));
+    console.log(t.name);
+    console.log("=".repeat(70));
+    console.log(`proxy:           ${t.proxy}`);
+
+    const raw = await ethers.provider.getStorage(t.proxy, IMPL_SLOT);
+    const liveImpl = ethers.getAddress("0x" + raw.slice(-40));
+    const trackedImpl = TRACKED_IMPL[t.name];
+
+    console.log(`live impl:       ${liveImpl}`);
+    console.log(`tracked impl:    ${trackedImpl}`);
+    console.log(`pointer match:   ${liveImpl.toLowerCase() === trackedImpl.toLowerCase() ? "✓ YES" : "✗ NO — needs upgrade"}`);
+
+    const liveBc = await ethers.provider.getCode(liveImpl);
+    const trackedBc = liveImpl.toLowerCase() === trackedImpl.toLowerCase()
+      ? liveBc
+      : await ethers.provider.getCode(trackedImpl);
+
+    let sourceBc: string | null = null;
+    try {
+      const a = await artifacts.readArtifact(t.implContract);
+      sourceBc = a.deployedBytecode;
+    } catch (e) {
+      console.log(`current source:  could not compile ${t.implContract}: ${(e as Error).message}`);
+    }
+
+    const liveStripped = stripMetadata(liveBc);
+    const trackedStripped = stripMetadata(trackedBc);
+    const sourceStripped = sourceBc ? stripMetadata(sourceBc) : null;
+
+    console.log(`live bytecode (stripped) hash:    ${ethers.id(liveStripped).slice(0, 18)}…`);
+    console.log(`tracked bytecode (stripped) hash: ${ethers.id(trackedStripped).slice(0, 18)}…`);
+    if (sourceStripped) {
+      console.log(`source bytecode (stripped) hash:  ${ethers.id(sourceStripped).slice(0, 18)}…`);
+    }
+
+    console.log();
+    console.log("Verdict:");
+    if (liveStripped === trackedStripped && sourceStripped && liveStripped === sourceStripped) {
+      console.log("  ✓ UP TO DATE — live impl matches tracked impl AND current source.");
+    } else if (liveStripped !== trackedStripped) {
+      console.log(`  ✗ PROXY POINTS AT OLDER IMPL — newer impl ${trackedImpl} is deployed`);
+      if (sourceStripped && trackedStripped === sourceStripped) {
+        console.log("  ↳ tracked impl matches current source — upgrade activates the latest code");
+      } else if (sourceStripped && trackedStripped !== sourceStripped) {
+        console.log("  ↳ tracked impl ALSO differs from current source — source is ahead of both");
+      }
+    } else if (sourceStripped && liveStripped !== sourceStripped) {
+      console.log("  ⚠ live impl matches tracked impl but DIFFERS from current source");
+      console.log("  ↳ source has been modified since last deploy — redeploy + upgrade needed");
+    } else {
+      console.log("  ? Cannot conclude — source bytecode unavailable");
+    }
+    console.log();
+  }
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/check-vana-mainnet-impls.ts
+++ b/scripts/check-vana-mainnet-impls.ts
@@ -1,0 +1,211 @@
+import { ethers, artifacts } from "hardhat";
+import * as fs from "fs";
+import * as path from "path";
+
+/**
+ * Cross-check every proxy on Vana mainnet:
+ *
+ *   A. liveImplPointer        — proxy's ERC1967 IMPLEMENTATION_SLOT
+ *   B. latestDeployedImpl     — address recorded in *Implementation.json artifact
+ *   C. artifactBytecode       — deployedBytecode in *Implementation.json
+ *   D. currentSourceBytecode  — deployedBytecode from compiling current source
+ *
+ * Drift states:
+ *   AT_LATEST_NEEDS_REDEPLOY  — A == B, but C != D (source moved ahead; needs new impl + upgrade)
+ *   IMPL_DRIFT                — A != B  (new impl exists, proxy not upgraded yet)
+ *   AT_LATEST                 — A == B AND C == D (everything in sync)
+ *   BYTECODE_DRIFT_LIVE       — A == B but live runtime bytecode differs from artifact bytecode
+ *                               (artifact is stale relative to what's actually onchain)
+ */
+
+const IMPL_SLOT = "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc";
+const DEPLOY_DIRS = [
+  path.resolve(__dirname, "../deployments/vana"),
+  path.resolve(__dirname, "../deployments-official/vana"),
+];
+
+interface ArtifactJson {
+  address?: string;
+  deployedBytecode?: string;
+  contractName?: string;
+}
+
+function readJson(p: string): ArtifactJson | null {
+  try {
+    return JSON.parse(fs.readFileSync(p, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function findArtifact(name: string): { artifact: ArtifactJson; source: string } | null {
+  for (const dir of DEPLOY_DIRS) {
+    const p = path.join(dir, `${name}.json`);
+    if (fs.existsSync(p)) {
+      const a = readJson(p);
+      if (a) return { artifact: a, source: path.basename(dir) };
+    }
+  }
+  return null;
+}
+
+function stripMetadata(bc: string): string {
+  // Solc appends a CBOR-encoded metadata block at the end of deployed bytecode.
+  // The last 2 bytes encode the length (big-endian) of the metadata in bytes.
+  // Total trailer = metadataLen + 2 (the length suffix).
+  if (!bc.startsWith("0x")) bc = "0x" + bc;
+  if (bc.length <= 6) return bc.toLowerCase();
+  const lengthHex = bc.slice(-4);
+  const metadataLen = parseInt(lengthHex, 16);
+  if (Number.isNaN(metadataLen) || metadataLen <= 0 || metadataLen > 2048) {
+    return bc.toLowerCase();
+  }
+  const totalTrailerHexChars = (metadataLen + 2) * 2;
+  if (bc.length - 2 <= totalTrailerHexChars) return bc.toLowerCase();
+  return bc.slice(0, bc.length - totalTrailerHexChars).toLowerCase();
+}
+
+function enumerateProxies(): { base: string; proxyAddress: string }[] {
+  const out: { base: string; proxyAddress: string }[] = [];
+  const seen = new Set<string>();
+  for (const dir of DEPLOY_DIRS) {
+    if (!fs.existsSync(dir)) continue;
+    for (const f of fs.readdirSync(dir)) {
+      if (!f.endsWith("Proxy.json")) continue;
+      const base = f.replace(/Proxy\.json$/, "");
+      if (seen.has(base)) continue;
+      seen.add(base);
+      // Skip Test proxies
+      if (/Test$/.test(base)) continue;
+      const a = readJson(path.join(dir, f));
+      if (a?.address) out.push({ base, proxyAddress: a.address });
+    }
+  }
+  return out.sort((a, b) => a.base.localeCompare(b.base));
+}
+
+async function tryCompileSourceBytecode(contractName: string): Promise<string | null> {
+  // Try the impl name variants in order
+  const candidates = [contractName + "Implementation", contractName];
+  for (const c of candidates) {
+    try {
+      const art = await artifacts.readArtifact(c);
+      if (art.deployedBytecode && art.deployedBytecode !== "0x") return art.deployedBytecode;
+    } catch {
+      /* try next */
+    }
+  }
+  return null;
+}
+
+async function main() {
+  const network = await ethers.provider.getNetwork();
+  if (Number(network.chainId) !== 1480) {
+    console.error("Run with --network vana (chainId 1480). Got:", network.chainId);
+    process.exit(1);
+  }
+
+  const proxies = enumerateProxies();
+  console.log(`Proxies enumerated: ${proxies.length}`);
+  console.log();
+
+  type Row = {
+    name: string;
+    proxy: string;
+    liveImpl: string;
+    latestImpl: string | null;
+    pointerMatch: boolean;
+    artifactBytecodeMatchesLive: boolean | null;
+    sourceMatchesArtifact: boolean | null;
+    state: string;
+  };
+  const rows: Row[] = [];
+
+  for (const { base, proxyAddress } of proxies) {
+    // Live impl pointer
+    let liveImpl: string;
+    try {
+      const raw = await ethers.provider.getStorage(proxyAddress, IMPL_SLOT);
+      liveImpl = ethers.getAddress("0x" + raw.slice(-40));
+    } catch {
+      continue;
+    }
+    if (liveImpl === ethers.ZeroAddress) continue; // not ERC1967
+
+    // Latest deployed impl per artifact
+    const implArt = findArtifact(base + "Implementation");
+    const latestImpl = implArt?.artifact.address ?? null;
+    const pointerMatch =
+      latestImpl !== null && liveImpl.toLowerCase() === latestImpl.toLowerCase();
+
+    // Bytecode: artifact vs live impl
+    let artifactBytecodeMatchesLive: boolean | null = null;
+    try {
+      const liveBytecode = await ethers.provider.getCode(liveImpl);
+      if (implArt?.artifact.deployedBytecode) {
+        artifactBytecodeMatchesLive =
+          stripMetadata(liveBytecode) === stripMetadata(implArt.artifact.deployedBytecode);
+      }
+    } catch {}
+
+    // Bytecode: source vs artifact (does current compile match what's tracked?)
+    let sourceMatchesArtifact: boolean | null = null;
+    const sourceBytecode = await tryCompileSourceBytecode(base);
+    if (sourceBytecode && implArt?.artifact.deployedBytecode) {
+      sourceMatchesArtifact =
+        stripMetadata(sourceBytecode) === stripMetadata(implArt.artifact.deployedBytecode);
+    }
+
+    let state: string;
+    if (!pointerMatch) state = "IMPL_DRIFT";
+    else if (artifactBytecodeMatchesLive === false) state = "BYTECODE_DRIFT_LIVE";
+    else if (sourceMatchesArtifact === false) state = "AT_LATEST_NEEDS_REDEPLOY";
+    else if (sourceMatchesArtifact === null) state = "AT_LATEST_NO_SOURCE";
+    else state = "AT_LATEST";
+
+    rows.push({
+      name: base,
+      proxy: proxyAddress,
+      liveImpl,
+      latestImpl,
+      pointerMatch,
+      artifactBytecodeMatchesLive,
+      sourceMatchesArtifact,
+      state,
+    });
+  }
+
+  const byState: Record<string, Row[]> = {};
+  for (const r of rows) (byState[r.state] ??= []).push(r);
+
+  const print = (title: string, list?: Row[]) => {
+    console.log("===== " + title + " (" + (list?.length ?? 0) + ") =====");
+    if (!list || list.length === 0) return;
+    for (const r of list) {
+      console.log(`  ${r.name}`);
+      console.log(`    proxy:        ${r.proxy}`);
+      console.log(`    live impl:    ${r.liveImpl}`);
+      if (r.latestImpl) console.log(`    latest impl:  ${r.latestImpl}`);
+    }
+    console.log();
+  };
+
+  print("IMPL_DRIFT — proxy needs upgradeToAndCall", byState.IMPL_DRIFT);
+  print("AT_LATEST_NEEDS_REDEPLOY — source ahead of mainnet, redeploy + upgrade", byState.AT_LATEST_NEEDS_REDEPLOY);
+  print("BYTECODE_DRIFT_LIVE — artifact bytecode does not match what's actually onchain", byState.BYTECODE_DRIFT_LIVE);
+  print("AT_LATEST — proxy + source in sync", byState.AT_LATEST);
+  print("AT_LATEST_NO_SOURCE — could not compile from current source (legacy / removed)", byState.AT_LATEST_NO_SOURCE);
+
+  console.log("Summary:");
+  for (const s of [
+    "IMPL_DRIFT",
+    "AT_LATEST_NEEDS_REDEPLOY",
+    "BYTECODE_DRIFT_LIVE",
+    "AT_LATEST",
+    "AT_LATEST_NO_SOURCE",
+  ]) {
+    console.log(`  ${s.padEnd(26)} ${byState[s]?.length ?? 0}`);
+  }
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/test/data/dataRegistryV2.ts
+++ b/test/data/dataRegistryV2.ts
@@ -1,0 +1,1959 @@
+import chai, { expect, should } from "chai";
+import chaiAsPromised from "chai-as-promised";
+import { ethers, upgrades } from "hardhat";
+import { time } from "@nomicfoundation/hardhat-network-helpers";
+import {
+  DataRegistryV2Implementation,
+  DataPortabilityServersV2Implementation,
+} from "../../typechain-types";
+import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers";
+
+chai.use(chaiAsPromised);
+should();
+
+describe("DataRegistryV2", () => {
+  let deployer: HardhatEthersSigner;
+  let owner: HardhatEthersSigner; // admin of the registry
+  let user1: HardhatEthersSigner; // data owner
+  let user2: HardhatEthersSigner; // second data owner
+  let relayer: HardhatEthersSigner; // submits signed txs
+  let recorder: HardhatEthersSigner; // holds ACCESS_RECORDER_ROLE
+  let server1: HardhatEthersSigner; // personal server key
+  let server2: HardhatEthersSigner; // second personal server key
+  let other: HardhatEthersSigner; // unrelated key
+
+  let registry: DataRegistryV2Implementation;
+  let servers: DataPortabilityServersV2Implementation;
+
+  const DEFAULT_ADMIN_ROLE =
+    "0x0000000000000000000000000000000000000000000000000000000000000000";
+  const ACCESS_RECORDER_ROLE = ethers.keccak256(
+    ethers.toUtf8Bytes("ACCESS_RECORDER_ROLE"),
+  );
+
+  // Status enum
+  const Status = { None: 0n, Active: 1n, Inactive: 2n, Unavailable: 3n };
+
+  const abiCoder = ethers.AbiCoder.defaultAbiCoder();
+
+  const SCOPE = "instagram.profile";
+  const DATA_HASH = ethers.keccak256(ethers.toUtf8Bytes("data-1"));
+  const META_HASH = ethers.keccak256(ethers.toUtf8Bytes("meta-1"));
+  const DATA_HASH_2 = ethers.keccak256(ethers.toUtf8Bytes("data-2"));
+  const META_HASH_2 = ethers.keccak256(ethers.toUtf8Bytes("meta-2"));
+
+  const dpId = (ownerAddress: string, scope: string) =>
+    ethers.keccak256(
+      abiCoder.encode(["address", "string"], [ownerAddress, scope]),
+    );
+
+  const commitmentOf = (dataHash: string, metadataHash: string) =>
+    ethers.keccak256(
+      abiCoder.encode(["bytes32", "bytes32"], [dataHash, metadataHash]),
+    );
+
+  // ====================== EIP-712 helpers ======================
+
+  const eip712Domain = async (verifyingContract: string) => ({
+    name: "Vana Data Portability",
+    version: "1",
+    chainId: (await ethers.provider.getNetwork()).chainId,
+    verifyingContract,
+  });
+
+  const AddDataTypes = {
+    AddData: [
+      { name: "ownerAddress", type: "address" },
+      { name: "scope", type: "string" },
+      { name: "dataHash", type: "bytes32" },
+      { name: "metadataHash", type: "bytes32" },
+      { name: "expectedVersion", type: "uint256" },
+    ],
+  };
+
+  const RecordDataAccessTypes = {
+    RecordDataAccess: [
+      { name: "ownerAddress", type: "address" },
+      { name: "scope", type: "string" },
+      { name: "version", type: "uint256" },
+      { name: "accessor", type: "address" },
+      { name: "recordId", type: "bytes32" },
+    ],
+  };
+
+  const SetStatusTypes = {
+    SetStatus: [
+      { name: "ownerAddress", type: "address" },
+      { name: "scope", type: "string" },
+      { name: "newStatus", type: "uint8" },
+      { name: "expectedSequence", type: "uint256" },
+    ],
+  };
+
+  const ServerRegistrationTypes = {
+    ServerRegistration: [
+      { name: "ownerAddress", type: "address" },
+      { name: "serverAddress", type: "address" },
+      { name: "publicKey", type: "string" },
+      { name: "serverUrl", type: "string" },
+    ],
+  };
+
+  const ServerDeregistrationTypes = {
+    ServerDeregistration: [
+      { name: "ownerAddress", type: "address" },
+      { name: "serverAddress", type: "address" },
+      { name: "serverId", type: "bytes32" },
+      { name: "deadline", type: "uint256" },
+    ],
+  };
+
+  const signAddData = async (
+    signer: HardhatEthersSigner,
+    ownerAddress: string,
+    scope: string,
+    dataHash: string,
+    metadataHash: string,
+    expectedVersion: bigint,
+  ) =>
+    signer.signTypedData(
+      await eip712Domain(await registry.getAddress()),
+      AddDataTypes,
+      { ownerAddress, scope, dataHash, metadataHash, expectedVersion },
+    );
+
+  const signSetStatus = async (
+    signer: HardhatEthersSigner,
+    ownerAddress: string,
+    scope: string,
+    newStatus: bigint,
+    expectedSequence: bigint,
+  ) =>
+    signer.signTypedData(
+      await eip712Domain(await registry.getAddress()),
+      SetStatusTypes,
+      { ownerAddress, scope, newStatus, expectedSequence },
+    );
+
+  const signRecordDataAccess = async (
+    signer: HardhatEthersSigner,
+    ownerAddress: string,
+    scope: string,
+    version: bigint,
+    accessor: string,
+    recordId: string,
+  ) =>
+    signer.signTypedData(
+      await eip712Domain(await registry.getAddress()),
+      RecordDataAccessTypes,
+      { ownerAddress, scope, version, accessor, recordId },
+    );
+
+  // Registers `serverSigner` as a personal server owned by `serverOwner` in
+  // the ServersV2 registry. Returns the serverId.
+  const registerServer = async (
+    serverOwner: HardhatEthersSigner,
+    serverSigner: HardhatEthersSigner,
+    publicKey = "test-public-key",
+    serverUrl = "https://server.example.com",
+  ): Promise<string> => {
+    const input = {
+      ownerAddress: serverOwner.address,
+      serverAddress: serverSigner.address,
+      publicKey,
+      serverUrl,
+    };
+    const signature = await serverOwner.signTypedData(
+      await eip712Domain(await servers.getAddress()),
+      ServerRegistrationTypes,
+      input,
+    );
+    await servers
+      .connect(relayer)
+      .registerServerWithSignature(input, signature);
+    return await servers.computeServerId(
+      serverSigner.address,
+      publicKey,
+      serverUrl,
+    );
+  };
+
+  const deregisterServer = async (
+    serverOwner: HardhatEthersSigner,
+    serverSigner: HardhatEthersSigner,
+    serverId: string,
+  ) => {
+    const deadline = BigInt(await time.latest()) + 1000n;
+    const input = {
+      ownerAddress: serverOwner.address,
+      serverAddress: serverSigner.address,
+      serverId,
+      deadline,
+    };
+    const signature = await serverOwner.signTypedData(
+      await eip712Domain(await servers.getAddress()),
+      ServerDeregistrationTypes,
+      input,
+    );
+    await servers
+      .connect(relayer)
+      .deregisterServerWithSignature(input, signature);
+  };
+
+  const deploy = async () => {
+    [
+      deployer,
+      owner,
+      user1,
+      user2,
+      relayer,
+      recorder,
+      server1,
+      server2,
+      other,
+    ] = await ethers.getSigners();
+
+    const registryDeploy = await upgrades.deployProxy(
+      await ethers.getContractFactory("DataRegistryV2Implementation"),
+      [owner.address],
+      { kind: "uups" },
+    );
+    registry = await ethers.getContractAt(
+      "DataRegistryV2Implementation",
+      registryDeploy.target,
+    );
+
+    const serversDeploy = await upgrades.deployProxy(
+      await ethers.getContractFactory(
+        "DataPortabilityServersV2Implementation",
+      ),
+      [ethers.ZeroAddress, owner.address],
+      { kind: "uups" },
+    );
+    servers = await ethers.getContractAt(
+      "DataPortabilityServersV2Implementation",
+      serversDeploy.target,
+    );
+  };
+
+  const wireServers = async () => {
+    await registry
+      .connect(owner)
+      .setDataPortabilityServers(await servers.getAddress());
+  };
+
+  // ====================== Setup ======================
+
+  describe("Setup", () => {
+    beforeEach(async () => {
+      await deploy();
+    });
+
+    it("should have correct params after deploy", async function () {
+      (await registry.hasRole(DEFAULT_ADMIN_ROLE, owner)).should.eq(true);
+      (await registry.hasRole(DEFAULT_ADMIN_ROLE, deployer)).should.eq(false);
+      (await registry.version()).should.eq(1);
+      (await registry.dataPortabilityServers()).should.eq(ethers.ZeroAddress);
+      (await registry.paused()).should.eq(false);
+    });
+
+    it("should reject re-initialization", async function () {
+      await expect(
+        registry.initialize(user1.address),
+      ).to.be.revertedWithCustomError(registry, "InvalidInitialization");
+    });
+
+    it("should reject zero owner at initialization", async function () {
+      const implFactory = await ethers.getContractFactory(
+        "DataRegistryV2Implementation",
+      );
+      const impl = await implFactory.deploy();
+      await impl.waitForDeployment();
+      const proxyFactory = await ethers.getContractFactory(
+        "DataRegistryV2Proxy",
+      );
+
+      await expect(
+        proxyFactory.deploy(
+          await impl.getAddress(),
+          implFactory.interface.encodeFunctionData("initialize", [
+            ethers.ZeroAddress,
+          ]),
+        ),
+      ).to.be.revertedWithCustomError(implFactory, "ZeroAddress");
+    });
+
+    it("should expose the expected EIP-712 typehashes", async function () {
+      (await registry.ADD_DATA_TYPEHASH()).should.eq(
+        ethers.keccak256(
+          ethers.toUtf8Bytes(
+            "AddData(address ownerAddress,string scope,bytes32 dataHash,bytes32 metadataHash,uint256 expectedVersion)",
+          ),
+        ),
+      );
+      (await registry.RECORD_ACCESS_TYPEHASH()).should.eq(
+        ethers.keccak256(
+          ethers.toUtf8Bytes(
+            "RecordDataAccess(address ownerAddress,string scope,uint256 version,address accessor,bytes32 recordId)",
+          ),
+        ),
+      );
+      (await registry.SET_STATUS_TYPEHASH()).should.eq(
+        ethers.keccak256(
+          ethers.toUtf8Bytes(
+            "SetStatus(address ownerAddress,string scope,uint8 newStatus,uint256 expectedSequence)",
+          ),
+        ),
+      );
+    });
+  });
+
+  // ====================== Pure helpers ======================
+
+  describe("Pure helpers", () => {
+    beforeEach(async () => {
+      await deploy();
+    });
+
+    it("dataPointId should equal keccak256(abi.encode(owner, scope))", async function () {
+      (await registry.dataPointId(user1.address, SCOPE)).should.eq(
+        dpId(user1.address, SCOPE),
+      );
+      (await registry.dataPointId(user2.address, "another.scope")).should.eq(
+        dpId(user2.address, "another.scope"),
+      );
+    });
+
+    it("computeCommitment should equal keccak256(abi.encode(dataHash, metadataHash))", async function () {
+      (await registry.computeCommitment(DATA_HASH, META_HASH)).should.eq(
+        commitmentOf(DATA_HASH, META_HASH),
+      );
+    });
+
+    it("dataPointById should return zero defaults for an unregistered id", async function () {
+      // Natspec: owner == address(0) signals "not found".
+      const unknownId = ethers.id("no-such-data-point");
+      const info = await registry.dataPointById(unknownId);
+      info.id.should.eq(unknownId);
+      info.owner.should.eq(ethers.ZeroAddress);
+      info.scope.should.eq("");
+      info.status.should.eq(Status.None);
+      info.currentVersion.should.eq(0n);
+      info.currentCommitment.should.eq(ethers.ZeroHash);
+      info.createdAt.should.eq(0n);
+      info.modifiedAt.should.eq(0n);
+      info.totalAccesses.should.eq(0n);
+    });
+  });
+
+  // ====================== addData ======================
+
+  describe("addData", () => {
+    beforeEach(async () => {
+      await deploy();
+    });
+
+    it("should create a data point with version 1 and correct fields", async function () {
+      const id = dpId(user1.address, SCOPE);
+
+      const [retId, retVersion] = await registry
+        .connect(user1)
+        .addData.staticCall(SCOPE, DATA_HASH, META_HASH);
+      retId.should.eq(id);
+      retVersion.should.eq(1n);
+
+      const tx = await registry
+        .connect(user1)
+        .addData(SCOPE, DATA_HASH, META_HASH);
+      const receipt = await tx.wait();
+      const blockTs = (await ethers.provider.getBlock(receipt!.blockNumber))!
+        .timestamp;
+
+      const commitment = commitmentOf(DATA_HASH, META_HASH);
+
+      await expect(tx)
+        .to.emit(registry, "DataPointCreated")
+        .withArgs(
+          id,
+          user1.address,
+          ethers.keccak256(ethers.toUtf8Bytes(SCOPE)),
+          SCOPE,
+        );
+      await expect(tx)
+        .to.emit(registry, "DataVersionAdded")
+        .withArgs(id, 1n, DATA_HASH, META_HASH, commitment);
+
+      const info = await registry.dataPoints(user1.address, SCOPE);
+      info.id.should.eq(id);
+      info.owner.should.eq(user1.address);
+      info.scope.should.eq(SCOPE);
+      info.status.should.eq(Status.Active);
+      info.currentVersion.should.eq(1n);
+      info.currentCommitment.should.eq(commitment);
+      info.createdAt.should.eq(BigInt(blockTs));
+      info.modifiedAt.should.eq(BigInt(blockTs));
+      info.totalAccesses.should.eq(0n);
+
+      // by-id lookup matches
+      const infoById = await registry.dataPointById(id);
+      infoById.owner.should.eq(user1.address);
+      infoById.currentVersion.should.eq(1n);
+
+      // views
+      (await registry.currentVersion(user1.address, SCOPE)).should.eq(1n);
+      (await registry.currentCommitment(user1.address, SCOPE)).should.eq(
+        commitment,
+      );
+      (await registry.dataCommitment(user1.address, SCOPE, 1)).should.eq(
+        commitment,
+      );
+    });
+
+    it("should append a new version for the same (owner, scope)", async function () {
+      const id = dpId(user1.address, SCOPE);
+      await registry.connect(user1).addData(SCOPE, DATA_HASH, META_HASH);
+      const createdAt = (await registry.dataPoints(user1.address, SCOPE))
+        .createdAt;
+
+      await time.increase(100);
+
+      const [, retVersion] = await registry
+        .connect(user1)
+        .addData.staticCall(SCOPE, DATA_HASH_2, META_HASH_2);
+      retVersion.should.eq(2n);
+
+      const tx = await registry
+        .connect(user1)
+        .addData(SCOPE, DATA_HASH_2, META_HASH_2);
+      const receipt = await tx.wait();
+      const blockTs = (await ethers.provider.getBlock(receipt!.blockNumber))!
+        .timestamp;
+
+      const commitment2 = commitmentOf(DATA_HASH_2, META_HASH_2);
+
+      // No second creation event on append, and no status event either —
+      // the point is already Active, so an always-emit mutant would fail here.
+      await expect(tx).to.not.emit(registry, "DataPointCreated");
+      await expect(tx).to.not.emit(registry, "DataPointStatusChanged");
+      await expect(tx)
+        .to.emit(registry, "DataVersionAdded")
+        .withArgs(id, 2n, DATA_HASH_2, META_HASH_2, commitment2);
+
+      const info = await registry.dataPoints(user1.address, SCOPE);
+      info.currentVersion.should.eq(2n);
+      info.currentCommitment.should.eq(commitment2);
+      info.createdAt.should.eq(createdAt);
+      info.modifiedAt.should.eq(BigInt(blockTs));
+      (BigInt(blockTs) > createdAt).should.eq(true);
+
+      // Version-1 commitment still retrievable.
+      (await registry.dataCommitment(user1.address, SCOPE, 1)).should.eq(
+        commitmentOf(DATA_HASH, META_HASH),
+      );
+      (await registry.dataCommitment(user1.address, SCOPE, 2)).should.eq(
+        commitment2,
+      );
+      (await registry.currentCommitment(user1.address, SCOPE)).should.eq(
+        commitment2,
+      );
+    });
+
+    it("should auto-revive an Inactive data point on addData", async function () {
+      const id = dpId(user1.address, SCOPE);
+      await registry.connect(user1).addData(SCOPE, DATA_HASH, META_HASH);
+      await registry.connect(user1).setStatus(SCOPE, Status.Inactive);
+      (await registry.dataPoints(user1.address, SCOPE)).status.should.eq(
+        Status.Inactive,
+      );
+
+      const tx = await registry
+        .connect(user1)
+        .addData(SCOPE, DATA_HASH_2, META_HASH_2);
+      await expect(tx)
+        .to.emit(registry, "DataPointStatusChanged")
+        .withArgs(id, Status.Active);
+
+      const info = await registry.dataPoints(user1.address, SCOPE);
+      info.status.should.eq(Status.Active);
+      info.currentVersion.should.eq(2n);
+    });
+
+    it("should auto-revive an Unavailable data point on addData", async function () {
+      // Natspec: auto-revives Inactive AND Unavailable.
+      const id = dpId(user1.address, SCOPE);
+      await registry.connect(user1).addData(SCOPE, DATA_HASH, META_HASH);
+      await registry.connect(user1).setStatus(SCOPE, Status.Unavailable);
+
+      const tx = await registry
+        .connect(user1)
+        .addData(SCOPE, DATA_HASH_2, META_HASH_2);
+      await expect(tx)
+        .to.emit(registry, "DataPointStatusChanged")
+        .withArgs(id, Status.Active);
+      (await registry.dataPoints(user1.address, SCOPE)).status.should.eq(
+        Status.Active,
+      );
+    });
+
+    it("should reject an empty scope", async function () {
+      await expect(
+        registry.connect(user1).addData("", DATA_HASH, META_HASH),
+      ).to.be.revertedWithCustomError(registry, "EmptyScope");
+    });
+
+    it("should reject a scope longer than 256 bytes", async function () {
+      await expect(
+        registry
+          .connect(user1)
+          .addData("s".repeat(257), DATA_HASH, META_HASH),
+      ).to.be.revertedWithCustomError(registry, "ScopeTooLong");
+    });
+
+    it("should accept a 256-byte scope (boundary)", async function () {
+      const scope256 = "s".repeat(256);
+      await registry.connect(user1).addData(scope256, DATA_HASH, META_HASH)
+        .should.be.fulfilled;
+      (await registry.currentVersion(user1.address, scope256)).should.eq(1n);
+    });
+  });
+
+  // ====================== Scope enumeration ======================
+
+  describe("Scope enumeration", () => {
+    const sharedScope = "shared.scope";
+    let id1: string;
+    let id2: string;
+
+    beforeEach(async () => {
+      await deploy();
+      await registry.connect(user1).addData(sharedScope, DATA_HASH, META_HASH);
+      await registry
+        .connect(user2)
+        .addData(sharedScope, DATA_HASH_2, META_HASH_2);
+      id1 = dpId(user1.address, sharedScope);
+      id2 = dpId(user2.address, sharedScope);
+    });
+
+    it("should count data points per scope", async function () {
+      (await registry.scopeDataPointsCount(sharedScope)).should.eq(2n);
+      (await registry.scopeDataPointsCount("unknown.scope")).should.eq(0n);
+    });
+
+    it("should not double-count appended versions", async function () {
+      await registry
+        .connect(user1)
+        .addData(sharedScope, DATA_HASH_2, META_HASH_2);
+      (await registry.scopeDataPointsCount(sharedScope)).should.eq(2n);
+    });
+
+    it("should expose scopeDataPointIdAt", async function () {
+      (await registry.scopeDataPointIdAt(sharedScope, 0)).should.eq(id1);
+      (await registry.scopeDataPointIdAt(sharedScope, 1)).should.eq(id2);
+    });
+
+    it("should paginate scopeDataPointIds", async function () {
+      (await registry.scopeDataPointIds(sharedScope, 0, 1)).should.deep.eq([
+        id1,
+      ]);
+      (await registry.scopeDataPointIds(sharedScope, 1, 10)).should.deep.eq([
+        id2,
+      ]);
+      (await registry.scopeDataPointIds(sharedScope, 0, 10)).should.deep.eq([
+        id1,
+        id2,
+      ]);
+      // offset >= total → empty
+      (await registry.scopeDataPointIds(sharedScope, 2, 10)).should.deep.eq(
+        [],
+      );
+      (await registry.scopeDataPointIds(sharedScope, 100, 10)).should.deep.eq(
+        [],
+      );
+    });
+  });
+
+  // ====================== setStatus ======================
+
+  describe("setStatus", () => {
+    beforeEach(async () => {
+      await deploy();
+      await registry.connect(user1).addData(SCOPE, DATA_HASH, META_HASH);
+    });
+
+    it("should change status and update modifiedAt", async function () {
+      const id = dpId(user1.address, SCOPE);
+      await time.increase(50);
+
+      const tx = await registry
+        .connect(user1)
+        .setStatus(SCOPE, Status.Unavailable);
+      const receipt = await tx.wait();
+      const blockTs = (await ethers.provider.getBlock(receipt!.blockNumber))!
+        .timestamp;
+
+      await expect(tx)
+        .to.emit(registry, "DataPointStatusChanged")
+        .withArgs(id, Status.Unavailable);
+
+      const info = await registry.dataPoints(user1.address, SCOPE);
+      info.status.should.eq(Status.Unavailable);
+      info.modifiedAt.should.eq(BigInt(blockTs));
+      (info.modifiedAt > info.createdAt).should.eq(true);
+    });
+
+    it("should be a silent no-op when the status is unchanged", async function () {
+      // data point is already Active
+      const modifiedBefore = (await registry.dataPoints(user1.address, SCOPE))
+        .modifiedAt;
+      await time.increase(100);
+
+      const tx = await registry.connect(user1).setStatus(SCOPE, Status.Active);
+      await expect(tx).to.not.emit(registry, "DataPointStatusChanged");
+
+      const info = await registry.dataPoints(user1.address, SCOPE);
+      info.status.should.eq(Status.Active);
+      // A true no-op: modifiedAt must not be bumped on the early-return path.
+      info.modifiedAt.should.eq(modifiedBefore);
+    });
+
+    it("should reject Status.None", async function () {
+      await expect(
+        registry.connect(user1).setStatus(SCOPE, Status.None),
+      ).to.be.revertedWithCustomError(registry, "InvalidStatus");
+    });
+
+    it("should reject a nonexistent data point", async function () {
+      const missingScope = "does.not.exist";
+      await expect(
+        registry.connect(user1).setStatus(missingScope, Status.Inactive),
+      )
+        .to.be.revertedWithCustomError(registry, "DataPointNotFound")
+        .withArgs(dpId(user1.address, missingScope));
+    });
+  });
+
+  // ====================== setDataPortabilityServers ======================
+
+  describe("setDataPortabilityServers", () => {
+    beforeEach(async () => {
+      await deploy();
+    });
+
+    it("should set the servers registry and emit event", async function () {
+      const serversAddress = await servers.getAddress();
+      await expect(
+        registry.connect(owner).setDataPortabilityServers(serversAddress),
+      )
+        .to.emit(registry, "DataPortabilityServersUpdated")
+        .withArgs(ethers.ZeroAddress, serversAddress);
+      (await registry.dataPortabilityServers()).should.eq(serversAddress);
+    });
+
+    it("should track the previous address on update", async function () {
+      const serversAddress = await servers.getAddress();
+      await registry.connect(owner).setDataPortabilityServers(serversAddress);
+      await expect(
+        registry.connect(owner).setDataPortabilityServers(other.address),
+      )
+        .to.emit(registry, "DataPortabilityServersUpdated")
+        .withArgs(serversAddress, other.address);
+    });
+
+    it("should reject non-admin", async function () {
+      await expect(
+        registry
+          .connect(user1)
+          .setDataPortabilityServers(await servers.getAddress()),
+      ).to.be.revertedWithCustomError(
+        registry,
+        "AccessControlUnauthorizedAccount",
+      );
+    });
+
+    it("should reject zero address", async function () {
+      await expect(
+        registry.connect(owner).setDataPortabilityServers(ethers.ZeroAddress),
+      ).to.be.revertedWithCustomError(registry, "ZeroAddress");
+    });
+  });
+
+  // ====================== addDataWithSignature (owner-signed) ======================
+
+  describe("addDataWithSignature - owner-signed", () => {
+    beforeEach(async () => {
+      await deploy();
+    });
+
+    it("should add data via relayer with owner signature", async function () {
+      const id = dpId(user1.address, SCOPE);
+      const signature = await signAddData(
+        user1,
+        user1.address,
+        SCOPE,
+        DATA_HASH,
+        META_HASH,
+        1n,
+      );
+
+      const tx = await registry
+        .connect(relayer)
+        .addDataWithSignature(
+          user1.address,
+          SCOPE,
+          DATA_HASH,
+          META_HASH,
+          1n,
+          signature,
+        );
+
+      await expect(tx)
+        .to.emit(registry, "DataPointCreated")
+        .withArgs(
+          id,
+          user1.address,
+          ethers.keccak256(ethers.toUtf8Bytes(SCOPE)),
+          SCOPE,
+        );
+      await expect(tx)
+        .to.emit(registry, "DataVersionAdded")
+        .withArgs(id, 1n, DATA_HASH, META_HASH, commitmentOf(DATA_HASH, META_HASH));
+      // Owner self-signed → no delegate event.
+      await expect(tx).to.not.emit(registry, "DataSignedByDelegate");
+
+      const info = await registry.dataPoints(user1.address, SCOPE);
+      info.owner.should.eq(user1.address);
+      info.currentVersion.should.eq(1n);
+    });
+
+    it("should reject a wrong expectedVersion", async function () {
+      const signature = await signAddData(
+        user1,
+        user1.address,
+        SCOPE,
+        DATA_HASH,
+        META_HASH,
+        5n,
+      );
+      await expect(
+        registry
+          .connect(relayer)
+          .addDataWithSignature(
+            user1.address,
+            SCOPE,
+            DATA_HASH,
+            META_HASH,
+            5n,
+            signature,
+          ),
+      )
+        .to.be.revertedWithCustomError(registry, "UnexpectedVersion")
+        .withArgs(1n, 5n);
+    });
+
+    it("should reject replay of the same signature", async function () {
+      const signature = await signAddData(
+        user1,
+        user1.address,
+        SCOPE,
+        DATA_HASH,
+        META_HASH,
+        1n,
+      );
+      await registry
+        .connect(relayer)
+        .addDataWithSignature(
+          user1.address,
+          SCOPE,
+          DATA_HASH,
+          META_HASH,
+          1n,
+          signature,
+        );
+
+      await expect(
+        registry
+          .connect(relayer)
+          .addDataWithSignature(
+            user1.address,
+            SCOPE,
+            DATA_HASH,
+            META_HASH,
+            1n,
+            signature,
+          ),
+      )
+        .to.be.revertedWithCustomError(registry, "UnexpectedVersion")
+        .withArgs(2n, 1n);
+    });
+
+    it("should reject a signature from an unrelated key", async function () {
+      const signature = await signAddData(
+        other,
+        user1.address,
+        SCOPE,
+        DATA_HASH,
+        META_HASH,
+        1n,
+      );
+      await expect(
+        registry
+          .connect(relayer)
+          .addDataWithSignature(
+            user1.address,
+            SCOPE,
+            DATA_HASH,
+            META_HASH,
+            1n,
+            signature,
+          ),
+      )
+        .to.be.revertedWithCustomError(registry, "OwnerMismatch")
+        .withArgs(user1.address, other.address);
+    });
+  });
+
+  // ====================== addDataWithSignature (delegate) ======================
+
+  describe("addDataWithSignature - delegate-signed", () => {
+    beforeEach(async () => {
+      await deploy();
+    });
+
+    it("should accept a signature from a server registered to the owner", async function () {
+      await wireServers();
+      await registerServer(user1, server1);
+
+      const id = dpId(user1.address, SCOPE);
+      const signature = await signAddData(
+        server1,
+        user1.address,
+        SCOPE,
+        DATA_HASH,
+        META_HASH,
+        1n,
+      );
+
+      const tx = await registry
+        .connect(relayer)
+        .addDataWithSignature(
+          user1.address,
+          SCOPE,
+          DATA_HASH,
+          META_HASH,
+          1n,
+          signature,
+        );
+
+      await expect(tx)
+        .to.emit(registry, "DataSignedByDelegate")
+        .withArgs(id, user1.address, server1.address);
+      await expect(tx).to.emit(registry, "DataVersionAdded");
+
+      const info = await registry.dataPoints(user1.address, SCOPE);
+      info.owner.should.eq(user1.address);
+      info.currentVersion.should.eq(1n);
+    });
+
+    it("should accept a delegate append on an existing data point (expectedVersion 2)", async function () {
+      await wireServers();
+      await registerServer(user1, server1);
+
+      // Owner creates version 1 directly; the delegate then appends v2.
+      await registry.connect(user1).addData(SCOPE, DATA_HASH, META_HASH);
+
+      const id = dpId(user1.address, SCOPE);
+      const signature = await signAddData(
+        server1,
+        user1.address,
+        SCOPE,
+        DATA_HASH_2,
+        META_HASH_2,
+        2n,
+      );
+
+      const tx = await registry
+        .connect(relayer)
+        .addDataWithSignature(
+          user1.address,
+          SCOPE,
+          DATA_HASH_2,
+          META_HASH_2,
+          2n,
+          signature,
+        );
+
+      await expect(tx)
+        .to.emit(registry, "DataVersionAdded")
+        .withArgs(
+          id,
+          2n,
+          DATA_HASH_2,
+          META_HASH_2,
+          commitmentOf(DATA_HASH_2, META_HASH_2),
+        );
+      await expect(tx)
+        .to.emit(registry, "DataSignedByDelegate")
+        .withArgs(id, user1.address, server1.address);
+      (await registry.currentVersion(user1.address, SCOPE)).should.eq(2n);
+    });
+
+    it("should reject a server registered to a different owner", async function () {
+      await wireServers();
+      await registerServer(user2, server1); // server1 belongs to user2
+
+      const signature = await signAddData(
+        server1,
+        user1.address,
+        SCOPE,
+        DATA_HASH,
+        META_HASH,
+        1n,
+      );
+      await expect(
+        registry
+          .connect(relayer)
+          .addDataWithSignature(
+            user1.address,
+            SCOPE,
+            DATA_HASH,
+            META_HASH,
+            1n,
+            signature,
+          ),
+      )
+        .to.be.revertedWithCustomError(registry, "OwnerMismatch")
+        .withArgs(user1.address, server1.address);
+    });
+
+    it("should reject a server signature after deregistration", async function () {
+      await wireServers();
+      const serverId = await registerServer(user1, server1);
+      await deregisterServer(user1, server1, serverId);
+
+      const signature = await signAddData(
+        server1,
+        user1.address,
+        SCOPE,
+        DATA_HASH,
+        META_HASH,
+        1n,
+      );
+      await expect(
+        registry
+          .connect(relayer)
+          .addDataWithSignature(
+            user1.address,
+            SCOPE,
+            DATA_HASH,
+            META_HASH,
+            1n,
+            signature,
+          ),
+      )
+        .to.be.revertedWithCustomError(registry, "OwnerMismatch")
+        .withArgs(user1.address, server1.address);
+    });
+
+    it("should reject a server signature when servers registry is unset", async function () {
+      // servers registry NOT wired on the data registry, but the server is
+      // registered in ServersV2 — only owner-self-signed accepted.
+      await registerServer(user1, server1);
+
+      const signature = await signAddData(
+        server1,
+        user1.address,
+        SCOPE,
+        DATA_HASH,
+        META_HASH,
+        1n,
+      );
+      await expect(
+        registry
+          .connect(relayer)
+          .addDataWithSignature(
+            user1.address,
+            SCOPE,
+            DATA_HASH,
+            META_HASH,
+            1n,
+            signature,
+          ),
+      )
+        .to.be.revertedWithCustomError(registry, "OwnerMismatch")
+        .withArgs(user1.address, server1.address);
+    });
+  });
+
+  // ====================== setStatusWithSignature ======================
+
+  describe("setStatusWithSignature", () => {
+    beforeEach(async () => {
+      await deploy();
+      await registry.connect(user1).addData(SCOPE, DATA_HASH, META_HASH);
+    });
+
+    it("should change status via relayer with owner signature", async function () {
+      const id = dpId(user1.address, SCOPE);
+      (await registry.statusSequence(user1.address, SCOPE)).should.eq(0n);
+
+      const signature = await signSetStatus(
+        user1,
+        user1.address,
+        SCOPE,
+        Status.Inactive,
+        1n,
+      );
+      const tx = await registry
+        .connect(relayer)
+        .setStatusWithSignature(
+          user1.address,
+          SCOPE,
+          Status.Inactive,
+          1n,
+          signature,
+        );
+
+      await expect(tx)
+        .to.emit(registry, "DataPointStatusChanged")
+        .withArgs(id, Status.Inactive);
+      await expect(tx).to.not.emit(registry, "StatusSignedByDelegate");
+
+      (await registry.dataPoints(user1.address, SCOPE)).status.should.eq(
+        Status.Inactive,
+      );
+      (await registry.statusSequence(user1.address, SCOPE)).should.eq(1n);
+    });
+
+    it("should reject a wrong expectedSequence", async function () {
+      const signature = await signSetStatus(
+        user1,
+        user1.address,
+        SCOPE,
+        Status.Inactive,
+        3n,
+      );
+      await expect(
+        registry
+          .connect(relayer)
+          .setStatusWithSignature(
+            user1.address,
+            SCOPE,
+            Status.Inactive,
+            3n,
+            signature,
+          ),
+      )
+        .to.be.revertedWithCustomError(registry, "UnexpectedVersion")
+        .withArgs(1n, 3n);
+    });
+
+    it("should reject replay of the same signature", async function () {
+      const signature = await signSetStatus(
+        user1,
+        user1.address,
+        SCOPE,
+        Status.Inactive,
+        1n,
+      );
+      await registry
+        .connect(relayer)
+        .setStatusWithSignature(
+          user1.address,
+          SCOPE,
+          Status.Inactive,
+          1n,
+          signature,
+        );
+
+      await expect(
+        registry
+          .connect(relayer)
+          .setStatusWithSignature(
+            user1.address,
+            SCOPE,
+            Status.Inactive,
+            1n,
+            signature,
+          ),
+      )
+        .to.be.revertedWithCustomError(registry, "UnexpectedVersion")
+        .withArgs(2n, 1n);
+    });
+
+    it("should reject Status.None", async function () {
+      const signature = await signSetStatus(
+        user1,
+        user1.address,
+        SCOPE,
+        Status.None,
+        1n,
+      );
+      await expect(
+        registry
+          .connect(relayer)
+          .setStatusWithSignature(
+            user1.address,
+            SCOPE,
+            Status.None,
+            1n,
+            signature,
+          ),
+      ).to.be.revertedWithCustomError(registry, "InvalidStatus");
+    });
+
+    it("should reject an unknown data point", async function () {
+      const missingScope = "does.not.exist";
+      const signature = await signSetStatus(
+        user1,
+        user1.address,
+        missingScope,
+        Status.Inactive,
+        1n,
+      );
+      await expect(
+        registry
+          .connect(relayer)
+          .setStatusWithSignature(
+            user1.address,
+            missingScope,
+            Status.Inactive,
+            1n,
+            signature,
+          ),
+      )
+        .to.be.revertedWithCustomError(registry, "DataPointNotFound")
+        .withArgs(dpId(user1.address, missingScope));
+    });
+
+    it("should consume the sequence without emitting on a signed no-op", async function () {
+      // Data point is Active; sign a change to Active with the correct next
+      // sequence. Tx succeeds, sequence is consumed, but no status event.
+      const signature = await signSetStatus(
+        user1,
+        user1.address,
+        SCOPE,
+        Status.Active,
+        1n,
+      );
+      const tx = await registry
+        .connect(relayer)
+        .setStatusWithSignature(
+          user1.address,
+          SCOPE,
+          Status.Active,
+          1n,
+          signature,
+        );
+
+      await expect(tx).to.not.emit(registry, "DataPointStatusChanged");
+      (await registry.statusSequence(user1.address, SCOPE)).should.eq(1n);
+      (await registry.dataPoints(user1.address, SCOPE)).status.should.eq(
+        Status.Active,
+      );
+
+      // Replay of the consumed signature must fail.
+      await expect(
+        registry
+          .connect(relayer)
+          .setStatusWithSignature(
+            user1.address,
+            SCOPE,
+            Status.Active,
+            1n,
+            signature,
+          ),
+      )
+        .to.be.revertedWithCustomError(registry, "UnexpectedVersion")
+        .withArgs(2n, 1n);
+    });
+
+    it("should accept a delegate signature and emit StatusSignedByDelegate", async function () {
+      await wireServers();
+      await registerServer(user1, server1);
+
+      const id = dpId(user1.address, SCOPE);
+      const signature = await signSetStatus(
+        server1,
+        user1.address,
+        SCOPE,
+        Status.Unavailable,
+        1n,
+      );
+      const tx = await registry
+        .connect(relayer)
+        .setStatusWithSignature(
+          user1.address,
+          SCOPE,
+          Status.Unavailable,
+          1n,
+          signature,
+        );
+
+      await expect(tx)
+        .to.emit(registry, "DataPointStatusChanged")
+        .withArgs(id, Status.Unavailable);
+      await expect(tx)
+        .to.emit(registry, "StatusSignedByDelegate")
+        .withArgs(id, user1.address, server1.address);
+    });
+
+    it("should emit StatusSignedByDelegate even on a delegate-signed no-op", async function () {
+      // Status is already Active; the delegate signs Active again. No status
+      // event, but the delegate attribution still fires and the sequence is
+      // consumed (impl's dedicated no-op branch for delegates).
+      await wireServers();
+      await registerServer(user1, server1);
+
+      const id = dpId(user1.address, SCOPE);
+      const signature = await signSetStatus(
+        server1,
+        user1.address,
+        SCOPE,
+        Status.Active,
+        1n,
+      );
+      const tx = await registry
+        .connect(relayer)
+        .setStatusWithSignature(
+          user1.address,
+          SCOPE,
+          Status.Active,
+          1n,
+          signature,
+        );
+
+      await expect(tx).to.not.emit(registry, "DataPointStatusChanged");
+      await expect(tx)
+        .to.emit(registry, "StatusSignedByDelegate")
+        .withArgs(id, user1.address, server1.address);
+      (await registry.statusSequence(user1.address, SCOPE)).should.eq(1n);
+    });
+
+    it("should keep the status sequence independent of the data version", async function () {
+      // Sign a status flip at sequence 1, then bump the data version — the
+      // pending status signature must still be valid.
+      const signature = await signSetStatus(
+        user1,
+        user1.address,
+        SCOPE,
+        Status.Inactive,
+        1n,
+      );
+
+      await registry.connect(user1).addData(SCOPE, DATA_HASH_2, META_HASH_2);
+      (await registry.currentVersion(user1.address, SCOPE)).should.eq(2n);
+
+      await registry
+        .connect(relayer)
+        .setStatusWithSignature(
+          user1.address,
+          SCOPE,
+          Status.Inactive,
+          1n,
+          signature,
+        ).should.be.fulfilled;
+
+      (await registry.dataPoints(user1.address, SCOPE)).status.should.eq(
+        Status.Inactive,
+      );
+      (await registry.statusSequence(user1.address, SCOPE)).should.eq(1n);
+    });
+
+    it("should reject a signature from an unrelated key", async function () {
+      const signature = await signSetStatus(
+        user2,
+        user1.address,
+        SCOPE,
+        Status.Inactive,
+        1n,
+      );
+      await expect(
+        registry
+          .connect(relayer)
+          .setStatusWithSignature(
+            user1.address,
+            SCOPE,
+            Status.Inactive,
+            1n,
+            signature,
+          ),
+      )
+        .to.be.revertedWithCustomError(registry, "OwnerMismatch")
+        .withArgs(user1.address, user2.address);
+      (await registry.statusSequence(user1.address, SCOPE)).should.eq(0n);
+    });
+
+    it("should reject a delegate registered to a different owner", async function () {
+      await wireServers();
+      await registerServer(user2, server1); // server1 belongs to user2
+
+      const signature = await signSetStatus(
+        server1,
+        user1.address,
+        SCOPE,
+        Status.Inactive,
+        1n,
+      );
+      await expect(
+        registry
+          .connect(relayer)
+          .setStatusWithSignature(
+            user1.address,
+            SCOPE,
+            Status.Inactive,
+            1n,
+            signature,
+          ),
+      )
+        .to.be.revertedWithCustomError(registry, "OwnerMismatch")
+        .withArgs(user1.address, server1.address);
+    });
+
+    it("should reject a delegate signature after deregistration", async function () {
+      await wireServers();
+      const serverId = await registerServer(user1, server1);
+      await deregisterServer(user1, server1, serverId);
+
+      const signature = await signSetStatus(
+        server1,
+        user1.address,
+        SCOPE,
+        Status.Inactive,
+        1n,
+      );
+      await expect(
+        registry
+          .connect(relayer)
+          .setStatusWithSignature(
+            user1.address,
+            SCOPE,
+            Status.Inactive,
+            1n,
+            signature,
+          ),
+      )
+        .to.be.revertedWithCustomError(registry, "OwnerMismatch")
+        .withArgs(user1.address, server1.address);
+    });
+
+    it("should reject a delegate signature when the servers registry is unset", async function () {
+      // server1 is registered in ServersV2, but the registry contract has not
+      // been wired to it — only owner-self-signed signatures are accepted.
+      await registerServer(user1, server1);
+
+      const signature = await signSetStatus(
+        server1,
+        user1.address,
+        SCOPE,
+        Status.Inactive,
+        1n,
+      );
+      await expect(
+        registry
+          .connect(relayer)
+          .setStatusWithSignature(
+            user1.address,
+            SCOPE,
+            Status.Inactive,
+            1n,
+            signature,
+          ),
+      )
+        .to.be.revertedWithCustomError(registry, "OwnerMismatch")
+        .withArgs(user1.address, server1.address);
+    });
+
+    it("should keep status sequences isolated per data point", async function () {
+      const otherScope = "other.scope";
+      await registry.connect(user2).addData(SCOPE, DATA_HASH, META_HASH);
+      await registry.connect(user1).addData(otherScope, DATA_HASH, META_HASH);
+
+      // Consume sequence 1 on (user1, SCOPE) only.
+      const signature = await signSetStatus(
+        user1,
+        user1.address,
+        SCOPE,
+        Status.Inactive,
+        1n,
+      );
+      await registry
+        .connect(relayer)
+        .setStatusWithSignature(
+          user1.address,
+          SCOPE,
+          Status.Inactive,
+          1n,
+          signature,
+        );
+
+      (await registry.statusSequence(user1.address, SCOPE)).should.eq(1n);
+      (await registry.statusSequence(user2.address, SCOPE)).should.eq(0n);
+      (await registry.statusSequence(user1.address, otherScope)).should.eq(0n);
+
+      // A sequence-1 signature for the other data points must still work.
+      const signature2 = await signSetStatus(
+        user2,
+        user2.address,
+        SCOPE,
+        Status.Unavailable,
+        1n,
+      );
+      await registry
+        .connect(relayer)
+        .setStatusWithSignature(
+          user2.address,
+          SCOPE,
+          Status.Unavailable,
+          1n,
+          signature2,
+        ).should.be.fulfilled;
+      (await registry.dataPoints(user2.address, SCOPE)).status.should.eq(
+        Status.Unavailable,
+      );
+      // The first data point is untouched by the second flip.
+      (await registry.dataPoints(user1.address, SCOPE)).status.should.eq(
+        Status.Inactive,
+      );
+    });
+  });
+
+  // ====================== recordDataAccess ======================
+
+  describe("recordDataAccess", () => {
+    const recordId1 = ethers.keccak256(ethers.toUtf8Bytes("record-1"));
+    const recordId2 = ethers.keccak256(ethers.toUtf8Bytes("record-2"));
+    const recordId3 = ethers.keccak256(ethers.toUtf8Bytes("record-3"));
+
+    beforeEach(async () => {
+      await deploy();
+      await registry.connect(user1).addData(SCOPE, DATA_HASH, META_HASH);
+      await registry
+        .connect(owner)
+        .grantRole(ACCESS_RECORDER_ROLE, recorder.address);
+    });
+
+    const setupTrustedServer = async () => {
+      await wireServers();
+      await registerServer(user1, server1);
+    };
+
+    it("should reject a caller without ACCESS_RECORDER_ROLE", async function () {
+      await setupTrustedServer();
+      const signature = await signRecordDataAccess(
+        server1,
+        user1.address,
+        SCOPE,
+        1n,
+        other.address,
+        recordId1,
+      );
+      await expect(
+        registry
+          .connect(user1)
+          .recordDataAccess(
+            user1.address,
+            SCOPE,
+            1n,
+            other.address,
+            recordId1,
+            signature,
+          ),
+      ).to.be.revertedWithCustomError(
+        registry,
+        "AccessControlUnauthorizedAccount",
+      );
+    });
+
+    it("should reject when the servers registry is unset", async function () {
+      // role granted, but no servers registry wired
+      const signature = await signRecordDataAccess(
+        server1,
+        user1.address,
+        SCOPE,
+        1n,
+        other.address,
+        recordId1,
+      );
+      await expect(
+        registry
+          .connect(recorder)
+          .recordDataAccess(
+            user1.address,
+            SCOPE,
+            1n,
+            other.address,
+            recordId1,
+            signature,
+          ),
+      ).to.be.revertedWithCustomError(registry, "DataPortabilityServersNotSet");
+    });
+
+    it("should record an access signed by a trusted server", async function () {
+      await setupTrustedServer();
+      const id = dpId(user1.address, SCOPE);
+      const signature = await signRecordDataAccess(
+        server1,
+        user1.address,
+        SCOPE,
+        1n,
+        other.address,
+        recordId1,
+      );
+
+      (await registry.isRecordIdUsed(recordId1)).should.eq(false);
+
+      await expect(
+        registry
+          .connect(recorder)
+          .recordDataAccess(
+            user1.address,
+            SCOPE,
+            1n,
+            other.address,
+            recordId1,
+            signature,
+          ),
+      )
+        .to.emit(registry, "DataAccessRecorded")
+        .withArgs(id, 1n, other.address, server1.address, recordId1, 1n, 1n);
+
+      (await registry.accessCount(user1.address, SCOPE, 1)).should.eq(1n);
+      (await registry.totalAccesses(user1.address, SCOPE)).should.eq(1n);
+      (await registry.dataPoints(user1.address, SCOPE)).totalAccesses.should.eq(
+        1n,
+      );
+      (await registry.isRecordIdUsed(recordId1)).should.eq(true);
+    });
+
+    it("should reject a duplicate recordId", async function () {
+      await setupTrustedServer();
+      const signature = await signRecordDataAccess(
+        server1,
+        user1.address,
+        SCOPE,
+        1n,
+        other.address,
+        recordId1,
+      );
+      await registry
+        .connect(recorder)
+        .recordDataAccess(
+          user1.address,
+          SCOPE,
+          1n,
+          other.address,
+          recordId1,
+          signature,
+        );
+
+      await expect(
+        registry
+          .connect(recorder)
+          .recordDataAccess(
+            user1.address,
+            SCOPE,
+            1n,
+            other.address,
+            recordId1,
+            signature,
+          ),
+      )
+        .to.be.revertedWithCustomError(registry, "RecordIdAlreadyUsed")
+        .withArgs(recordId1);
+    });
+
+    it("should reject a reused recordId even with a different payload", async function () {
+      // Single-use must key on the recordId itself, not the full digest — a
+      // fresh signature over a different accessor with the same recordId
+      // must still be rejected.
+      await setupTrustedServer();
+      const signature = await signRecordDataAccess(
+        server1,
+        user1.address,
+        SCOPE,
+        1n,
+        other.address,
+        recordId1,
+      );
+      await registry
+        .connect(recorder)
+        .recordDataAccess(
+          user1.address,
+          SCOPE,
+          1n,
+          other.address,
+          recordId1,
+          signature,
+        );
+
+      const differentPayloadSig = await signRecordDataAccess(
+        server1,
+        user1.address,
+        SCOPE,
+        1n,
+        user2.address, // different accessor
+        recordId1, // same recordId
+      );
+      await expect(
+        registry
+          .connect(recorder)
+          .recordDataAccess(
+            user1.address,
+            SCOPE,
+            1n,
+            user2.address,
+            recordId1,
+            differentPayloadSig,
+          ),
+      )
+        .to.be.revertedWithCustomError(registry, "RecordIdAlreadyUsed")
+        .withArgs(recordId1);
+    });
+
+    it("should reject version 0 and versions above currentVersion", async function () {
+      await setupTrustedServer();
+      const id = dpId(user1.address, SCOPE);
+
+      const sigV0 = await signRecordDataAccess(
+        server1,
+        user1.address,
+        SCOPE,
+        0n,
+        other.address,
+        recordId1,
+      );
+      await expect(
+        registry
+          .connect(recorder)
+          .recordDataAccess(
+            user1.address,
+            SCOPE,
+            0n,
+            other.address,
+            recordId1,
+            sigV0,
+          ),
+      )
+        .to.be.revertedWithCustomError(registry, "UnknownVersion")
+        .withArgs(id, 0n);
+
+      const sigV2 = await signRecordDataAccess(
+        server1,
+        user1.address,
+        SCOPE,
+        2n,
+        other.address,
+        recordId2,
+      );
+      await expect(
+        registry
+          .connect(recorder)
+          .recordDataAccess(
+            user1.address,
+            SCOPE,
+            2n,
+            other.address,
+            recordId2,
+            sigV2,
+          ),
+      )
+        .to.be.revertedWithCustomError(registry, "UnknownVersion")
+        .withArgs(id, 2n);
+    });
+
+    it("should reject a signature from a non-trusted key", async function () {
+      await setupTrustedServer();
+      const signature = await signRecordDataAccess(
+        server2, // not registered as anyone's server
+        user1.address,
+        SCOPE,
+        1n,
+        other.address,
+        recordId1,
+      );
+      await expect(
+        registry
+          .connect(recorder)
+          .recordDataAccess(
+            user1.address,
+            SCOPE,
+            1n,
+            other.address,
+            recordId1,
+            signature,
+          ),
+      )
+        .to.be.revertedWithCustomError(registry, "UntrustedServer")
+        .withArgs(user1.address, server2.address);
+    });
+
+    it("should reject a server trusted by a different owner", async function () {
+      await wireServers();
+      await registerServer(user2, server1); // server1 belongs to user2
+
+      const signature = await signRecordDataAccess(
+        server1,
+        user1.address,
+        SCOPE,
+        1n,
+        other.address,
+        recordId1,
+      );
+      await expect(
+        registry
+          .connect(recorder)
+          .recordDataAccess(
+            user1.address,
+            SCOPE,
+            1n,
+            other.address,
+            recordId1,
+            signature,
+          ),
+      )
+        .to.be.revertedWithCustomError(registry, "UntrustedServer")
+        .withArgs(user1.address, server1.address);
+    });
+
+    it("should track per-version counters and the aggregate total", async function () {
+      await setupTrustedServer();
+      const id = dpId(user1.address, SCOPE);
+      await registry.connect(user1).addData(SCOPE, DATA_HASH_2, META_HASH_2); // v2
+
+      // record against v1
+      const sig1 = await signRecordDataAccess(
+        server1,
+        user1.address,
+        SCOPE,
+        1n,
+        other.address,
+        recordId1,
+      );
+      await registry
+        .connect(recorder)
+        .recordDataAccess(
+          user1.address,
+          SCOPE,
+          1n,
+          other.address,
+          recordId1,
+          sig1,
+        );
+
+      // record twice against v2
+      const sig2 = await signRecordDataAccess(
+        server1,
+        user1.address,
+        SCOPE,
+        2n,
+        other.address,
+        recordId2,
+      );
+      await registry
+        .connect(recorder)
+        .recordDataAccess(
+          user1.address,
+          SCOPE,
+          2n,
+          other.address,
+          recordId2,
+          sig2,
+        );
+
+      const sig3 = await signRecordDataAccess(
+        server1,
+        user1.address,
+        SCOPE,
+        2n,
+        user2.address,
+        recordId3,
+      );
+      await expect(
+        registry
+          .connect(recorder)
+          .recordDataAccess(
+            user1.address,
+            SCOPE,
+            2n,
+            user2.address,
+            recordId3,
+            sig3,
+          ),
+      )
+        .to.emit(registry, "DataAccessRecorded")
+        .withArgs(id, 2n, user2.address, server1.address, recordId3, 2n, 3n);
+
+      (await registry.accessCount(user1.address, SCOPE, 1)).should.eq(1n);
+      (await registry.accessCount(user1.address, SCOPE, 2)).should.eq(2n);
+      (await registry.totalAccesses(user1.address, SCOPE)).should.eq(3n);
+    });
+  });
+
+  // ====================== Pause ======================
+
+  describe("Pause", () => {
+    beforeEach(async () => {
+      await deploy();
+      await registry.connect(user1).addData(SCOPE, DATA_HASH, META_HASH);
+      await registry
+        .connect(owner)
+        .grantRole(ACCESS_RECORDER_ROLE, recorder.address);
+    });
+
+    it("should only allow admin to pause and unpause", async function () {
+      await expect(
+        registry.connect(user1).pause(),
+      ).to.be.revertedWithCustomError(
+        registry,
+        "AccessControlUnauthorizedAccount",
+      );
+
+      await registry.connect(owner).pause();
+      (await registry.paused()).should.eq(true);
+
+      await expect(
+        registry.connect(user1).unpause(),
+      ).to.be.revertedWithCustomError(
+        registry,
+        "AccessControlUnauthorizedAccount",
+      );
+
+      await registry.connect(owner).unpause();
+      (await registry.paused()).should.eq(false);
+    });
+
+    it("should gate all write entrypoints while paused and restore on unpause", async function () {
+      const addDataSig = await signAddData(
+        user1,
+        user1.address,
+        SCOPE,
+        DATA_HASH_2,
+        META_HASH_2,
+        2n,
+      );
+      const setStatusSig = await signSetStatus(
+        user1,
+        user1.address,
+        SCOPE,
+        Status.Inactive,
+        1n,
+      );
+      const recordSig = await signRecordDataAccess(
+        server1,
+        user1.address,
+        SCOPE,
+        1n,
+        other.address,
+        ethers.keccak256(ethers.toUtf8Bytes("paused-record")),
+      );
+
+      await registry.connect(owner).pause();
+
+      await expect(
+        registry.connect(user1).addData(SCOPE, DATA_HASH_2, META_HASH_2),
+      ).to.be.revertedWithCustomError(registry, "EnforcedPause");
+
+      await expect(
+        registry.connect(user1).setStatus(SCOPE, Status.Inactive),
+      ).to.be.revertedWithCustomError(registry, "EnforcedPause");
+
+      await expect(
+        registry
+          .connect(relayer)
+          .addDataWithSignature(
+            user1.address,
+            SCOPE,
+            DATA_HASH_2,
+            META_HASH_2,
+            2n,
+            addDataSig,
+          ),
+      ).to.be.revertedWithCustomError(registry, "EnforcedPause");
+
+      await expect(
+        registry
+          .connect(relayer)
+          .setStatusWithSignature(
+            user1.address,
+            SCOPE,
+            Status.Inactive,
+            1n,
+            setStatusSig,
+          ),
+      ).to.be.revertedWithCustomError(registry, "EnforcedPause");
+
+      await expect(
+        registry
+          .connect(recorder)
+          .recordDataAccess(
+            user1.address,
+            SCOPE,
+            1n,
+            other.address,
+            ethers.keccak256(ethers.toUtf8Bytes("paused-record")),
+            recordSig,
+          ),
+      ).to.be.revertedWithCustomError(registry, "EnforcedPause");
+
+      // Unpause restores writes.
+      await registry.connect(owner).unpause();
+      await registry.connect(user1).addData(SCOPE, DATA_HASH_2, META_HASH_2)
+        .should.be.fulfilled;
+      (await registry.currentVersion(user1.address, SCOPE)).should.eq(2n);
+    });
+  });
+
+  // ====================== Upgrade authorization ======================
+
+  describe("Upgrade authorization", () => {
+    beforeEach(async () => {
+      await deploy();
+    });
+
+    it("should reject upgradeToAndCall from non-admin", async function () {
+      const newImpl = await (
+        await ethers.getContractFactory("DataRegistryV2Implementation")
+      ).deploy();
+      await newImpl.waitForDeployment();
+
+      await expect(
+        registry
+          .connect(user1)
+          .upgradeToAndCall(await newImpl.getAddress(), "0x"),
+      ).to.be.revertedWithCustomError(
+        registry,
+        "AccessControlUnauthorizedAccount",
+      );
+    });
+
+    it("should allow admin to upgrade and preserve data state", async function () {
+      // Populate real state first so the upgrade proves storage survival,
+      // not just that the call didn't revert.
+      await registry.connect(user1).addData(SCOPE, DATA_HASH, META_HASH);
+      await registry.connect(user1).addData(SCOPE, DATA_HASH_2, META_HASH_2);
+      await registry.connect(user1).setStatus(SCOPE, Status.Inactive);
+
+      const newImpl = await (
+        await ethers.getContractFactory("DataRegistryV2Implementation")
+      ).deploy();
+      await newImpl.waitForDeployment();
+
+      await registry
+        .connect(owner)
+        .upgradeToAndCall(await newImpl.getAddress(), "0x").should.be
+        .fulfilled;
+
+      (await registry.version()).should.eq(1);
+      const info = await registry.dataPoints(user1.address, SCOPE);
+      info.currentVersion.should.eq(2n);
+      info.status.should.eq(Status.Inactive);
+      info.currentCommitment.should.eq(commitmentOf(DATA_HASH_2, META_HASH_2));
+      (await registry.dataCommitment(user1.address, SCOPE, 1)).should.eq(
+        commitmentOf(DATA_HASH, META_HASH),
+      );
+      (await registry.hasRole(DEFAULT_ADMIN_ROLE, owner.address)).should.eq(
+        true,
+      );
+    });
+  });
+});

--- a/test/dataPortability/dataPortabilityEscrow.ts
+++ b/test/dataPortability/dataPortabilityEscrow.ts
@@ -1,0 +1,2016 @@
+import chai, { expect, should } from "chai";
+import chaiAsPromised from "chai-as-promised";
+import { ethers, upgrades } from "hardhat";
+import {
+  loadFixture,
+  time,
+} from "@nomicfoundation/hardhat-network-helpers";
+import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers";
+import {
+  DataPortabilityEscrowImplementation,
+  DataPortabilityPermissionsV2Implementation,
+  DataPortabilityServersV2Implementation,
+  DataRegistryV2Implementation,
+  ERC20FeeOnTransferMock,
+  ERC20Mock,
+  ERC3009Mock,
+  NativeRejecterMock,
+  OpTargetMock,
+} from "../../typechain-types";
+
+chai.use(chaiAsPromised);
+should();
+
+describe("DataPortabilityEscrow", () => {
+  let deployer: HardhatEthersSigner;
+  let owner: HardhatEthersSigner;
+  let facilitator: HardhatEthersSigner;
+  let user1: HardhatEthersSigner;
+  let user2: HardhatEthersSigner;
+  let payee: HardhatEthersSigner;
+  let relayer: HardhatEthersSigner;
+  let serverSigner: HardhatEthersSigner;
+
+  let escrow: DataPortabilityEscrowImplementation;
+  let token: ERC20Mock;
+  let token3009: ERC3009Mock;
+  let feeToken: ERC20FeeOnTransferMock;
+  let rejecter: NativeRejecterMock;
+  let opTarget: OpTargetMock;
+
+  const DEFAULT_ADMIN_ROLE =
+    "0x0000000000000000000000000000000000000000000000000000000000000000";
+  const FACILITATOR_ROLE = ethers.keccak256(
+    ethers.toUtf8Bytes("FACILITATOR_ROLE"),
+  );
+  const NATIVE = ethers.ZeroAddress;
+  const ZERO_REF = ethers.ZeroHash;
+
+  // OpKind enum mirror
+  const OpKind = {
+    Unspecified: 0n,
+    DataRegistration: 1n,
+    ServerRegistration: 2n,
+    BuilderRegistration: 3n,
+    GrantRegistration: 4n,
+    DataAccess: 5n,
+  };
+
+  const abiCoder = ethers.AbiCoder.defaultAbiCoder();
+  const parseEther = ethers.parseEther;
+
+  const deploy = async () => {
+    [deployer, owner, facilitator, user1, user2, payee, relayer, serverSigner] =
+      await ethers.getSigners();
+
+    const EscrowFactory = await ethers.getContractFactory(
+      "DataPortabilityEscrowImplementation",
+    );
+    const escrowDeploy = await upgrades.deployProxy(
+      EscrowFactory,
+      [owner.address, facilitator.address],
+      { kind: "uups" },
+    );
+    escrow = await ethers.getContractAt(
+      "DataPortabilityEscrowImplementation",
+      escrowDeploy.target,
+    );
+
+    const ERC20MockFactory = await ethers.getContractFactory("ERC20Mock");
+    token = await ERC20MockFactory.deploy("Test Token", "TT");
+    await token.waitForDeployment();
+
+    const ERC3009MockFactory = await ethers.getContractFactory("ERC3009Mock");
+    token3009 = await ERC3009MockFactory.deploy();
+    await token3009.waitForDeployment();
+
+    const FeeTokenFactory = await ethers.getContractFactory(
+      "ERC20FeeOnTransferMock",
+    );
+    feeToken = await FeeTokenFactory.deploy(1000); // 10% fee
+    await feeToken.waitForDeployment();
+
+    const RejecterFactory =
+      await ethers.getContractFactory("NativeRejecterMock");
+    rejecter = await RejecterFactory.deploy();
+    await rejecter.waitForDeployment();
+
+    const OpTargetFactory = await ethers.getContractFactory("OpTargetMock");
+    opTarget = await OpTargetFactory.deploy();
+    await opTarget.waitForDeployment();
+
+    // distribute tokens
+    await token.connect(deployer).transfer(user1.address, parseEther("1000"));
+    await token.connect(deployer).transfer(user2.address, parseEther("1000"));
+    await token3009.mint(user1.address, parseEther("1000"));
+    await feeToken.mint(user1.address, parseEther("1000"));
+  };
+
+  beforeEach(async () => {
+    await loadFixture(deploy);
+  });
+
+  const whitelist = async (tokenAddress: string) => {
+    await escrow.connect(owner).setTokenWhitelisted(tokenAddress, true);
+  };
+
+  const depositNativeFor = async (
+    account: HardhatEthersSigner,
+    amount: bigint,
+  ) => {
+    await escrow
+      .connect(account)
+      .depositNative(account.address, { value: amount });
+  };
+
+  const depositTokenFor = async (
+    account: HardhatEthersSigner,
+    amount: bigint,
+  ) => {
+    await whitelist(await token.getAddress());
+    await token.connect(account).approve(await escrow.getAddress(), amount);
+    await escrow
+      .connect(account)
+      .depositToken(account.address, await token.getAddress(), amount);
+  };
+
+  // ---- EIP-3009 signing helper ----
+  const sign3009 = async (
+    from: HardhatEthersSigner,
+    params: {
+      account: string;
+      value: bigint;
+      validAfter?: bigint;
+      validBefore?: bigint;
+      salt?: string;
+    },
+  ) => {
+    const validAfter = params.validAfter ?? 0n;
+    const validBefore =
+      params.validBefore ?? BigInt((await time.latest()) + 3600);
+    const salt = params.salt ?? ethers.id("default-salt");
+    const nonce = ethers.keccak256(
+      abiCoder.encode(["address", "bytes32"], [params.account, salt]),
+    );
+
+    const domain = {
+      name: "Mock USDC",
+      version: "1",
+      chainId: (await ethers.provider.getNetwork()).chainId,
+      verifyingContract: await token3009.getAddress(),
+    };
+    const types = {
+      ReceiveWithAuthorization: [
+        { name: "from", type: "address" },
+        { name: "to", type: "address" },
+        { name: "value", type: "uint256" },
+        { name: "validAfter", type: "uint256" },
+        { name: "validBefore", type: "uint256" },
+        { name: "nonce", type: "bytes32" },
+      ],
+    };
+    const message = {
+      from: from.address,
+      to: await escrow.getAddress(),
+      value: params.value,
+      validAfter,
+      validBefore,
+      nonce,
+    };
+    const signature = await from.signTypedData(domain, types, message);
+    const { v, r, s } = ethers.Signature.from(signature);
+    return { validAfter, validBefore, salt, nonce, v, r, s };
+  };
+
+  describe("Setup", () => {
+    it("should set roles and version correctly", async function () {
+      (await escrow.hasRole(DEFAULT_ADMIN_ROLE, owner.address)).should.eq(true);
+      (await escrow.hasRole(FACILITATOR_ROLE, facilitator.address)).should.eq(
+        true,
+      );
+      (await escrow.hasRole(DEFAULT_ADMIN_ROLE, deployer.address)).should.eq(
+        false,
+      );
+      (await escrow.hasRole(FACILITATOR_ROLE, owner.address)).should.eq(false);
+      (await escrow.version()).should.eq(1);
+    });
+
+    it("should reject re-initialization", async function () {
+      await escrow
+        .initialize(owner.address, facilitator.address)
+        .should.be.rejectedWith("InvalidInitialization()");
+    });
+
+    it("should reject zero addresses in initialize", async function () {
+      const EscrowFactory = await ethers.getContractFactory(
+        "DataPortabilityEscrowImplementation",
+      );
+      const impl = await EscrowFactory.deploy();
+      await impl.waitForDeployment();
+      const ProxyFactory = await ethers.getContractFactory(
+        "DataPortabilityEscrowProxy",
+      );
+
+      await expect(
+        ProxyFactory.deploy(
+          await impl.getAddress(),
+          EscrowFactory.interface.encodeFunctionData("initialize", [
+            ethers.ZeroAddress,
+            facilitator.address,
+          ]),
+        ),
+      ).to.be.revertedWithCustomError(EscrowFactory, "ZeroAddress");
+
+      await expect(
+        ProxyFactory.deploy(
+          await impl.getAddress(),
+          EscrowFactory.interface.encodeFunctionData("initialize", [
+            owner.address,
+            ethers.ZeroAddress,
+          ]),
+        ),
+      ).to.be.revertedWithCustomError(EscrowFactory, "ZeroAddress");
+    });
+
+    it("should only allow admin to authorize upgrades", async function () {
+      const EscrowFactory = await ethers.getContractFactory(
+        "DataPortabilityEscrowImplementation",
+      );
+      const newImpl = await EscrowFactory.deploy();
+      await newImpl.waitForDeployment();
+
+      await expect(
+        escrow
+          .connect(user1)
+          .upgradeToAndCall(await newImpl.getAddress(), "0x"),
+      ).to.be.revertedWithCustomError(
+        escrow,
+        "AccessControlUnauthorizedAccount",
+      );
+
+      await escrow
+        .connect(owner)
+        .upgradeToAndCall(await newImpl.getAddress(), "0x").should.be.fulfilled;
+    });
+
+    it("should only allow admin to pause and unpause", async function () {
+      await expect(
+        escrow.connect(user1).pause(),
+      ).to.be.revertedWithCustomError(
+        escrow,
+        "AccessControlUnauthorizedAccount",
+      );
+      await escrow.connect(owner).pause();
+      (await escrow.paused()).should.eq(true);
+      await expect(
+        escrow.connect(facilitator).unpause(),
+      ).to.be.revertedWithCustomError(
+        escrow,
+        "AccessControlUnauthorizedAccount",
+      );
+      await escrow.connect(owner).unpause();
+      (await escrow.paused()).should.eq(false);
+    });
+  });
+
+  describe("Native deposits", () => {
+    it("should credit the target account and emit Deposited", async function () {
+      const amount = parseEther("5");
+      await expect(
+        escrow.connect(user1).depositNative(user1.address, { value: amount }),
+      )
+        .to.emit(escrow, "Deposited")
+        .withArgs(user1.address, user1.address, NATIVE, amount);
+
+      (await escrow.balanceOf(user1.address, NATIVE)).should.eq(amount);
+      (
+        await ethers.provider.getBalance(await escrow.getAddress())
+      ).should.eq(amount);
+    });
+
+    it("should allow depositing on behalf of another account", async function () {
+      const amount = parseEther("2");
+      await expect(
+        escrow.connect(user2).depositNative(user1.address, { value: amount }),
+      )
+        .to.emit(escrow, "Deposited")
+        .withArgs(user2.address, user1.address, NATIVE, amount);
+
+      (await escrow.balanceOf(user1.address, NATIVE)).should.eq(amount);
+      (await escrow.balanceOf(user2.address, NATIVE)).should.eq(0);
+    });
+
+    it("should accumulate multiple deposits", async function () {
+      await depositNativeFor(user1, parseEther("1"));
+      await depositNativeFor(user1, parseEther("2"));
+      (await escrow.balanceOf(user1.address, NATIVE)).should.eq(
+        parseEther("3"),
+      );
+    });
+
+    it("should reject zero amount", async function () {
+      await expect(
+        escrow.connect(user1).depositNative(user1.address, { value: 0 }),
+      ).to.be.revertedWithCustomError(escrow, "ZeroAmount");
+    });
+
+    it("should reject zero account", async function () {
+      await expect(
+        escrow
+          .connect(user1)
+          .depositNative(ethers.ZeroAddress, { value: parseEther("1") }),
+      ).to.be.revertedWithCustomError(escrow, "ZeroAddress");
+    });
+
+    it("should reject deposits when paused", async function () {
+      await escrow.connect(owner).pause();
+      await expect(
+        escrow
+          .connect(user1)
+          .depositNative(user1.address, { value: parseEther("1") }),
+      ).to.be.revertedWithCustomError(escrow, "EnforcedPause");
+    });
+
+    it("should reject bare native transfers via receive()", async function () {
+      await expect(
+        user1.sendTransaction({
+          to: await escrow.getAddress(),
+          value: parseEther("1"),
+        }),
+      ).to.be.revertedWithCustomError(escrow, "UnexpectedNativeValue");
+    });
+  });
+
+  describe("Token whitelist", () => {
+    it("should only allow admin to update the whitelist", async function () {
+      await expect(
+        escrow
+          .connect(user1)
+          .setTokenWhitelisted(await token.getAddress(), true),
+      ).to.be.revertedWithCustomError(
+        escrow,
+        "AccessControlUnauthorizedAccount",
+      );
+    });
+
+    it("should whitelist and un-whitelist with events", async function () {
+      const tokenAddress = await token.getAddress();
+      await expect(escrow.connect(owner).setTokenWhitelisted(tokenAddress, true))
+        .to.emit(escrow, "TokenWhitelistUpdated")
+        .withArgs(tokenAddress, true);
+      (await escrow.isWhitelistedToken(tokenAddress)).should.eq(true);
+
+      await expect(
+        escrow.connect(owner).setTokenWhitelisted(tokenAddress, false),
+      )
+        .to.emit(escrow, "TokenWhitelistUpdated")
+        .withArgs(tokenAddress, false);
+      (await escrow.isWhitelistedToken(tokenAddress)).should.eq(false);
+    });
+
+    it("should never whitelist the native placeholder address(0)", async function () {
+      await expect(
+        escrow.connect(owner).setTokenWhitelisted(ethers.ZeroAddress, true),
+      ).to.be.revertedWithCustomError(escrow, "ZeroAddress");
+    });
+  });
+
+  describe("Token deposits", () => {
+    it("should reject non-whitelisted tokens", async function () {
+      const tokenAddress = await token.getAddress();
+      await token
+        .connect(user1)
+        .approve(await escrow.getAddress(), parseEther("1"));
+      await expect(
+        escrow
+          .connect(user1)
+          .depositToken(user1.address, tokenAddress, parseEther("1")),
+      )
+        .to.be.revertedWithCustomError(escrow, "AssetNotSupported")
+        .withArgs(tokenAddress);
+    });
+
+    it("should credit the account and emit Deposited", async function () {
+      const tokenAddress = await token.getAddress();
+      const amount = parseEther("10");
+      await whitelist(tokenAddress);
+      await token.connect(user1).approve(await escrow.getAddress(), amount);
+
+      await expect(
+        escrow.connect(user1).depositToken(user2.address, tokenAddress, amount),
+      )
+        .to.emit(escrow, "Deposited")
+        .withArgs(user1.address, user2.address, tokenAddress, amount);
+
+      (await escrow.balanceOf(user2.address, tokenAddress)).should.eq(amount);
+      (await token.balanceOf(await escrow.getAddress())).should.eq(amount);
+    });
+
+    it("should reject zero amount and zero account", async function () {
+      const tokenAddress = await token.getAddress();
+      await whitelist(tokenAddress);
+      await expect(
+        escrow.connect(user1).depositToken(user1.address, tokenAddress, 0),
+      ).to.be.revertedWithCustomError(escrow, "ZeroAmount");
+      await expect(
+        escrow
+          .connect(user1)
+          .depositToken(ethers.ZeroAddress, tokenAddress, parseEther("1")),
+      ).to.be.revertedWithCustomError(escrow, "ZeroAddress");
+    });
+
+    it("should credit only the received amount for fee-on-transfer tokens", async function () {
+      const feeTokenAddress = await feeToken.getAddress();
+      const amount = parseEther("100");
+      await whitelist(feeTokenAddress);
+      await feeToken.connect(user1).approve(await escrow.getAddress(), amount);
+
+      const expected = (amount * 9000n) / 10000n; // 10% fee burned
+      await expect(
+        escrow
+          .connect(user1)
+          .depositToken(user1.address, feeTokenAddress, amount),
+      )
+        .to.emit(escrow, "Deposited")
+        .withArgs(user1.address, user1.address, feeTokenAddress, expected);
+
+      (await escrow.balanceOf(user1.address, feeTokenAddress)).should.eq(
+        expected,
+      );
+    });
+
+    it("should reject when nothing is actually received (100% fee)", async function () {
+      const feeTokenAddress = await feeToken.getAddress();
+      await feeToken.setFeeBps(10000);
+      await whitelist(feeTokenAddress);
+      await feeToken
+        .connect(user1)
+        .approve(await escrow.getAddress(), parseEther("1"));
+      await expect(
+        escrow
+          .connect(user1)
+          .depositToken(user1.address, feeTokenAddress, parseEther("1")),
+      ).to.be.revertedWithCustomError(escrow, "ZeroAmount");
+    });
+
+    it("should reject deposits when paused", async function () {
+      const tokenAddress = await token.getAddress();
+      await whitelist(tokenAddress);
+      await token
+        .connect(user1)
+        .approve(await escrow.getAddress(), parseEther("1"));
+      await escrow.connect(owner).pause();
+      await expect(
+        escrow
+          .connect(user1)
+          .depositToken(user1.address, tokenAddress, parseEther("1")),
+      ).to.be.revertedWithCustomError(escrow, "EnforcedPause");
+    });
+
+    it("should keep de-whitelisted funds movable (settle + withdraw) but block new deposits", async function () {
+      const tokenAddress = await token.getAddress();
+      await depositTokenFor(user1, parseEther("10"));
+
+      await escrow.connect(owner).setTokenWhitelisted(tokenAddress, false);
+
+      // new deposit blocked
+      await token
+        .connect(user1)
+        .approve(await escrow.getAddress(), parseEther("1"));
+      await expect(
+        escrow
+          .connect(user1)
+          .depositToken(user1.address, tokenAddress, parseEther("1")),
+      ).to.be.revertedWithCustomError(escrow, "AssetNotSupported");
+
+      // settle of already-escrowed funds still works
+      await escrow
+        .connect(facilitator)
+        .settle(
+          user1.address,
+          payee.address,
+          tokenAddress,
+          parseEther("4"),
+          OpKind.Unspecified,
+          ZERO_REF,
+        );
+      (await token.balanceOf(payee.address)).should.eq(parseEther("4"));
+
+      // withdraw still works
+      await escrow
+        .connect(facilitator)
+        .withdraw(user1.address, tokenAddress, parseEther("6"), ZERO_REF);
+      (await escrow.balanceOf(user1.address, tokenAddress)).should.eq(0);
+    });
+  });
+
+  describe("EIP-3009 deposits (depositTokenWithAuthorization)", () => {
+    const value = parseEther("50");
+    let tokenAddress: string;
+
+    beforeEach(async () => {
+      tokenAddress = await token3009.getAddress();
+      await whitelist(tokenAddress);
+    });
+
+    it("should deposit with a valid authorization submitted by a relayer", async function () {
+      const { validAfter, validBefore, salt, nonce, v, r, s } = await sign3009(
+        user1,
+        { account: user1.address, value },
+      );
+
+      await expect(
+        escrow
+          .connect(relayer)
+          .depositTokenWithAuthorization(
+            user1.address,
+            user1.address,
+            tokenAddress,
+            value,
+            validAfter,
+            validBefore,
+            salt,
+            v,
+            r,
+            s,
+          ),
+      )
+        .to.emit(escrow, "Deposited")
+        .withArgs(user1.address, user1.address, tokenAddress, value);
+
+      (await escrow.balanceOf(user1.address, tokenAddress)).should.eq(value);
+      (await token3009.balanceOf(await escrow.getAddress())).should.eq(value);
+      (await token3009.authorizationState(user1.address, nonce)).should.eq(
+        true,
+      );
+    });
+
+    it("should support crediting a beneficiary different from the token owner", async function () {
+      const { validAfter, validBefore, salt, v, r, s } = await sign3009(
+        user1,
+        { account: user2.address, value },
+      );
+
+      await expect(
+        escrow
+          .connect(relayer)
+          .depositTokenWithAuthorization(
+            user2.address,
+            user1.address,
+            tokenAddress,
+            value,
+            validAfter,
+            validBefore,
+            salt,
+            v,
+            r,
+            s,
+          ),
+      )
+        .to.emit(escrow, "Deposited")
+        .withArgs(user1.address, user2.address, tokenAddress, value);
+
+      (await escrow.balanceOf(user2.address, tokenAddress)).should.eq(value);
+      (await escrow.balanceOf(user1.address, tokenAddress)).should.eq(0);
+    });
+
+    it("should reject a relayer that substitutes the beneficiary account", async function () {
+      // user1 signs for beneficiary user1, relayer tries to redirect to user2:
+      // the recomputed nonce differs from the signed one → token signature check fails.
+      const { validAfter, validBefore, salt, v, r, s } = await sign3009(
+        user1,
+        { account: user1.address, value },
+      );
+
+      await expect(
+        escrow
+          .connect(relayer)
+          .depositTokenWithAuthorization(
+            user2.address,
+            user1.address,
+            tokenAddress,
+            value,
+            validAfter,
+            validBefore,
+            salt,
+            v,
+            r,
+            s,
+          ),
+      ).to.be.revertedWithCustomError(
+        token3009,
+        "InvalidAuthorizationSignature",
+      );
+    });
+
+    it("should reject replay of a consumed authorization", async function () {
+      const { validAfter, validBefore, salt, v, r, s } = await sign3009(
+        user1,
+        { account: user1.address, value },
+      );
+      await escrow
+        .connect(relayer)
+        .depositTokenWithAuthorization(
+          user1.address,
+          user1.address,
+          tokenAddress,
+          value,
+          validAfter,
+          validBefore,
+          salt,
+          v,
+          r,
+          s,
+        );
+
+      await expect(
+        escrow
+          .connect(relayer)
+          .depositTokenWithAuthorization(
+            user1.address,
+            user1.address,
+            tokenAddress,
+            value,
+            validAfter,
+            validBefore,
+            salt,
+            v,
+            r,
+            s,
+          ),
+      ).to.be.revertedWithCustomError(token3009, "AuthorizationAlreadyUsed");
+    });
+
+    it("should reject non-whitelisted tokens", async function () {
+      await escrow.connect(owner).setTokenWhitelisted(tokenAddress, false);
+      const { validAfter, validBefore, salt, v, r, s } = await sign3009(
+        user1,
+        { account: user1.address, value },
+      );
+      await expect(
+        escrow
+          .connect(relayer)
+          .depositTokenWithAuthorization(
+            user1.address,
+            user1.address,
+            tokenAddress,
+            value,
+            validAfter,
+            validBefore,
+            salt,
+            v,
+            r,
+            s,
+          ),
+      ).to.be.revertedWithCustomError(escrow, "AssetNotSupported");
+    });
+
+    it("should reject zero value / zero account / zero from", async function () {
+      const { validAfter, validBefore, salt, v, r, s } = await sign3009(
+        user1,
+        { account: user1.address, value },
+      );
+      await expect(
+        escrow
+          .connect(relayer)
+          .depositTokenWithAuthorization(
+            user1.address,
+            user1.address,
+            tokenAddress,
+            0,
+            validAfter,
+            validBefore,
+            salt,
+            v,
+            r,
+            s,
+          ),
+      ).to.be.revertedWithCustomError(escrow, "ZeroAmount");
+      await expect(
+        escrow
+          .connect(relayer)
+          .depositTokenWithAuthorization(
+            ethers.ZeroAddress,
+            user1.address,
+            tokenAddress,
+            value,
+            validAfter,
+            validBefore,
+            salt,
+            v,
+            r,
+            s,
+          ),
+      ).to.be.revertedWithCustomError(escrow, "ZeroAddress");
+      await expect(
+        escrow
+          .connect(relayer)
+          .depositTokenWithAuthorization(
+            user1.address,
+            ethers.ZeroAddress,
+            tokenAddress,
+            value,
+            validAfter,
+            validBefore,
+            salt,
+            v,
+            r,
+            s,
+          ),
+      ).to.be.revertedWithCustomError(escrow, "ZeroAddress");
+    });
+
+    it("should respect the validity window", async function () {
+      const now = BigInt(await time.latest());
+
+      // expired
+      let sig = await sign3009(user1, {
+        account: user1.address,
+        value,
+        validBefore: now - 1n,
+      });
+      await expect(
+        escrow
+          .connect(relayer)
+          .depositTokenWithAuthorization(
+            user1.address,
+            user1.address,
+            tokenAddress,
+            value,
+            sig.validAfter,
+            sig.validBefore,
+            sig.salt,
+            sig.v,
+            sig.r,
+            sig.s,
+          ),
+      ).to.be.revertedWithCustomError(token3009, "AuthorizationExpired");
+
+      // not yet valid
+      sig = await sign3009(user1, {
+        account: user1.address,
+        value,
+        validAfter: now + 3600n,
+        validBefore: now + 7200n,
+      });
+      await expect(
+        escrow
+          .connect(relayer)
+          .depositTokenWithAuthorization(
+            user1.address,
+            user1.address,
+            tokenAddress,
+            value,
+            sig.validAfter,
+            sig.validBefore,
+            sig.salt,
+            sig.v,
+            sig.r,
+            sig.s,
+          ),
+      ).to.be.revertedWithCustomError(token3009, "AuthorizationNotYetValid");
+    });
+
+    it("should credit only the balance diff when less than value arrives", async function () {
+      // The token skims 10% after transfer — natspec: "Balance-diff
+      // accounting credits only what actually arrived."
+      await token3009.setSkimBps(1000);
+      const { validAfter, validBefore, salt, v, r, s } = await sign3009(
+        user1,
+        { account: user1.address, value },
+      );
+
+      const expected = (value * 9000n) / 10000n;
+      await expect(
+        escrow
+          .connect(relayer)
+          .depositTokenWithAuthorization(
+            user1.address,
+            user1.address,
+            tokenAddress,
+            value,
+            validAfter,
+            validBefore,
+            salt,
+            v,
+            r,
+            s,
+          ),
+      )
+        .to.emit(escrow, "Deposited")
+        .withArgs(user1.address, user1.address, tokenAddress, expected);
+
+      (await escrow.balanceOf(user1.address, tokenAddress)).should.eq(
+        expected,
+      );
+    });
+
+    it("should reject when nothing actually arrives (100% skim)", async function () {
+      await token3009.setSkimBps(10000);
+      const { validAfter, validBefore, salt, v, r, s } = await sign3009(
+        user1,
+        { account: user1.address, value },
+      );
+      await expect(
+        escrow
+          .connect(relayer)
+          .depositTokenWithAuthorization(
+            user1.address,
+            user1.address,
+            tokenAddress,
+            value,
+            validAfter,
+            validBefore,
+            salt,
+            v,
+            r,
+            s,
+          ),
+      ).to.be.revertedWithCustomError(escrow, "ZeroAmount");
+    });
+
+    it("should reject when paused", async function () {
+      const { validAfter, validBefore, salt, v, r, s } = await sign3009(
+        user1,
+        { account: user1.address, value },
+      );
+      await escrow.connect(owner).pause();
+      await expect(
+        escrow
+          .connect(relayer)
+          .depositTokenWithAuthorization(
+            user1.address,
+            user1.address,
+            tokenAddress,
+            value,
+            validAfter,
+            validBefore,
+            salt,
+            v,
+            r,
+            s,
+          ),
+      ).to.be.revertedWithCustomError(escrow, "EnforcedPause");
+    });
+  });
+
+  describe("Settle", () => {
+    it("should only be callable by the facilitator", async function () {
+      await depositNativeFor(user1, parseEther("5"));
+      await expect(
+        escrow
+          .connect(user1)
+          .settle(
+            user1.address,
+            payee.address,
+            NATIVE,
+            parseEther("1"),
+            OpKind.Unspecified,
+            ZERO_REF,
+          ),
+      ).to.be.revertedWithCustomError(
+        escrow,
+        "AccessControlUnauthorizedAccount",
+      );
+    });
+
+    it("should debit the account and pay the external recipient (native)", async function () {
+      await depositNativeFor(user1, parseEther("5"));
+      const ref = ethers.id("grant-1");
+
+      const tx = escrow
+        .connect(facilitator)
+        .settle(
+          user1.address,
+          payee.address,
+          NATIVE,
+          parseEther("2"),
+          OpKind.GrantRegistration,
+          ref,
+        );
+
+      await expect(tx)
+        .to.emit(escrow, "Settled")
+        .withArgs(
+          user1.address,
+          payee.address,
+          ref,
+          NATIVE,
+          parseEther("2"),
+          OpKind.GrantRegistration,
+        );
+      await expect(tx).to.changeEtherBalances(
+        [payee, escrow],
+        [parseEther("2"), -parseEther("2")],
+      );
+
+      (await escrow.balanceOf(user1.address, NATIVE)).should.eq(
+        parseEther("3"),
+      );
+    });
+
+    it("should debit the account and pay the external recipient (ERC20)", async function () {
+      await depositTokenFor(user1, parseEther("10"));
+      const tokenAddress = await token.getAddress();
+
+      await expect(
+        escrow
+          .connect(facilitator)
+          .settle(
+            user1.address,
+            payee.address,
+            tokenAddress,
+            parseEther("4"),
+            OpKind.DataAccess,
+            ZERO_REF,
+          ),
+      )
+        .to.emit(escrow, "Settled")
+        .withArgs(
+          user1.address,
+          payee.address,
+          ZERO_REF,
+          tokenAddress,
+          parseEther("4"),
+          OpKind.DataAccess,
+        );
+
+      (await token.balanceOf(payee.address)).should.eq(parseEther("4"));
+      (await escrow.balanceOf(user1.address, tokenAddress)).should.eq(
+        parseEther("6"),
+      );
+    });
+
+    it("should reject on insufficient balance with details", async function () {
+      await depositNativeFor(user1, parseEther("1"));
+      await expect(
+        escrow
+          .connect(facilitator)
+          .settle(
+            user1.address,
+            payee.address,
+            NATIVE,
+            parseEther("2"),
+            OpKind.Unspecified,
+            ZERO_REF,
+          ),
+      )
+        .to.be.revertedWithCustomError(escrow, "InsufficientBalance")
+        .withArgs(user1.address, NATIVE, parseEther("2"), parseEther("1"));
+    });
+
+    it("should reject zero amount and zero addresses", async function () {
+      await depositNativeFor(user1, parseEther("1"));
+      await expect(
+        escrow
+          .connect(facilitator)
+          .settle(
+            user1.address,
+            payee.address,
+            NATIVE,
+            0,
+            OpKind.Unspecified,
+            ZERO_REF,
+          ),
+      ).to.be.revertedWithCustomError(escrow, "ZeroAmount");
+      await expect(
+        escrow
+          .connect(facilitator)
+          .settle(
+            ethers.ZeroAddress,
+            payee.address,
+            NATIVE,
+            parseEther("1"),
+            OpKind.Unspecified,
+            ZERO_REF,
+          ),
+      ).to.be.revertedWithCustomError(escrow, "ZeroAddress");
+      await expect(
+        escrow
+          .connect(facilitator)
+          .settle(
+            user1.address,
+            ethers.ZeroAddress,
+            NATIVE,
+            parseEther("1"),
+            OpKind.Unspecified,
+            ZERO_REF,
+          ),
+      ).to.be.revertedWithCustomError(escrow, "ZeroAddress");
+    });
+
+    it("should surface NativeTransferFailed for rejecting recipients", async function () {
+      await depositNativeFor(user1, parseEther("1"));
+      await expect(
+        escrow
+          .connect(facilitator)
+          .settle(
+            user1.address,
+            await rejecter.getAddress(),
+            NATIVE,
+            parseEther("1"),
+            OpKind.Unspecified,
+            ZERO_REF,
+          ),
+      ).to.be.revertedWithCustomError(escrow, "NativeTransferFailed");
+    });
+
+    it("should reject when paused", async function () {
+      await depositNativeFor(user1, parseEther("1"));
+      await escrow.connect(owner).pause();
+      await expect(
+        escrow
+          .connect(facilitator)
+          .settle(
+            user1.address,
+            payee.address,
+            NATIVE,
+            parseEther("1"),
+            OpKind.Unspecified,
+            ZERO_REF,
+          ),
+      ).to.be.revertedWithCustomError(escrow, "EnforcedPause");
+    });
+  });
+
+  describe("SettleBatch", () => {
+    it("should execute multiple ops across assets and emit one Settled each", async function () {
+      await depositNativeFor(user1, parseEther("5"));
+      await depositTokenFor(user2, parseEther("10"));
+      const tokenAddress = await token.getAddress();
+
+      const refA = ethers.id("ref-a");
+      const refB = ethers.id("ref-b");
+      const tx = escrow.connect(facilitator).settleBatch([
+        {
+          from: user1.address,
+          to: payee.address,
+          asset: NATIVE,
+          amount: parseEther("1"),
+          opKind: OpKind.GrantRegistration,
+          ref: refA,
+        },
+        {
+          from: user2.address,
+          to: payee.address,
+          asset: tokenAddress,
+          amount: parseEther("3"),
+          opKind: OpKind.DataAccess,
+          ref: refB,
+        },
+      ]);
+
+      await expect(tx)
+        .to.emit(escrow, "Settled")
+        .withArgs(
+          user1.address,
+          payee.address,
+          refA,
+          NATIVE,
+          parseEther("1"),
+          OpKind.GrantRegistration,
+        );
+      await expect(tx)
+        .to.emit(escrow, "Settled")
+        .withArgs(
+          user2.address,
+          payee.address,
+          refB,
+          tokenAddress,
+          parseEther("3"),
+          OpKind.DataAccess,
+        );
+
+      (await escrow.balanceOf(user1.address, NATIVE)).should.eq(
+        parseEther("4"),
+      );
+      (await escrow.balanceOf(user2.address, tokenAddress)).should.eq(
+        parseEther("7"),
+      );
+    });
+
+    it("should be atomic — a failing op reverts the whole batch", async function () {
+      await depositNativeFor(user1, parseEther("5"));
+
+      await expect(
+        escrow.connect(facilitator).settleBatch([
+          {
+            from: user1.address,
+            to: payee.address,
+            asset: NATIVE,
+            amount: parseEther("1"),
+            opKind: OpKind.Unspecified,
+            ref: ZERO_REF,
+          },
+          {
+            from: user2.address, // nothing deposited
+            to: payee.address,
+            asset: NATIVE,
+            amount: parseEther("1"),
+            opKind: OpKind.Unspecified,
+            ref: ZERO_REF,
+          },
+        ]),
+      ).to.be.revertedWithCustomError(escrow, "InsufficientBalance");
+
+      (await escrow.balanceOf(user1.address, NATIVE)).should.eq(
+        parseEther("5"),
+      );
+    });
+
+    it("should accept an empty batch as a no-op", async function () {
+      await escrow.connect(facilitator).settleBatch([]).should.be.fulfilled;
+    });
+
+    it("should only be callable by the facilitator", async function () {
+      await expect(
+        escrow.connect(user1).settleBatch([]),
+      ).to.be.revertedWithCustomError(
+        escrow,
+        "AccessControlUnauthorizedAccount",
+      );
+    });
+
+    it("should reject when paused", async function () {
+      await escrow.connect(owner).pause();
+      await expect(
+        escrow.connect(facilitator).settleBatch([]),
+      ).to.be.revertedWithCustomError(escrow, "EnforcedPause");
+    });
+  });
+
+  describe("Withdraw", () => {
+    it("should return funds to the account holder (native)", async function () {
+      await depositNativeFor(user1, parseEther("3"));
+      const ref = ethers.id("refund-1");
+
+      const tx = escrow
+        .connect(facilitator)
+        .withdraw(user1.address, NATIVE, parseEther("3"), ref);
+
+      await expect(tx)
+        .to.emit(escrow, "Withdrawn")
+        .withArgs(user1.address, NATIVE, parseEther("3"), ref);
+      await expect(tx).to.changeEtherBalances(
+        [user1, escrow],
+        [parseEther("3"), -parseEther("3")],
+      );
+      (await escrow.balanceOf(user1.address, NATIVE)).should.eq(0);
+    });
+
+    it("should return funds to the account holder (ERC20)", async function () {
+      await depositTokenFor(user1, parseEther("10"));
+      const tokenAddress = await token.getAddress();
+      const before = await token.balanceOf(user1.address);
+
+      await escrow
+        .connect(facilitator)
+        .withdraw(user1.address, tokenAddress, parseEther("10"), ZERO_REF);
+
+      (await token.balanceOf(user1.address)).should.eq(
+        before + parseEther("10"),
+      );
+      (await escrow.balanceOf(user1.address, tokenAddress)).should.eq(0);
+    });
+
+    it("should reject on insufficient balance", async function () {
+      await expect(
+        escrow
+          .connect(facilitator)
+          .withdraw(user1.address, NATIVE, parseEther("1"), ZERO_REF),
+      ).to.be.revertedWithCustomError(escrow, "InsufficientBalance");
+    });
+
+    it("should only be callable by the facilitator", async function () {
+      await depositNativeFor(user1, parseEther("1"));
+      await expect(
+        escrow
+          .connect(user1)
+          .withdraw(user1.address, NATIVE, parseEther("1"), ZERO_REF),
+      ).to.be.revertedWithCustomError(
+        escrow,
+        "AccessControlUnauthorizedAccount",
+      );
+    });
+
+    it("should reject when paused", async function () {
+      await depositNativeFor(user1, parseEther("1"));
+      await escrow.connect(owner).pause();
+      await expect(
+        escrow
+          .connect(facilitator)
+          .withdraw(user1.address, NATIVE, parseEther("1"), ZERO_REF),
+      ).to.be.revertedWithCustomError(escrow, "EnforcedPause");
+    });
+  });
+
+  describe("Cross-contract wiring (setPermissions / setDataRegistry)", () => {
+    it("should be admin-only and reject zero addresses", async function () {
+      await expect(
+        escrow.connect(user1).setPermissions(user2.address),
+      ).to.be.revertedWithCustomError(
+        escrow,
+        "AccessControlUnauthorizedAccount",
+      );
+      await expect(
+        escrow.connect(owner).setPermissions(ethers.ZeroAddress),
+      ).to.be.revertedWithCustomError(escrow, "ZeroAddress");
+      await expect(
+        escrow.connect(user1).setDataRegistry(user2.address),
+      ).to.be.revertedWithCustomError(
+        escrow,
+        "AccessControlUnauthorizedAccount",
+      );
+      await expect(
+        escrow.connect(owner).setDataRegistry(ethers.ZeroAddress),
+      ).to.be.revertedWithCustomError(escrow, "ZeroAddress");
+    });
+
+    it("should emit update events with previous and current values", async function () {
+      await expect(escrow.connect(owner).setPermissions(user2.address))
+        .to.emit(escrow, "PermissionsUpdated")
+        .withArgs(ethers.ZeroAddress, user2.address);
+      await expect(escrow.connect(owner).setPermissions(user1.address))
+        .to.emit(escrow, "PermissionsUpdated")
+        .withArgs(user2.address, user1.address);
+      (await escrow.permissions()).should.eq(user1.address);
+
+      await expect(escrow.connect(owner).setDataRegistry(user2.address))
+        .to.emit(escrow, "DataRegistryUpdated")
+        .withArgs(ethers.ZeroAddress, user2.address);
+      (await escrow.dataRegistry()).should.eq(user2.address);
+    });
+  });
+
+  describe("Op allowlist (setOpAllowed)", () => {
+    let target: string;
+    let pokeSelector: string;
+    let failSelector: string;
+
+    beforeEach(async () => {
+      target = await opTarget.getAddress();
+      pokeSelector = opTarget.interface.getFunction("poke").selector;
+      failSelector = opTarget.interface.getFunction("fail").selector;
+    });
+
+    it("should be admin-only and reject a zero target", async function () {
+      await expect(
+        escrow.connect(user1).setOpAllowed(target, pokeSelector, true),
+      ).to.be.revertedWithCustomError(
+        escrow,
+        "AccessControlUnauthorizedAccount",
+      );
+      await expect(
+        escrow
+          .connect(owner)
+          .setOpAllowed(ethers.ZeroAddress, pokeSelector, true),
+      ).to.be.revertedWithCustomError(escrow, "ZeroAddress");
+    });
+
+    it("should manage the selector and target sets", async function () {
+      await expect(escrow.connect(owner).setOpAllowed(target, pokeSelector, true))
+        .to.emit(escrow, "OpAllowed")
+        .withArgs(target, pokeSelector);
+
+      (await escrow.isAllowedOp(target, pokeSelector)).should.eq(true);
+      [...(await escrow.getAllowedTargets())].should.deep.eq([target]);
+      [...(await escrow.getAllowedSelectors(target))].should.deep.eq([
+        pokeSelector,
+      ]);
+
+      // second selector, same target — target list unchanged
+      await escrow.connect(owner).setOpAllowed(target, failSelector, true);
+      [...(await escrow.getAllowedTargets())].should.deep.eq([target]);
+      [...(await escrow.getAllowedSelectors(target))].should.have.members([
+        pokeSelector,
+        failSelector,
+      ]);
+
+      // removing one selector keeps the target
+      await expect(
+        escrow.connect(owner).setOpAllowed(target, pokeSelector, false),
+      )
+        .to.emit(escrow, "OpDisallowed")
+        .withArgs(target, pokeSelector);
+      [...(await escrow.getAllowedTargets())].should.deep.eq([target]);
+
+      // removing the last selector drops the target
+      await escrow.connect(owner).setOpAllowed(target, failSelector, false);
+      [...(await escrow.getAllowedTargets())].should.deep.eq([]);
+      [...(await escrow.getAllowedSelectors(target))].should.deep.eq([]);
+    });
+
+    it("should be idempotent without spurious events", async function () {
+      await escrow.connect(owner).setOpAllowed(target, pokeSelector, true);
+      await expect(
+        escrow.connect(owner).setOpAllowed(target, pokeSelector, true),
+      ).to.not.emit(escrow, "OpAllowed");
+
+      await expect(
+        escrow.connect(owner).setOpAllowed(target, failSelector, false),
+      ).to.not.emit(escrow, "OpDisallowed");
+    });
+  });
+
+  describe("runOpAndSettle", () => {
+    let target: string;
+    let pokeSelector: string;
+
+    beforeEach(async () => {
+      target = await opTarget.getAddress();
+      pokeSelector = opTarget.interface.getFunction("poke").selector;
+      await escrow.connect(owner).setOpAllowed(target, pokeSelector, true);
+      await depositNativeFor(user1, parseEther("5"));
+    });
+
+    it("should only be callable by the facilitator", async function () {
+      const callData = opTarget.interface.encodeFunctionData("poke", [41]);
+      await expect(
+        escrow.connect(user1).runOpAndSettle(target, callData, []),
+      ).to.be.revertedWithCustomError(
+        escrow,
+        "AccessControlUnauthorizedAccount",
+      );
+    });
+
+    it("should reject calldata shorter than a selector", async function () {
+      await expect(
+        escrow.connect(facilitator).runOpAndSettle(target, "0x112233", []),
+      ).to.be.revertedWithCustomError(escrow, "CallDataTooShort");
+    });
+
+    it("should accept exactly-4-byte calldata past the length check (boundary)", async function () {
+      // A bare non-allowed selector: 4 bytes must clear CallDataTooShort and
+      // fail on the ALLOWLIST instead — proving the boundary is `< 4`.
+      const failSelector = opTarget.interface.getFunction("fail").selector;
+      await expect(
+        escrow.connect(facilitator).runOpAndSettle(target, failSelector, []),
+      )
+        .to.be.revertedWithCustomError(escrow, "OpNotAllowed")
+        .withArgs(target, failSelector);
+    });
+
+    it("should return the target's raw return data", async function () {
+      const callData = opTarget.interface.encodeFunctionData("poke", [41]);
+      const returnData = await escrow
+        .connect(facilitator)
+        .runOpAndSettle.staticCall(target, callData, []);
+      returnData.should.eq(abiCoder.encode(["uint256"], [42]));
+    });
+
+    it("should reject non-allowlisted (target, selector) pairs", async function () {
+      const callData = opTarget.interface.encodeFunctionData("fail", [1]);
+      const failSelector = opTarget.interface.getFunction("fail").selector;
+      await expect(
+        escrow.connect(facilitator).runOpAndSettle(target, callData, []),
+      )
+        .to.be.revertedWithCustomError(escrow, "OpNotAllowed")
+        .withArgs(target, failSelector);
+    });
+
+    it("should scope the allowlist by target, not just selector", async function () {
+      // `poke` is allowed on `target` — the same selector on a different
+      // target must be rejected.
+      const OpTargetFactory = await ethers.getContractFactory("OpTargetMock");
+      const otherTarget = await OpTargetFactory.deploy();
+      await otherTarget.waitForDeployment();
+      const otherAddress = await otherTarget.getAddress();
+
+      (await escrow.isAllowedOp(otherAddress, pokeSelector)).should.eq(false);
+
+      const callData = opTarget.interface.encodeFunctionData("poke", [1]);
+      await expect(
+        escrow.connect(facilitator).runOpAndSettle(otherAddress, callData, []),
+      )
+        .to.be.revertedWithCustomError(escrow, "OpNotAllowed")
+        .withArgs(otherAddress, pokeSelector);
+    });
+
+    it("should dispatch the call, emit OpExecuted, and run the settles", async function () {
+      const callData = opTarget.interface.encodeFunctionData("poke", [41]);
+      const ref = ethers.id("op-ref");
+      const expectedReturn = abiCoder.encode(["uint256"], [42]);
+
+      const tx = escrow.connect(facilitator).runOpAndSettle(target, callData, [
+        {
+          from: user1.address,
+          to: payee.address,
+          asset: NATIVE,
+          amount: parseEther("1"),
+          opKind: OpKind.DataRegistration,
+          ref,
+        },
+      ]);
+
+      await expect(tx)
+        .to.emit(escrow, "OpExecuted")
+        .withArgs(target, pokeSelector, expectedReturn);
+      await expect(tx)
+        .to.emit(opTarget, "Poked")
+        .withArgs(await escrow.getAddress(), 0, 41);
+      await expect(tx)
+        .to.emit(escrow, "Settled")
+        .withArgs(
+          user1.address,
+          payee.address,
+          ref,
+          NATIVE,
+          parseEther("1"),
+          OpKind.DataRegistration,
+        );
+
+      (await opTarget.lastX()).should.eq(41);
+      (await escrow.balanceOf(user1.address, NATIVE)).should.eq(
+        parseEther("4"),
+      );
+    });
+
+    it("should bubble the target's typed revert", async function () {
+      const failSelector = opTarget.interface.getFunction("fail").selector;
+      await escrow.connect(owner).setOpAllowed(target, failSelector, true);
+      const callData = opTarget.interface.encodeFunctionData("fail", [7]);
+
+      await expect(
+        escrow.connect(facilitator).runOpAndSettle(target, callData, []),
+      )
+        .to.be.revertedWithCustomError(opTarget, "TypedFailure")
+        .withArgs(7);
+    });
+
+    it("should revert the op when a settle fails (atomicity)", async function () {
+      const callData = opTarget.interface.encodeFunctionData("poke", [99]);
+      await expect(
+        escrow.connect(facilitator).runOpAndSettle(target, callData, [
+          {
+            from: user1.address,
+            to: payee.address,
+            asset: NATIVE,
+            amount: parseEther("100"), // more than deposited
+            opKind: OpKind.Unspecified,
+            ref: ZERO_REF,
+          },
+        ]),
+      ).to.be.revertedWithCustomError(escrow, "InsufficientBalance");
+
+      // target state rolled back too
+      (await opTarget.lastX()).should.eq(0);
+    });
+
+    it("should reject when paused", async function () {
+      const callData = opTarget.interface.encodeFunctionData("poke", [1]);
+      await escrow.connect(owner).pause();
+      await expect(
+        escrow.connect(facilitator).runOpAndSettle(target, callData, []),
+      ).to.be.revertedWithCustomError(escrow, "EnforcedPause");
+    });
+  });
+
+  describe("registerAndSettle (integration with PermissionsV2)", () => {
+    let permissions: DataPortabilityPermissionsV2Implementation;
+    const granteeId = ethers.id("grantee-1");
+    const scopes = ["scope.read", "scope.write"];
+
+    const signGrant = async (
+      grantor: HardhatEthersSigner,
+      grantVersion: bigint,
+      expiresAt: bigint,
+      signer: HardhatEthersSigner = grantor,
+    ) => {
+      const domain = {
+        name: "Vana Data Portability",
+        version: "1",
+        chainId: (await ethers.provider.getNetwork()).chainId,
+        verifyingContract: await permissions.getAddress(),
+      };
+      const types = {
+        GrantRegistration: [
+          { name: "grantorAddress", type: "address" },
+          { name: "granteeId", type: "bytes32" },
+          { name: "scopes", type: "string[]" },
+          { name: "grantVersion", type: "uint256" },
+          { name: "expiresAt", type: "uint256" },
+        ],
+      };
+      const input = {
+        grantorAddress: grantor.address,
+        granteeId,
+        scopes,
+        grantVersion,
+        expiresAt,
+      };
+      const signature = await signer.signTypedData(domain, types, input);
+      return { input, signature };
+    };
+
+    beforeEach(async () => {
+      const PermissionsFactory = await ethers.getContractFactory(
+        "DataPortabilityPermissionsV2Implementation",
+      );
+      const permissionsDeploy = await upgrades.deployProxy(
+        PermissionsFactory,
+        [owner.address],
+        { kind: "uups" },
+      );
+      permissions = await ethers.getContractAt(
+        "DataPortabilityPermissionsV2Implementation",
+        permissionsDeploy.target,
+      );
+      await depositNativeFor(user1, parseEther("5"));
+    });
+
+    it("should revert when the permissions contract is unset", async function () {
+      const { input, signature } = await signGrant(user1, 1n, 0n);
+      await expect(
+        escrow.connect(facilitator).registerAndSettle(input, signature, []),
+      ).to.be.revertedWithCustomError(escrow, "PermissionsNotSet");
+    });
+
+    it("should register the permission and run payouts atomically", async function () {
+      await escrow
+        .connect(owner)
+        .setPermissions(await permissions.getAddress());
+      const { input, signature } = await signGrant(user1, 1n, 0n);
+
+      const expectedGrantId = await permissions.grantId(
+        user1.address,
+        granteeId,
+      );
+      const returnedGrantId = await escrow
+        .connect(facilitator)
+        .registerAndSettle.staticCall(input, signature, []);
+      returnedGrantId.should.eq(expectedGrantId);
+
+      const tx = escrow.connect(facilitator).registerAndSettle(input, signature, [
+        {
+          from: user1.address,
+          to: payee.address,
+          asset: NATIVE,
+          amount: parseEther("1"),
+          opKind: OpKind.GrantRegistration,
+          ref: expectedGrantId,
+        },
+      ]);
+
+      await expect(tx)
+        .to.emit(permissions, "PermissionSet")
+        .withArgs(expectedGrantId, user1.address, granteeId, scopes, 1n, 0n);
+      await expect(tx)
+        .to.emit(escrow, "Settled")
+        .withArgs(
+          user1.address,
+          payee.address,
+          expectedGrantId,
+          NATIVE,
+          parseEther("1"),
+          OpKind.GrantRegistration,
+        );
+      await expect(tx).to.changeEtherBalances([payee], [parseEther("1")]);
+
+      const stored = await permissions.permissions(expectedGrantId);
+      stored.grantorAddress.should.eq(user1.address);
+      stored.granteeId.should.eq(granteeId);
+      (await permissions.isActive(expectedGrantId)).should.eq(true);
+      (await escrow.balanceOf(user1.address, NATIVE)).should.eq(
+        parseEther("4"),
+      );
+    });
+
+    it("should revert the whole bundle on a bad grant signature", async function () {
+      await escrow
+        .connect(owner)
+        .setPermissions(await permissions.getAddress());
+      // user2 signs user1's exact payload — recovers to user2, not the
+      // claimed grantor → GrantorMismatch inside permissions.
+      const { input, signature: wrongSignature } = await signGrant(
+        user1,
+        1n,
+        0n,
+        user2,
+      );
+
+      await expect(
+        escrow.connect(facilitator).registerAndSettle(input, wrongSignature, [
+          {
+            from: user1.address,
+            to: payee.address,
+            asset: NATIVE,
+            amount: parseEther("1"),
+            opKind: OpKind.GrantRegistration,
+            ref: ZERO_REF,
+          },
+        ]),
+      )
+        .to.be.revertedWithCustomError(permissions, "GrantorMismatch")
+        .withArgs(user1.address, user2.address);
+
+      (await escrow.balanceOf(user1.address, NATIVE)).should.eq(
+        parseEther("5"),
+      );
+    });
+
+    it("should not register the permission when a payout fails", async function () {
+      await escrow
+        .connect(owner)
+        .setPermissions(await permissions.getAddress());
+      const { input, signature } = await signGrant(user1, 1n, 0n);
+      const id = await permissions.grantId(user1.address, granteeId);
+
+      await expect(
+        escrow.connect(facilitator).registerAndSettle(input, signature, [
+          {
+            from: user1.address,
+            to: payee.address,
+            asset: NATIVE,
+            amount: parseEther("100"), // more than escrowed
+            opKind: OpKind.GrantRegistration,
+            ref: id,
+          },
+        ]),
+      ).to.be.revertedWithCustomError(escrow, "InsufficientBalance");
+
+      (await permissions.isActive(id)).should.eq(false);
+      (await permissions.permissions(id)).grantorAddress.should.eq(
+        ethers.ZeroAddress,
+      );
+    });
+
+    it("should only be callable by the facilitator and respect pause", async function () {
+      await escrow
+        .connect(owner)
+        .setPermissions(await permissions.getAddress());
+      const { input, signature } = await signGrant(user1, 1n, 0n);
+
+      await expect(
+        escrow.connect(user1).registerAndSettle(input, signature, []),
+      ).to.be.revertedWithCustomError(
+        escrow,
+        "AccessControlUnauthorizedAccount",
+      );
+
+      await escrow.connect(owner).pause();
+      await expect(
+        escrow.connect(facilitator).registerAndSettle(input, signature, []),
+      ).to.be.revertedWithCustomError(escrow, "EnforcedPause");
+    });
+  });
+
+  describe("recordAccessAndSettle (integration with DataRegistryV2)", () => {
+    let servers: DataPortabilityServersV2Implementation;
+    let registry: DataRegistryV2Implementation;
+    const scope = "vana.profile";
+    const dataHash = ethers.id("data-1");
+    const metadataHash = ethers.id("meta-1");
+
+    const signRecordAccess = async (
+      signer: HardhatEthersSigner,
+      params: {
+        ownerAddress: string;
+        version: bigint;
+        accessor: string;
+        recordId: string;
+      },
+    ) => {
+      const domain = {
+        name: "Vana Data Portability",
+        version: "1",
+        chainId: (await ethers.provider.getNetwork()).chainId,
+        verifyingContract: await registry.getAddress(),
+      };
+      const types = {
+        RecordDataAccess: [
+          { name: "ownerAddress", type: "address" },
+          { name: "scope", type: "string" },
+          { name: "version", type: "uint256" },
+          { name: "accessor", type: "address" },
+          { name: "recordId", type: "bytes32" },
+        ],
+      };
+      return signer.signTypedData(domain, types, {
+        ownerAddress: params.ownerAddress,
+        scope,
+        version: params.version,
+        accessor: params.accessor,
+        recordId: params.recordId,
+      });
+    };
+
+    beforeEach(async () => {
+      // Deploy servers registry and data registry, wire everything together.
+      const ServersFactory = await ethers.getContractFactory(
+        "DataPortabilityServersV2Implementation",
+      );
+      const serversDeploy = await upgrades.deployProxy(
+        ServersFactory,
+        [ethers.ZeroAddress, owner.address],
+        { kind: "uups" },
+      );
+      servers = await ethers.getContractAt(
+        "DataPortabilityServersV2Implementation",
+        serversDeploy.target,
+      );
+
+      const RegistryFactory = await ethers.getContractFactory(
+        "DataRegistryV2Implementation",
+      );
+      const registryDeploy = await upgrades.deployProxy(
+        RegistryFactory,
+        [owner.address],
+        { kind: "uups" },
+      );
+      registry = await ethers.getContractAt(
+        "DataRegistryV2Implementation",
+        registryDeploy.target,
+      );
+
+      await registry
+        .connect(owner)
+        .setDataPortabilityServers(await servers.getAddress());
+      await registry
+        .connect(owner)
+        .grantRole(
+          await registry.ACCESS_RECORDER_ROLE(),
+          await escrow.getAddress(),
+        );
+
+      // user1 registers serverSigner as their trusted personal server.
+      const domain = {
+        name: "Vana Data Portability",
+        version: "1",
+        chainId: (await ethers.provider.getNetwork()).chainId,
+        verifyingContract: await servers.getAddress(),
+      };
+      const registration = {
+        ownerAddress: user1.address,
+        serverAddress: serverSigner.address,
+        publicKey: "pubkey-1",
+        serverUrl: "https://server.example",
+      };
+      const regSignature = await user1.signTypedData(
+        domain,
+        {
+          ServerRegistration: [
+            { name: "ownerAddress", type: "address" },
+            { name: "serverAddress", type: "address" },
+            { name: "publicKey", type: "string" },
+            { name: "serverUrl", type: "string" },
+          ],
+        },
+        registration,
+      );
+      await servers
+        .connect(relayer)
+        .registerServerWithSignature(registration, regSignature);
+
+      // user1 creates the data point (version 1).
+      await registry.connect(user1).addData(scope, dataHash, metadataHash);
+
+      // escrow funding for payouts
+      await depositNativeFor(user1, parseEther("5"));
+    });
+
+    it("should revert when the data registry is unset", async function () {
+      const recordId = ethers.id("record-0");
+      const signature = await signRecordAccess(serverSigner, {
+        ownerAddress: user1.address,
+        version: 1n,
+        accessor: user2.address,
+        recordId,
+      });
+      await expect(
+        escrow
+          .connect(facilitator)
+          .recordAccessAndSettle(
+            user1.address,
+            scope,
+            1n,
+            user2.address,
+            recordId,
+            signature,
+            [],
+          ),
+      ).to.be.revertedWithCustomError(escrow, "DataRegistryNotSet");
+    });
+
+    describe("with registry wired", () => {
+      beforeEach(async () => {
+        await escrow
+          .connect(owner)
+          .setDataRegistry(await registry.getAddress());
+      });
+
+      it("should record the access and run payouts atomically", async function () {
+        const recordId = ethers.id("record-1");
+        const grantRef = ethers.id("grant-ref");
+        const signature = await signRecordAccess(serverSigner, {
+          ownerAddress: user1.address,
+          version: 1n,
+          accessor: user2.address,
+          recordId,
+        });
+
+        const id = await registry.dataPointId(user1.address, scope);
+        const tx = escrow
+          .connect(facilitator)
+          .recordAccessAndSettle(
+            user1.address,
+            scope,
+            1n,
+            user2.address,
+            recordId,
+            signature,
+            [
+              {
+                from: user1.address,
+                to: payee.address,
+                asset: NATIVE,
+                amount: parseEther("1"),
+                opKind: OpKind.DataAccess,
+                ref: grantRef,
+              },
+            ],
+          );
+
+        await expect(tx)
+          .to.emit(registry, "DataAccessRecorded")
+          .withArgs(
+            id,
+            1n,
+            user2.address,
+            serverSigner.address,
+            recordId,
+            1n,
+            1n,
+          );
+        await expect(tx)
+          .to.emit(escrow, "Settled")
+          .withArgs(
+            user1.address,
+            payee.address,
+            grantRef,
+            NATIVE,
+            parseEther("1"),
+            OpKind.DataAccess,
+          );
+
+        (await registry.totalAccesses(user1.address, scope)).should.eq(1);
+        (await registry.accessCount(user1.address, scope, 1)).should.eq(1);
+        (await registry.isRecordIdUsed(recordId)).should.eq(true);
+        (await escrow.balanceOf(user1.address, NATIVE)).should.eq(
+          parseEther("4"),
+        );
+      });
+
+      it("should reject a duplicate recordId and roll back the payouts", async function () {
+        const recordId = ethers.id("record-2");
+        const signature = await signRecordAccess(serverSigner, {
+          ownerAddress: user1.address,
+          version: 1n,
+          accessor: user2.address,
+          recordId,
+        });
+
+        await escrow
+          .connect(facilitator)
+          .recordAccessAndSettle(
+            user1.address,
+            scope,
+            1n,
+            user2.address,
+            recordId,
+            signature,
+            [],
+          );
+
+        await expect(
+          escrow
+            .connect(facilitator)
+            .recordAccessAndSettle(
+              user1.address,
+              scope,
+              1n,
+              user2.address,
+              recordId,
+              signature,
+              [
+                {
+                  from: user1.address,
+                  to: payee.address,
+                  asset: NATIVE,
+                  amount: parseEther("1"),
+                  opKind: OpKind.DataAccess,
+                  ref: ZERO_REF,
+                },
+              ],
+            ),
+        ).to.be.revertedWithCustomError(registry, "RecordIdAlreadyUsed");
+
+        (await escrow.balanceOf(user1.address, NATIVE)).should.eq(
+          parseEther("5"),
+        );
+        (await registry.totalAccesses(user1.address, scope)).should.eq(1);
+      });
+
+      it("should not record the access when a payout fails", async function () {
+        const recordId = ethers.id("record-3");
+        const signature = await signRecordAccess(serverSigner, {
+          ownerAddress: user1.address,
+          version: 1n,
+          accessor: user2.address,
+          recordId,
+        });
+
+        await expect(
+          escrow
+            .connect(facilitator)
+            .recordAccessAndSettle(
+              user1.address,
+              scope,
+              1n,
+              user2.address,
+              recordId,
+              signature,
+              [
+                {
+                  from: user1.address,
+                  to: payee.address,
+                  asset: NATIVE,
+                  amount: parseEther("100"),
+                  opKind: OpKind.DataAccess,
+                  ref: ZERO_REF,
+                },
+              ],
+            ),
+        ).to.be.revertedWithCustomError(escrow, "InsufficientBalance");
+
+        (await registry.isRecordIdUsed(recordId)).should.eq(false);
+        (await registry.totalAccesses(user1.address, scope)).should.eq(0);
+      });
+
+      it("should bubble UntrustedServer for signatures from unregistered keys", async function () {
+        const recordId = ethers.id("record-4");
+        const signature = await signRecordAccess(user2, {
+          ownerAddress: user1.address,
+          version: 1n,
+          accessor: user2.address,
+          recordId,
+        });
+
+        await expect(
+          escrow
+            .connect(facilitator)
+            .recordAccessAndSettle(
+              user1.address,
+              scope,
+              1n,
+              user2.address,
+              recordId,
+              signature,
+              [],
+            ),
+        ).to.be.revertedWithCustomError(registry, "UntrustedServer");
+      });
+
+      it("should only be callable by the facilitator and respect pause", async function () {
+        const recordId = ethers.id("record-5");
+        const signature = await signRecordAccess(serverSigner, {
+          ownerAddress: user1.address,
+          version: 1n,
+          accessor: user2.address,
+          recordId,
+        });
+
+        await expect(
+          escrow
+            .connect(user1)
+            .recordAccessAndSettle(
+              user1.address,
+              scope,
+              1n,
+              user2.address,
+              recordId,
+              signature,
+              [],
+            ),
+        ).to.be.revertedWithCustomError(
+          escrow,
+          "AccessControlUnauthorizedAccount",
+        );
+
+        await escrow.connect(owner).pause();
+        await expect(
+          escrow
+            .connect(facilitator)
+            .recordAccessAndSettle(
+              user1.address,
+              scope,
+              1n,
+              user2.address,
+              recordId,
+              signature,
+              [],
+            ),
+        ).to.be.revertedWithCustomError(escrow, "EnforcedPause");
+      });
+    });
+  });
+});

--- a/test/dataPortability/dataPortabilityPermissionsV2.ts
+++ b/test/dataPortability/dataPortabilityPermissionsV2.ts
@@ -1,0 +1,947 @@
+import chai, { expect, should } from "chai";
+import chaiAsPromised from "chai-as-promised";
+import { anyValue } from "@nomicfoundation/hardhat-chai-matchers/withArgs";
+import { ethers, upgrades } from "hardhat";
+import { time } from "@nomicfoundation/hardhat-network-helpers";
+import {
+  DataPortabilityPermissionsV2Implementation,
+  DataPortabilityServersV2Implementation,
+} from "../../typechain-types";
+import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers";
+
+chai.use(chaiAsPromised);
+should();
+
+describe("DataPortabilityPermissionsV2", () => {
+  let deployer: HardhatEthersSigner;
+  let owner: HardhatEthersSigner;
+  let grantor: HardhatEthersSigner;
+  let relayer: HardhatEthersSigner;
+  let serverSigner: HardhatEthersSigner;
+  let otherOwner: HardhatEthersSigner;
+  let otherServerSigner: HardhatEthersSigner;
+  let stranger: HardhatEthersSigner;
+
+  let permissionsContract: DataPortabilityPermissionsV2Implementation;
+  let serversContract: DataPortabilityServersV2Implementation;
+
+  let chainId: bigint;
+
+  const DEFAULT_ADMIN_ROLE =
+    "0x0000000000000000000000000000000000000000000000000000000000000000";
+
+  const GRANTEE_ID_1 = ethers.keccak256(ethers.toUtf8Bytes("grantee-1"));
+  const GRANTEE_ID_2 = ethers.keccak256(ethers.toUtf8Bytes("grantee-2"));
+
+  const grantRegistrationTypes = {
+    GrantRegistration: [
+      { name: "grantorAddress", type: "address" },
+      { name: "granteeId", type: "bytes32" },
+      { name: "scopes", type: "string[]" },
+      { name: "grantVersion", type: "uint256" },
+      { name: "expiresAt", type: "uint256" },
+    ],
+  };
+
+  const serverRegistrationTypes = {
+    ServerRegistration: [
+      { name: "ownerAddress", type: "address" },
+      { name: "serverAddress", type: "address" },
+      { name: "publicKey", type: "string" },
+      { name: "serverUrl", type: "string" },
+    ],
+  };
+
+  const serverDeregistrationTypes = {
+    ServerDeregistration: [
+      { name: "ownerAddress", type: "address" },
+      { name: "serverAddress", type: "address" },
+      { name: "serverId", type: "bytes32" },
+      { name: "deadline", type: "uint256" },
+    ],
+  };
+
+  const permissionsDomain = async () => ({
+    name: "Vana Data Portability",
+    version: "1",
+    chainId: chainId,
+    verifyingContract: await permissionsContract.getAddress(),
+  });
+
+  const serversDomain = async () => ({
+    name: "Vana Data Portability",
+    version: "1",
+    chainId: chainId,
+    verifyingContract: await serversContract.getAddress(),
+  });
+
+  type PermissionInput = {
+    grantorAddress: string;
+    granteeId: string;
+    scopes: string[];
+    grantVersion: bigint | number;
+    expiresAt: bigint | number;
+  };
+
+  const makeInput = (
+    overrides: Partial<PermissionInput> = {},
+  ): PermissionInput => ({
+    grantorAddress: grantor.address,
+    granteeId: GRANTEE_ID_1,
+    scopes: ["read:files", "read:profile"],
+    grantVersion: 1,
+    expiresAt: 0,
+    ...overrides,
+  });
+
+  const signGrantRegistration = async (
+    signer: HardhatEthersSigner,
+    input: PermissionInput,
+  ) => {
+    return signer.signTypedData(
+      await permissionsDomain(),
+      grantRegistrationTypes,
+      {
+        grantorAddress: input.grantorAddress,
+        granteeId: input.granteeId,
+        scopes: input.scopes,
+        grantVersion: input.grantVersion,
+        expiresAt: input.expiresAt,
+      },
+    );
+  };
+
+  // Registers a server on ServersV2, signed by `serverOwner` (EIP-712).
+  const registerServer = async (
+    serverOwner: HardhatEthersSigner,
+    serverAddress: string,
+    publicKey = "test-public-key",
+    serverUrl = "https://server.example.com",
+  ): Promise<string> => {
+    const registration = {
+      ownerAddress: serverOwner.address,
+      serverAddress,
+      publicKey,
+      serverUrl,
+    };
+    const signature = await serverOwner.signTypedData(
+      await serversDomain(),
+      serverRegistrationTypes,
+      registration,
+    );
+    await serversContract
+      .connect(relayer)
+      .registerServerWithSignature(registration, signature);
+    return await serversContract.activeServerId(serverAddress);
+  };
+
+  const deregisterServer = async (
+    serverOwner: HardhatEthersSigner,
+    serverAddress: string,
+    serverId: string,
+  ) => {
+    const deadline = (await time.latest()) + 3600;
+    const deregistration = {
+      ownerAddress: serverOwner.address,
+      serverAddress,
+      serverId,
+      deadline,
+    };
+    const signature = await serverOwner.signTypedData(
+      await serversDomain(),
+      serverDeregistrationTypes,
+      deregistration,
+    );
+    await serversContract
+      .connect(relayer)
+      .deregisterServerWithSignature(deregistration, signature);
+  };
+
+  const computeGrantIdTs = async (
+    grantorAddress: string,
+    granteeId: string,
+  ): Promise<string> => {
+    const ds = ethers.TypedDataEncoder.hashDomain(await permissionsDomain());
+    return ethers.keccak256(
+      ethers.AbiCoder.defaultAbiCoder().encode(
+        ["bytes32", "address", "bytes32"],
+        [ds, grantorAddress, granteeId],
+      ),
+    );
+  };
+
+  const deploy = async () => {
+    [
+      deployer,
+      owner,
+      grantor,
+      relayer,
+      serverSigner,
+      otherOwner,
+      otherServerSigner,
+      stranger,
+    ] = await ethers.getSigners();
+
+    chainId = (await ethers.provider.getNetwork()).chainId;
+
+    const permissionsDeploy = await upgrades.deployProxy(
+      await ethers.getContractFactory(
+        "DataPortabilityPermissionsV2Implementation",
+      ),
+      [owner.address],
+      { kind: "uups" },
+    );
+    permissionsContract = await ethers.getContractAt(
+      "DataPortabilityPermissionsV2Implementation",
+      permissionsDeploy.target,
+    );
+
+    const serversDeploy = await upgrades.deployProxy(
+      await ethers.getContractFactory(
+        "DataPortabilityServersV2Implementation",
+      ),
+      [ethers.ZeroAddress, owner.address],
+      { kind: "uups" },
+    );
+    serversContract = await ethers.getContractAt(
+      "DataPortabilityServersV2Implementation",
+      serversDeploy.target,
+    );
+  };
+
+  beforeEach(async () => {
+    await deploy();
+  });
+
+  describe("initialize", () => {
+    it("should grant DEFAULT_ADMIN_ROLE to the owner", async () => {
+      (
+        await permissionsContract.hasRole(DEFAULT_ADMIN_ROLE, owner.address)
+      ).should.eq(true);
+      (
+        await permissionsContract.hasRole(DEFAULT_ADMIN_ROLE, deployer.address)
+      ).should.eq(false);
+    });
+
+    it("should return version 1", async () => {
+      (await permissionsContract.version()).should.eq(1);
+    });
+
+    it("should leave dataPortabilityServers unset after deploy", async () => {
+      (await permissionsContract.dataPortabilityServers()).should.eq(
+        ethers.ZeroAddress,
+      );
+    });
+
+    it("should reject re-initialization", async () => {
+      await expect(
+        permissionsContract.connect(owner).initialize(owner.address),
+      ).to.be.revertedWithCustomError(
+        permissionsContract,
+        "InvalidInitialization",
+      );
+    });
+
+    it("should reject a zero owner address", async () => {
+      const implFactory = await ethers.getContractFactory(
+        "DataPortabilityPermissionsV2Implementation",
+      );
+      const impl = await implFactory.deploy();
+      await impl.waitForDeployment();
+
+      const proxyFactory = await ethers.getContractFactory(
+        "DataPortabilityPermissionsV2Proxy",
+      );
+      const initData = implFactory.interface.encodeFunctionData("initialize", [
+        ethers.ZeroAddress,
+      ]);
+      await expect(
+        proxyFactory.deploy(impl.target, initData),
+      ).to.be.revertedWithCustomError(impl, "ZeroAddress");
+    });
+  });
+
+  describe("grantId and domainSeparator views", () => {
+    it("domainSeparator() should match ethers.TypedDataEncoder.hashDomain", async () => {
+      const expected = ethers.TypedDataEncoder.hashDomain(
+        await permissionsDomain(),
+      );
+      (await permissionsContract.domainSeparator()).should.eq(expected);
+    });
+
+    it("grantId() should equal keccak256(abi.encode(domainSeparator, grantor, granteeId))", async () => {
+      const expected = await computeGrantIdTs(grantor.address, GRANTEE_ID_1);
+      (
+        await permissionsContract.grantId(grantor.address, GRANTEE_ID_1)
+      ).should.eq(expected);
+
+      const expected2 = await computeGrantIdTs(
+        otherOwner.address,
+        GRANTEE_ID_2,
+      );
+      (
+        await permissionsContract.grantId(otherOwner.address, GRANTEE_ID_2)
+      ).should.eq(expected2);
+      expected.should.not.eq(expected2);
+    });
+
+    it("GRANT_REGISTRATION_TYPEHASH should match the declared type string", async () => {
+      const expected = ethers.keccak256(
+        ethers.toUtf8Bytes(
+          "GrantRegistration(address grantorAddress,bytes32 granteeId,string[] scopes,uint256 grantVersion,uint256 expiresAt)",
+        ),
+      );
+      (await permissionsContract.GRANT_REGISTRATION_TYPEHASH()).should.eq(
+        expected,
+      );
+    });
+  });
+
+  describe("addPermission (direct)", () => {
+    it("should revert with GrantorMismatch when msg.sender is not the grantor", async () => {
+      const input = makeInput();
+      await expect(
+        permissionsContract.connect(stranger).addPermission(input),
+      )
+        .to.be.revertedWithCustomError(permissionsContract, "GrantorMismatch")
+        .withArgs(grantor.address, stranger.address);
+    });
+
+    it("should create a permission and emit PermissionSet", async () => {
+      const input = makeInput({ expiresAt: (await time.latest()) + 10_000 });
+      const id = await computeGrantIdTs(grantor.address, GRANTEE_ID_1);
+
+      await expect(permissionsContract.connect(grantor).addPermission(input))
+        .to.emit(permissionsContract, "PermissionSet")
+        .withArgs(
+          id,
+          grantor.address,
+          GRANTEE_ID_1,
+          input.scopes,
+          input.grantVersion,
+          input.expiresAt,
+        );
+
+      const stored = await permissionsContract.permissions(id);
+      stored.grantorAddress.should.eq(grantor.address);
+      stored.granteeId.should.eq(GRANTEE_ID_1);
+      stored.scopes.should.deep.eq(input.scopes);
+      stored.grantVersion.should.eq(1);
+      stored.expiresAt.should.eq(input.expiresAt);
+    });
+
+    it("should return the deterministic grant id", async () => {
+      const input = makeInput();
+      const expectedId = await computeGrantIdTs(
+        grantor.address,
+        GRANTEE_ID_1,
+      );
+      const returnedId = await permissionsContract
+        .connect(grantor)
+        .addPermission.staticCall(input);
+      returnedId.should.eq(expectedId);
+    });
+
+    it("should revert with ZeroGranteeId for a zero granteeId", async () => {
+      const input = makeInput({ granteeId: ethers.ZeroHash });
+      await expect(
+        permissionsContract.connect(grantor).addPermission(input),
+      ).to.be.revertedWithCustomError(permissionsContract, "ZeroGranteeId");
+    });
+
+    it("should revert with EmptyScopes for an empty scopes array", async () => {
+      const input = makeInput({ scopes: [] });
+      await expect(
+        permissionsContract.connect(grantor).addPermission(input),
+      ).to.be.revertedWithCustomError(permissionsContract, "EmptyScopes");
+    });
+
+    describe("grantVersion monotonicity", () => {
+      it("should reject grantVersion 0 on first write with InvalidGrantVersion(0, 0)", async () => {
+        const input = makeInput({ grantVersion: 0 });
+        await expect(
+          permissionsContract.connect(grantor).addPermission(input),
+        )
+          .to.be.revertedWithCustomError(
+            permissionsContract,
+            "InvalidGrantVersion",
+          )
+          .withArgs(0, 0);
+      });
+
+      it("should accept grantVersion 1 as the first write", async () => {
+        await permissionsContract
+          .connect(grantor)
+          .addPermission(makeInput({ grantVersion: 1 })).should.be.fulfilled;
+      });
+
+      it("should reject a re-write with the same grantVersion", async () => {
+        await permissionsContract
+          .connect(grantor)
+          .addPermission(makeInput({ grantVersion: 1 }));
+        await expect(
+          permissionsContract
+            .connect(grantor)
+            .addPermission(makeInput({ grantVersion: 1 })),
+        )
+          .to.be.revertedWithCustomError(
+            permissionsContract,
+            "InvalidGrantVersion",
+          )
+          .withArgs(1, 1);
+      });
+
+      it("should reject a re-write with a lower grantVersion", async () => {
+        await permissionsContract
+          .connect(grantor)
+          .addPermission(makeInput({ grantVersion: 5 }));
+        await expect(
+          permissionsContract
+            .connect(grantor)
+            .addPermission(makeInput({ grantVersion: 3 })),
+        )
+          .to.be.revertedWithCustomError(
+            permissionsContract,
+            "InvalidGrantVersion",
+          )
+          .withArgs(5, 3);
+      });
+
+      it("should overwrite (upsert) with a higher grantVersion, fully replacing scopes and expiresAt", async () => {
+        const firstExpiry = (await time.latest()) + 100_000;
+        await permissionsContract.connect(grantor).addPermission(
+          makeInput({
+            scopes: ["scope:a", "scope:b", "scope:c"],
+            grantVersion: 1,
+            expiresAt: firstExpiry,
+          }),
+        );
+
+        const id = await computeGrantIdTs(grantor.address, GRANTEE_ID_1);
+        let stored = await permissionsContract.permissions(id);
+        stored.scopes.should.deep.eq(["scope:a", "scope:b", "scope:c"]);
+        stored.expiresAt.should.eq(firstExpiry);
+
+        const secondExpiry = (await time.latest()) + 200_000;
+        await permissionsContract.connect(grantor).addPermission(
+          makeInput({
+            scopes: ["scope:only"],
+            grantVersion: 2,
+            expiresAt: secondExpiry,
+          }),
+        );
+
+        stored = await permissionsContract.permissions(id);
+        stored.scopes.should.deep.eq(["scope:only"]);
+        stored.scopes.length.should.eq(1);
+        stored.grantVersion.should.eq(2);
+        stored.expiresAt.should.eq(secondExpiry);
+      });
+    });
+  });
+
+  describe("isActive", () => {
+    it("should return false for an unknown id", async () => {
+      (
+        await permissionsContract.isActive(
+          ethers.keccak256(ethers.toUtf8Bytes("nonexistent")),
+        )
+      ).should.eq(false);
+    });
+
+    it("should return true for a perpetual permission (expiresAt == 0)", async () => {
+      await permissionsContract
+        .connect(grantor)
+        .addPermission(makeInput({ expiresAt: 0 }));
+      const id = await computeGrantIdTs(grantor.address, GRANTEE_ID_1);
+      (await permissionsContract.isActive(id)).should.eq(true);
+
+      // Still perpetual far in the future.
+      await time.increase(10 * 365 * 24 * 3600);
+      (await permissionsContract.isActive(id)).should.eq(true);
+    });
+
+    it("should be active before and exactly at expiresAt, inactive after", async () => {
+      const expiresAt = (await time.latest()) + 10_000;
+      await permissionsContract
+        .connect(grantor)
+        .addPermission(makeInput({ expiresAt }));
+      const id = await computeGrantIdTs(grantor.address, GRANTEE_ID_1);
+
+      (await permissionsContract.isActive(id)).should.eq(true);
+
+      // isActive uses <= — exactly at expiresAt is still active.
+      await time.increaseTo(expiresAt);
+      (await permissionsContract.isActive(id)).should.eq(true);
+
+      await time.increaseTo(expiresAt + 1);
+      (await permissionsContract.isActive(id)).should.eq(false);
+    });
+
+    it("should support revocation via upsert with a past expiresAt and higher grantVersion", async () => {
+      await permissionsContract
+        .connect(grantor)
+        .addPermission(makeInput({ grantVersion: 1, expiresAt: 0 }));
+      const id = await computeGrantIdTs(grantor.address, GRANTEE_ID_1);
+      (await permissionsContract.isActive(id)).should.eq(true);
+
+      const pastTimestamp = (await time.latest()) - 100;
+      await permissionsContract
+        .connect(grantor)
+        .addPermission(
+          makeInput({ grantVersion: 2, expiresAt: pastTimestamp }),
+        );
+
+      (await permissionsContract.isActive(id)).should.eq(false);
+      // Record still exists.
+      const stored = await permissionsContract.permissions(id);
+      stored.grantorAddress.should.eq(grantor.address);
+      stored.grantVersion.should.eq(2);
+    });
+  });
+
+  describe("addPermissionWithSignature (grantor-signed)", () => {
+    it("should allow any relayer to submit a grantor-signed permission", async () => {
+      const input = makeInput();
+      const signature = await signGrantRegistration(grantor, input);
+      const id = await computeGrantIdTs(grantor.address, GRANTEE_ID_1);
+
+      const tx = await permissionsContract
+        .connect(relayer)
+        .addPermissionWithSignature(input, signature);
+
+      await expect(tx)
+        .to.emit(permissionsContract, "PermissionSet")
+        .withArgs(
+          id,
+          grantor.address,
+          GRANTEE_ID_1,
+          input.scopes,
+          input.grantVersion,
+          input.expiresAt,
+        );
+      await expect(tx).to.not.emit(
+        permissionsContract,
+        "PermissionSignedByDelegate",
+      );
+
+      const stored = await permissionsContract.permissions(id);
+      stored.grantorAddress.should.eq(grantor.address);
+      stored.scopes.should.deep.eq(input.scopes);
+    });
+
+    it("should reject a replay of the same input + signature via grantVersion monotonicity", async () => {
+      const input = makeInput({ grantVersion: 1 });
+      const signature = await signGrantRegistration(grantor, input);
+
+      await permissionsContract
+        .connect(relayer)
+        .addPermissionWithSignature(input, signature);
+
+      await expect(
+        permissionsContract
+          .connect(relayer)
+          .addPermissionWithSignature(input, signature),
+      )
+        .to.be.revertedWithCustomError(
+          permissionsContract,
+          "InvalidGrantVersion",
+        )
+        .withArgs(1, 1);
+    });
+
+    it("should reject a signature from an unrelated key with GrantorMismatch", async () => {
+      const input = makeInput();
+      const signature = await signGrantRegistration(stranger, input);
+
+      await expect(
+        permissionsContract
+          .connect(relayer)
+          .addPermissionWithSignature(input, signature),
+      )
+        .to.be.revertedWithCustomError(permissionsContract, "GrantorMismatch")
+        .withArgs(grantor.address, stranger.address);
+    });
+
+    it("should revert for a malformed 65-byte signature", async () => {
+      const input = makeInput();
+      const garbageSignature = "0x" + "11".repeat(64) + "1b";
+      // Either an ECDSA custom error or GrantorMismatch, depending on whether
+      // the garbage bytes recover to some address — assert it reverts.
+      await expect(
+        permissionsContract
+          .connect(relayer)
+          .addPermissionWithSignature(input, garbageSignature),
+      ).to.be.reverted;
+    });
+
+    it("should revert with ECDSAInvalidSignatureS for a high-s (malleable) signature", async () => {
+      // Deterministic malformed-signature case: flip s into the upper half
+      // of the curve order — OZ ECDSA rejects it outright, so a malleated
+      // twin of a valid signature can never be replayed.
+      const input = makeInput();
+      const valid = ethers.Signature.from(
+        await signGrantRegistration(grantor, input),
+      );
+      const N = BigInt(
+        "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141",
+      );
+      const highS = ethers.toBeHex(N - BigInt(valid.s), 32);
+      const flippedV = valid.v === 27 ? 28 : 27;
+      const malleated = ethers.concat([
+        valid.r,
+        highS,
+        ethers.toBeHex(flippedV, 1),
+      ]);
+
+      await expect(
+        permissionsContract
+          .connect(relayer)
+          .addPermissionWithSignature(input, malleated),
+      )
+        .to.be.revertedWithCustomError(
+          permissionsContract,
+          "ECDSAInvalidSignatureS",
+        )
+        .withArgs(highS);
+    });
+
+    it("should revert with ECDSAInvalidSignatureLength for a wrong-length signature", async () => {
+      const input = makeInput();
+      await expect(
+        permissionsContract
+          .connect(relayer)
+          .addPermissionWithSignature(input, "0x1234"),
+      )
+        .to.be.revertedWithCustomError(
+          permissionsContract,
+          "ECDSAInvalidSignatureLength",
+        )
+        .withArgs(2);
+    });
+
+    it("should revert for a signature over different data (tampered input)", async () => {
+      const input = makeInput({ scopes: ["read:files"] });
+      const signature = await signGrantRegistration(grantor, input);
+      const tampered = { ...input, scopes: ["read:files", "write:files"] };
+
+      await expect(
+        permissionsContract
+          .connect(relayer)
+          .addPermissionWithSignature(tampered, signature),
+      )
+        .to.be.revertedWithCustomError(permissionsContract, "GrantorMismatch")
+        // The recovered signer of a tampered digest is unknowable, but the
+        // claimed grantor must be reported as the first arg.
+        .withArgs(grantor.address, anyValue);
+    });
+  });
+
+  describe("setDataPortabilityServers", () => {
+    it("should be admin-only", async () => {
+      await expect(
+        permissionsContract
+          .connect(stranger)
+          .setDataPortabilityServers(await serversContract.getAddress()),
+      )
+        .to.be.revertedWithCustomError(
+          permissionsContract,
+          "AccessControlUnauthorizedAccount",
+        )
+        .withArgs(stranger.address, DEFAULT_ADMIN_ROLE);
+    });
+
+    it("should reject the zero address", async () => {
+      await expect(
+        permissionsContract
+          .connect(owner)
+          .setDataPortabilityServers(ethers.ZeroAddress),
+      ).to.be.revertedWithCustomError(permissionsContract, "ZeroAddress");
+    });
+
+    it("should set the registry and emit DataPortabilityServersUpdated", async () => {
+      const serversAddress = await serversContract.getAddress();
+      await expect(
+        permissionsContract
+          .connect(owner)
+          .setDataPortabilityServers(serversAddress),
+      )
+        .to.emit(permissionsContract, "DataPortabilityServersUpdated")
+        .withArgs(ethers.ZeroAddress, serversAddress);
+
+      (await permissionsContract.dataPortabilityServers()).should.eq(
+        serversAddress,
+      );
+
+      // Updating again reports the previous address.
+      const serversDeploy2 = await upgrades.deployProxy(
+        await ethers.getContractFactory(
+          "DataPortabilityServersV2Implementation",
+        ),
+        [ethers.ZeroAddress, owner.address],
+        { kind: "uups" },
+      );
+      await expect(
+        permissionsContract
+          .connect(owner)
+          .setDataPortabilityServers(serversDeploy2.target),
+      )
+        .to.emit(permissionsContract, "DataPortabilityServersUpdated")
+        .withArgs(serversAddress, serversDeploy2.target);
+    });
+  });
+
+  describe("addPermissionWithSignature (delegate-signed)", () => {
+    beforeEach(async () => {
+      await permissionsContract
+        .connect(owner)
+        .setDataPortabilityServers(await serversContract.getAddress());
+    });
+
+    it("should accept a signature from a server registered to the grantor and emit both events", async () => {
+      await registerServer(grantor, serverSigner.address);
+
+      const input = makeInput();
+      const signature = await signGrantRegistration(serverSigner, input);
+      const id = await computeGrantIdTs(grantor.address, GRANTEE_ID_1);
+
+      const tx = await permissionsContract
+        .connect(relayer)
+        .addPermissionWithSignature(input, signature);
+
+      await expect(tx)
+        .to.emit(permissionsContract, "PermissionSet")
+        .withArgs(
+          id,
+          grantor.address,
+          GRANTEE_ID_1,
+          input.scopes,
+          input.grantVersion,
+          input.expiresAt,
+        );
+      await expect(tx)
+        .to.emit(permissionsContract, "PermissionSignedByDelegate")
+        .withArgs(id, grantor.address, serverSigner.address);
+
+      const stored = await permissionsContract.permissions(id);
+      stored.grantorAddress.should.eq(grantor.address);
+    });
+
+    it("should still accept a grantor-self-signed permission while the servers registry is set", async () => {
+      // Registry configured AND the grantor has a registered delegate — the
+      // self-signed path must keep working and must NOT be tagged as
+      // delegate-signed.
+      await registerServer(grantor, serverSigner.address);
+
+      const input = makeInput();
+      const signature = await signGrantRegistration(grantor, input);
+      const id = await computeGrantIdTs(grantor.address, GRANTEE_ID_1);
+
+      const tx = await permissionsContract
+        .connect(relayer)
+        .addPermissionWithSignature(input, signature);
+
+      await expect(tx)
+        .to.emit(permissionsContract, "PermissionSet")
+        .withArgs(
+          id,
+          grantor.address,
+          GRANTEE_ID_1,
+          input.scopes,
+          input.grantVersion,
+          input.expiresAt,
+        );
+      await expect(tx).to.not.emit(
+        permissionsContract,
+        "PermissionSignedByDelegate",
+      );
+    });
+
+    it("should reject a signature from a server registered to a DIFFERENT owner", async () => {
+      await registerServer(otherOwner, otherServerSigner.address);
+
+      const input = makeInput(); // grantor is the claimed grantor
+      const signature = await signGrantRegistration(otherServerSigner, input);
+
+      await expect(
+        permissionsContract
+          .connect(relayer)
+          .addPermissionWithSignature(input, signature),
+      )
+        .to.be.revertedWithCustomError(permissionsContract, "GrantorMismatch")
+        .withArgs(grantor.address, otherServerSigner.address);
+    });
+
+    it("should reject a delegate signature after the server is deregistered", async () => {
+      const serverId = await registerServer(grantor, serverSigner.address);
+
+      const input = makeInput();
+      const signature = await signGrantRegistration(serverSigner, input);
+
+      // Works while registered (static call proves it would succeed AND
+      // returns the correct deterministic id).
+      (
+        await permissionsContract
+          .connect(relayer)
+          .addPermissionWithSignature.staticCall(input, signature)
+      ).should.eq(await computeGrantIdTs(grantor.address, GRANTEE_ID_1));
+
+      await deregisterServer(grantor, serverSigner.address, serverId);
+
+      await expect(
+        permissionsContract
+          .connect(relayer)
+          .addPermissionWithSignature(input, signature),
+      )
+        .to.be.revertedWithCustomError(permissionsContract, "GrantorMismatch")
+        .withArgs(grantor.address, serverSigner.address);
+    });
+
+    it("should reject a server signature when dataPortabilityServers is unset", async () => {
+      // Fresh PermissionsV2 without setDataPortabilityServers.
+      const freshDeploy = await upgrades.deployProxy(
+        await ethers.getContractFactory(
+          "DataPortabilityPermissionsV2Implementation",
+        ),
+        [owner.address],
+        { kind: "uups" },
+      );
+      const freshPermissions = await ethers.getContractAt(
+        "DataPortabilityPermissionsV2Implementation",
+        freshDeploy.target,
+      );
+
+      await registerServer(grantor, serverSigner.address);
+
+      const input = makeInput();
+      const freshDomain = {
+        name: "Vana Data Portability",
+        version: "1",
+        chainId: chainId,
+        verifyingContract: await freshPermissions.getAddress(),
+      };
+      const signature = await serverSigner.signTypedData(
+        freshDomain,
+        grantRegistrationTypes,
+        {
+          grantorAddress: input.grantorAddress,
+          granteeId: input.granteeId,
+          scopes: input.scopes,
+          grantVersion: input.grantVersion,
+          expiresAt: input.expiresAt,
+        },
+      );
+
+      await expect(
+        freshPermissions
+          .connect(relayer)
+          .addPermissionWithSignature(input, signature),
+      )
+        .to.be.revertedWithCustomError(freshPermissions, "GrantorMismatch")
+        .withArgs(grantor.address, serverSigner.address);
+    });
+  });
+
+  describe("pause / unpause", () => {
+    it("should be admin-only", async () => {
+      await expect(
+        permissionsContract.connect(stranger).pause(),
+      )
+        .to.be.revertedWithCustomError(
+          permissionsContract,
+          "AccessControlUnauthorizedAccount",
+        )
+        .withArgs(stranger.address, DEFAULT_ADMIN_ROLE);
+
+      await permissionsContract.connect(owner).pause();
+
+      await expect(
+        permissionsContract.connect(stranger).unpause(),
+      )
+        .to.be.revertedWithCustomError(
+          permissionsContract,
+          "AccessControlUnauthorizedAccount",
+        )
+        .withArgs(stranger.address, DEFAULT_ADMIN_ROLE);
+    });
+
+    it("should block addPermission and addPermissionWithSignature while paused, and restore on unpause", async () => {
+      const input = makeInput();
+      const signature = await signGrantRegistration(grantor, input);
+
+      await permissionsContract.connect(owner).pause();
+      (await permissionsContract.paused()).should.eq(true);
+
+      await expect(
+        permissionsContract.connect(grantor).addPermission(input),
+      ).to.be.revertedWithCustomError(permissionsContract, "EnforcedPause");
+
+      await expect(
+        permissionsContract
+          .connect(relayer)
+          .addPermissionWithSignature(input, signature),
+      ).to.be.revertedWithCustomError(permissionsContract, "EnforcedPause");
+
+      await permissionsContract.connect(owner).unpause();
+      (await permissionsContract.paused()).should.eq(false);
+
+      await permissionsContract
+        .connect(relayer)
+        .addPermissionWithSignature(input, signature).should.be.fulfilled;
+
+      const input2 = makeInput({ granteeId: GRANTEE_ID_2 });
+      await permissionsContract.connect(grantor).addPermission(input2).should
+        .be.fulfilled;
+    });
+  });
+
+  describe("upgrade authorization", () => {
+    it("should reject upgradeToAndCall from a non-admin", async () => {
+      const implFactory = await ethers.getContractFactory(
+        "DataPortabilityPermissionsV2Implementation",
+      );
+      const newImpl = await implFactory.deploy();
+      await newImpl.waitForDeployment();
+
+      await expect(
+        permissionsContract
+          .connect(stranger)
+          .upgradeToAndCall(newImpl.target, "0x"),
+      )
+        .to.be.revertedWithCustomError(
+          permissionsContract,
+          "AccessControlUnauthorizedAccount",
+        )
+        .withArgs(stranger.address, DEFAULT_ADMIN_ROLE);
+    });
+
+    it("should allow an admin upgrade and preserve state", async () => {
+      // Write some state first.
+      const input = makeInput();
+      await permissionsContract.connect(grantor).addPermission(input);
+      const id = await computeGrantIdTs(grantor.address, GRANTEE_ID_1);
+
+      const implFactory = await ethers.getContractFactory(
+        "DataPortabilityPermissionsV2Implementation",
+      );
+      const newImpl = await implFactory.deploy();
+      await newImpl.waitForDeployment();
+
+      await permissionsContract
+        .connect(owner)
+        .upgradeToAndCall(newImpl.target, "0x").should.be.fulfilled;
+
+      const implAddress = await upgrades.erc1967.getImplementationAddress(
+        await permissionsContract.getAddress(),
+      );
+      implAddress.should.eq(await newImpl.getAddress());
+
+      // State preserved across the upgrade.
+      (await permissionsContract.version()).should.eq(1);
+      const stored = await permissionsContract.permissions(id);
+      stored.grantorAddress.should.eq(grantor.address);
+      stored.scopes.should.deep.eq(input.scopes);
+      (await permissionsContract.isActive(id)).should.eq(true);
+    });
+  });
+});

--- a/test/dataPortability/dataPortabilityServersV2.ts
+++ b/test/dataPortability/dataPortabilityServersV2.ts
@@ -1,0 +1,1058 @@
+import chai, { expect, should } from "chai";
+import chaiAsPromised from "chai-as-promised";
+import { anyValue } from "@nomicfoundation/hardhat-chai-matchers/withArgs";
+import { time } from "@nomicfoundation/hardhat-network-helpers";
+import { ethers, upgrades } from "hardhat";
+import { DataPortabilityServersV2Implementation } from "../../typechain-types";
+import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers";
+
+chai.use(chaiAsPromised);
+should();
+
+describe("DataPortabilityServersV2", () => {
+  let trustedForwarder: HardhatEthersSigner;
+  let deployer: HardhatEthersSigner;
+  let owner: HardhatEthersSigner;
+  let maintainer: HardhatEthersSigner;
+  let serverOwner1: HardhatEthersSigner;
+  let serverOwner2: HardhatEthersSigner;
+  let relayer: HardhatEthersSigner;
+  let server1: HardhatEthersSigner;
+  let server2: HardhatEthersSigner;
+
+  let serversContract: DataPortabilityServersV2Implementation;
+
+  const DEFAULT_ADMIN_ROLE =
+    "0x0000000000000000000000000000000000000000000000000000000000000000";
+  const MAINTAINER_ROLE = ethers.keccak256(
+    ethers.toUtf8Bytes("MAINTAINER_ROLE"),
+  );
+
+  const PUBLIC_KEY_1 = "0x04aabbccddeeff00112233445566778899";
+  const SERVER_URL_1 = "https://server1.example.com";
+  const PUBLIC_KEY_2 = "0x04ffeeddccbbaa99887766554433221100";
+  const SERVER_URL_2 = "https://server2.example.com";
+
+  type ServerRegistration = {
+    ownerAddress: string;
+    serverAddress: string;
+    publicKey: string;
+    serverUrl: string;
+  };
+
+  type ServerDeregistration = {
+    ownerAddress: string;
+    serverAddress: string;
+    serverId: string;
+    deadline: bigint | number;
+  };
+
+  const eip712Domain = async () => ({
+    name: "Vana Data Portability",
+    version: "1",
+    chainId: (await ethers.provider.getNetwork()).chainId,
+    verifyingContract: await serversContract.getAddress(),
+  });
+
+  const signRegistration = async (
+    signer: HardhatEthersSigner,
+    registration: ServerRegistration,
+  ) => {
+    const domain = await eip712Domain();
+    const types = {
+      ServerRegistration: [
+        { name: "ownerAddress", type: "address" },
+        { name: "serverAddress", type: "address" },
+        { name: "publicKey", type: "string" },
+        { name: "serverUrl", type: "string" },
+      ],
+    };
+    return await signer.signTypedData(domain, types, registration);
+  };
+
+  const signDeregistration = async (
+    signer: HardhatEthersSigner,
+    deregistration: ServerDeregistration,
+  ) => {
+    const domain = await eip712Domain();
+    const types = {
+      ServerDeregistration: [
+        { name: "ownerAddress", type: "address" },
+        { name: "serverAddress", type: "address" },
+        { name: "serverId", type: "bytes32" },
+        { name: "deadline", type: "uint256" },
+      ],
+    };
+    return await signer.signTypedData(domain, types, deregistration);
+  };
+
+  const futureDeadline = async (secondsFromNow = 3600) => {
+    const block = await ethers.provider.getBlock("latest");
+    return BigInt(block!.timestamp + secondsFromNow);
+  };
+
+  // Register a server owned by `ownerSigner` (submitted by `relayer` unless
+  // overridden) and return { serverId, receipt }.
+  const registerServer = async (
+    ownerSigner: HardhatEthersSigner,
+    serverAddress: string,
+    publicKey: string,
+    serverUrl: string,
+    submitter: HardhatEthersSigner = relayer,
+  ) => {
+    const registration: ServerRegistration = {
+      ownerAddress: ownerSigner.address,
+      serverAddress,
+      publicKey,
+      serverUrl,
+    };
+    const signature = await signRegistration(ownerSigner, registration);
+    const tx = await serversContract
+      .connect(submitter)
+      .registerServerWithSignature(registration, signature);
+    const receipt = await tx.wait();
+    const serverId = await serversContract.computeServerId(
+      serverAddress,
+      publicKey,
+      serverUrl,
+    );
+    return { serverId, receipt, registration };
+  };
+
+  const deregisterServer = async (
+    ownerSigner: HardhatEthersSigner,
+    serverAddress: string,
+    serverId: string,
+    submitter: HardhatEthersSigner = relayer,
+  ) => {
+    const deregistration: ServerDeregistration = {
+      ownerAddress: ownerSigner.address,
+      serverAddress,
+      serverId,
+      deadline: await futureDeadline(),
+    };
+    const signature = await signDeregistration(ownerSigner, deregistration);
+    const tx = await serversContract
+      .connect(submitter)
+      .deregisterServerWithSignature(deregistration, signature);
+    return { deregistration, signature, receipt: await tx.wait() };
+  };
+
+  const deploy = async () => {
+    [
+      trustedForwarder,
+      deployer,
+      owner,
+      maintainer,
+      serverOwner1,
+      serverOwner2,
+      relayer,
+      server1,
+      server2,
+    ] = await ethers.getSigners();
+
+    const factory = await ethers.getContractFactory(
+      "DataPortabilityServersV2Implementation",
+    );
+
+    const proxyDeploy = await upgrades.deployProxy(
+      factory,
+      [trustedForwarder.address, owner.address],
+      { kind: "uups" },
+    );
+
+    serversContract = await ethers.getContractAt(
+      "DataPortabilityServersV2Implementation",
+      proxyDeploy.target,
+    );
+
+    await serversContract
+      .connect(owner)
+      .grantRole(MAINTAINER_ROLE, maintainer.address);
+  };
+
+  beforeEach(async () => {
+    await deploy();
+  });
+
+  describe("Setup", () => {
+    it("should have correct params after deploy", async function () {
+      (await serversContract.hasRole(DEFAULT_ADMIN_ROLE, owner)).should.eq(
+        true,
+      );
+      (await serversContract.hasRole(MAINTAINER_ROLE, owner)).should.eq(true);
+      (
+        await serversContract.hasRole(MAINTAINER_ROLE, maintainer)
+      ).should.eq(true);
+      (await serversContract.trustedForwarder()).should.eq(
+        trustedForwarder.address,
+      );
+      (await serversContract.version()).should.eq(1);
+      (await serversContract.serversCount()).should.eq(0);
+      (await serversContract.paused()).should.eq(false);
+    });
+
+    it("should expose the expected EIP-712 typehashes", async function () {
+      (await serversContract.SERVER_REGISTRATION_TYPEHASH()).should.eq(
+        ethers.keccak256(
+          ethers.toUtf8Bytes(
+            "ServerRegistration(address ownerAddress,address serverAddress,string publicKey,string serverUrl)",
+          ),
+        ),
+      );
+      (await serversContract.SERVER_DEREGISTRATION_TYPEHASH()).should.eq(
+        ethers.keccak256(
+          ethers.toUtf8Bytes(
+            "ServerDeregistration(address ownerAddress,address serverAddress,bytes32 serverId,uint256 deadline)",
+          ),
+        ),
+      );
+    });
+
+    it("should reject re-initialization", async function () {
+      await expect(
+        serversContract.initialize(trustedForwarder.address, owner.address),
+      ).to.be.revertedWithCustomError(serversContract, "InvalidInitialization");
+    });
+
+    it("should reject initialization with zero owner", async function () {
+      const implFactory = await ethers.getContractFactory(
+        "DataPortabilityServersV2Implementation",
+      );
+      const impl = await implFactory.deploy();
+      await impl.waitForDeployment();
+
+      const proxyFactory = await ethers.getContractFactory(
+        "DataPortabilityServersV2Proxy",
+      );
+      const initData = implFactory.interface.encodeFunctionData("initialize", [
+        trustedForwarder.address,
+        ethers.ZeroAddress,
+      ]);
+
+      await expect(
+        proxyFactory.deploy(await impl.getAddress(), initData),
+      ).to.be.revertedWithCustomError(implFactory, "ZeroAddress");
+    });
+  });
+
+  describe("computeServerId", () => {
+    it("should expose the standard EIP-712 domain separator", async function () {
+      // Independent recomputation — this is the value off-chain gateways use
+      // to predict serverIds, so it must match hashDomain of the documented
+      // domain, not merely be internally consistent.
+      (await serversContract.domainSeparator()).should.eq(
+        ethers.TypedDataEncoder.hashDomain(await eip712Domain()),
+      );
+    });
+
+    it("should equal keccak256(abi.encode(domainSeparator, serverAddress, publicKey, serverUrl))", async function () {
+      const domainSep = ethers.TypedDataEncoder.hashDomain(
+        await eip712Domain(),
+      );
+      const expected = ethers.keccak256(
+        ethers.AbiCoder.defaultAbiCoder().encode(
+          ["bytes32", "address", "string", "string"],
+          [domainSep, server1.address, PUBLIC_KEY_1, SERVER_URL_1],
+        ),
+      );
+
+      (
+        await serversContract.computeServerId(
+          server1.address,
+          PUBLIC_KEY_1,
+          SERVER_URL_1,
+        )
+      ).should.eq(expected);
+    });
+
+    it("should produce different ids for different inputs", async function () {
+      const id1 = await serversContract.computeServerId(
+        server1.address,
+        PUBLIC_KEY_1,
+        SERVER_URL_1,
+      );
+      const id2 = await serversContract.computeServerId(
+        server1.address,
+        PUBLIC_KEY_1,
+        SERVER_URL_2,
+      );
+      const id3 = await serversContract.computeServerId(
+        server2.address,
+        PUBLIC_KEY_1,
+        SERVER_URL_1,
+      );
+      id1.should.not.eq(id2);
+      id1.should.not.eq(id3);
+      id2.should.not.eq(id3);
+    });
+  });
+
+  describe("registerServerWithSignature", () => {
+    it("should register a server via any relayer with the owner's signature", async function () {
+      const registration: ServerRegistration = {
+        ownerAddress: serverOwner1.address,
+        serverAddress: server1.address,
+        publicKey: PUBLIC_KEY_1,
+        serverUrl: SERVER_URL_1,
+      };
+      const signature = await signRegistration(serverOwner1, registration);
+
+      const expectedServerId = await serversContract.computeServerId(
+        server1.address,
+        PUBLIC_KEY_1,
+        SERVER_URL_1,
+      );
+
+      const tx = await serversContract
+        .connect(relayer)
+        .registerServerWithSignature(registration, signature);
+      const receipt = await tx.wait();
+
+      await expect(tx)
+        .to.emit(serversContract, "ServerRegistered")
+        .withArgs(
+          expectedServerId,
+          serverOwner1.address,
+          server1.address,
+          PUBLIC_KEY_1,
+          SERVER_URL_1,
+        );
+
+      const server = await serversContract.getServer(expectedServerId);
+      server.id.should.eq(expectedServerId);
+      server.ownerAddress.should.eq(serverOwner1.address);
+      server.serverAddress.should.eq(server1.address);
+      server.publicKey.should.eq(PUBLIC_KEY_1);
+      server.serverUrl.should.eq(SERVER_URL_1);
+      server.registeredAtBlock.should.eq(receipt!.blockNumber);
+      server.revokedAtBlock.should.eq(0);
+
+      (await serversContract.activeServerId(server1.address)).should.eq(
+        expectedServerId,
+      );
+
+      const activeServer = await serversContract.getActiveServerByAddress(
+        server1.address,
+      );
+      activeServer.id.should.eq(expectedServerId);
+      activeServer.ownerAddress.should.eq(serverOwner1.address);
+      activeServer.serverAddress.should.eq(server1.address);
+      activeServer.publicKey.should.eq(PUBLIC_KEY_1);
+      activeServer.serverUrl.should.eq(SERVER_URL_1);
+
+      const owned = await serversContract.ownerServers(serverOwner1.address);
+      owned.length.should.eq(1);
+      owned[0].id.should.eq(expectedServerId);
+
+      (await serversContract.serversCount()).should.eq(1);
+    });
+
+    it("should register multiple servers and increment serversCount", async function () {
+      const { serverId: id1 } = await registerServer(
+        serverOwner1,
+        server1.address,
+        PUBLIC_KEY_1,
+        SERVER_URL_1,
+      );
+      const { serverId: id2 } = await registerServer(
+        serverOwner1,
+        server2.address,
+        PUBLIC_KEY_2,
+        SERVER_URL_2,
+      );
+
+      (await serversContract.serversCount()).should.eq(2);
+      const owned = await serversContract.ownerServers(serverOwner1.address);
+      owned.length.should.eq(2);
+      owned[0].id.should.eq(id1);
+      owned[1].id.should.eq(id2);
+    });
+
+    it("should revert with ZeroAddress for zero ownerAddress", async function () {
+      const registration: ServerRegistration = {
+        ownerAddress: ethers.ZeroAddress,
+        serverAddress: server1.address,
+        publicKey: PUBLIC_KEY_1,
+        serverUrl: SERVER_URL_1,
+      };
+      const signature = await signRegistration(serverOwner1, registration);
+
+      await expect(
+        serversContract
+          .connect(relayer)
+          .registerServerWithSignature(registration, signature),
+      ).to.be.revertedWithCustomError(serversContract, "ZeroAddress");
+    });
+
+    it("should revert with ZeroAddress for zero serverAddress", async function () {
+      const registration: ServerRegistration = {
+        ownerAddress: serverOwner1.address,
+        serverAddress: ethers.ZeroAddress,
+        publicKey: PUBLIC_KEY_1,
+        serverUrl: SERVER_URL_1,
+      };
+      const signature = await signRegistration(serverOwner1, registration);
+
+      await expect(
+        serversContract
+          .connect(relayer)
+          .registerServerWithSignature(registration, signature),
+      ).to.be.revertedWithCustomError(serversContract, "ZeroAddress");
+    });
+
+    it("should revert with EmptyPublicKey for empty publicKey", async function () {
+      const registration: ServerRegistration = {
+        ownerAddress: serverOwner1.address,
+        serverAddress: server1.address,
+        publicKey: "",
+        serverUrl: SERVER_URL_1,
+      };
+      const signature = await signRegistration(serverOwner1, registration);
+
+      await expect(
+        serversContract
+          .connect(relayer)
+          .registerServerWithSignature(registration, signature),
+      ).to.be.revertedWithCustomError(serversContract, "EmptyPublicKey");
+    });
+
+    it("should revert with EmptyUrl for empty serverUrl", async function () {
+      const registration: ServerRegistration = {
+        ownerAddress: serverOwner1.address,
+        serverAddress: server1.address,
+        publicKey: PUBLIC_KEY_1,
+        serverUrl: "",
+      };
+      const signature = await signRegistration(serverOwner1, registration);
+
+      await expect(
+        serversContract
+          .connect(relayer)
+          .registerServerWithSignature(registration, signature),
+      ).to.be.revertedWithCustomError(serversContract, "EmptyUrl");
+    });
+
+    it("should revert with OwnerMismatch when signed by someone else", async function () {
+      const registration: ServerRegistration = {
+        ownerAddress: serverOwner1.address,
+        serverAddress: server1.address,
+        publicKey: PUBLIC_KEY_1,
+        serverUrl: SERVER_URL_1,
+      };
+      // serverOwner2 signs a payload claiming serverOwner1 as owner.
+      const signature = await signRegistration(serverOwner2, registration);
+
+      await expect(
+        serversContract
+          .connect(relayer)
+          .registerServerWithSignature(registration, signature),
+      )
+        .to.be.revertedWithCustomError(serversContract, "OwnerMismatch")
+        .withArgs(serverOwner1.address, serverOwner2.address);
+    });
+
+    it("should revert with OwnerMismatch when the signed payload differs from the submitted input", async function () {
+      const signedRegistration: ServerRegistration = {
+        ownerAddress: serverOwner1.address,
+        serverAddress: server1.address,
+        publicKey: PUBLIC_KEY_1,
+        serverUrl: SERVER_URL_1,
+      };
+      const signature = await signRegistration(
+        serverOwner1,
+        signedRegistration,
+      );
+
+      // Tamper with the serverUrl after signing.
+      const tampered: ServerRegistration = {
+        ...signedRegistration,
+        serverUrl: SERVER_URL_2,
+      };
+
+      await expect(
+        serversContract
+          .connect(relayer)
+          .registerServerWithSignature(tampered, signature),
+      ).to.be.revertedWithCustomError(serversContract, "OwnerMismatch");
+    });
+
+    it("should revert with ECDSAInvalidSignature for an unrecoverable signature", async function () {
+      const registration: ServerRegistration = {
+        ownerAddress: serverOwner1.address,
+        serverAddress: server1.address,
+        publicKey: PUBLIC_KEY_1,
+        serverUrl: SERVER_URL_1,
+      };
+      // v = 0 makes ecrecover return address(0) deterministically — OZ
+      // ECDSA surfaces this as its own typed error, never OwnerMismatch.
+      const unrecoverable = "0x" + "11".repeat(64) + "00";
+
+      await expect(
+        serversContract
+          .connect(relayer)
+          .registerServerWithSignature(registration, unrecoverable),
+      ).to.be.revertedWithCustomError(serversContract, "ECDSAInvalidSignature");
+    });
+
+    it("should revert with ServerAlreadyRegistered for an already-active serverAddress", async function () {
+      await registerServer(
+        serverOwner1,
+        server1.address,
+        PUBLIC_KEY_1,
+        SERVER_URL_1,
+      );
+
+      const registration: ServerRegistration = {
+        ownerAddress: serverOwner2.address,
+        serverAddress: server1.address,
+        publicKey: PUBLIC_KEY_2,
+        serverUrl: SERVER_URL_2,
+      };
+      const signature = await signRegistration(serverOwner2, registration);
+
+      await expect(
+        serversContract
+          .connect(relayer)
+          .registerServerWithSignature(registration, signature),
+      )
+        .to.be.revertedWithCustomError(
+          serversContract,
+          "ServerAlreadyRegistered",
+        )
+        .withArgs(server1.address);
+    });
+  });
+
+  describe("Re-registration semantics", () => {
+    it("should reject re-registering the identical tuple after deregistration (id collision)", async function () {
+      const { serverId } = await registerServer(
+        serverOwner1,
+        server1.address,
+        PUBLIC_KEY_1,
+        SERVER_URL_1,
+      );
+      await deregisterServer(serverOwner1, server1.address, serverId);
+
+      // Same (serverAddress, publicKey, serverUrl) tuple -> same serverId,
+      // which collides with the revoked record.
+      const registration: ServerRegistration = {
+        ownerAddress: serverOwner1.address,
+        serverAddress: server1.address,
+        publicKey: PUBLIC_KEY_1,
+        serverUrl: SERVER_URL_1,
+      };
+      const signature = await signRegistration(serverOwner1, registration);
+
+      await expect(
+        serversContract
+          .connect(relayer)
+          .registerServerWithSignature(registration, signature),
+      )
+        .to.be.revertedWithCustomError(
+          serversContract,
+          "ServerAlreadyRegistered",
+        )
+        .withArgs(server1.address);
+    });
+
+    it("should allow re-registering the same serverAddress with a different serverUrl", async function () {
+      const { serverId: oldId } = await registerServer(
+        serverOwner1,
+        server1.address,
+        PUBLIC_KEY_1,
+        SERVER_URL_1,
+      );
+      await deregisterServer(serverOwner1, server1.address, oldId);
+
+      const { serverId: newId } = await registerServer(
+        serverOwner1,
+        server1.address,
+        PUBLIC_KEY_1,
+        SERVER_URL_2,
+      );
+
+      newId.should.not.eq(oldId);
+      (await serversContract.activeServerId(server1.address)).should.eq(newId);
+      (await serversContract.serversCount()).should.eq(2);
+
+      const active = await serversContract.getActiveServerByAddress(
+        server1.address,
+      );
+      active.id.should.eq(newId);
+      active.serverUrl.should.eq(SERVER_URL_2);
+      active.revokedAtBlock.should.eq(0);
+
+      // Both records exist under the owner.
+      const owned = await serversContract.ownerServers(serverOwner1.address);
+      owned.length.should.eq(2);
+      owned[0].id.should.eq(oldId);
+      owned[0].revokedAtBlock.should.not.eq(0);
+      owned[1].id.should.eq(newId);
+    });
+
+    it("should allow re-registering the same serverAddress with a different publicKey", async function () {
+      const { serverId: oldId } = await registerServer(
+        serverOwner1,
+        server1.address,
+        PUBLIC_KEY_1,
+        SERVER_URL_1,
+      );
+      await deregisterServer(serverOwner1, server1.address, oldId);
+
+      const { serverId: newId } = await registerServer(
+        serverOwner1,
+        server1.address,
+        PUBLIC_KEY_2,
+        SERVER_URL_1,
+      );
+
+      newId.should.not.eq(oldId);
+      (await serversContract.activeServerId(server1.address)).should.eq(newId);
+      const active = await serversContract.getActiveServerByAddress(
+        server1.address,
+      );
+      active.publicKey.should.eq(PUBLIC_KEY_2);
+    });
+  });
+
+  describe("deregisterServerWithSignature", () => {
+    let serverId: string;
+
+    beforeEach(async () => {
+      ({ serverId } = await registerServer(
+        serverOwner1,
+        server1.address,
+        PUBLIC_KEY_1,
+        SERVER_URL_1,
+      ));
+    });
+
+    it("should deregister a server via any relayer with the owner's signature", async function () {
+      const deregistration: ServerDeregistration = {
+        ownerAddress: serverOwner1.address,
+        serverAddress: server1.address,
+        serverId,
+        deadline: await futureDeadline(),
+      };
+      const signature = await signDeregistration(serverOwner1, deregistration);
+
+      const tx = await serversContract
+        .connect(relayer)
+        .deregisterServerWithSignature(deregistration, signature);
+      const receipt = await tx.wait();
+
+      await expect(tx)
+        .to.emit(serversContract, "ServerDeregistered")
+        .withArgs(serverId, serverOwner1.address, server1.address);
+
+      // Record is retained but revoked.
+      const server = await serversContract.getServer(serverId);
+      server.revokedAtBlock.should.eq(receipt!.blockNumber);
+
+      // Active pointer is cleared.
+      (await serversContract.activeServerId(server1.address)).should.eq(
+        ethers.ZeroHash,
+      );
+
+      await expect(
+        serversContract.getActiveServerByAddress(server1.address),
+      ).to.be.revertedWithCustomError(serversContract, "ServerNotFound");
+
+      // Owner enumeration still includes the revoked record.
+      const owned = await serversContract.ownerServers(serverOwner1.address);
+      owned.length.should.eq(1);
+      owned[0].id.should.eq(serverId);
+      owned[0].revokedAtBlock.should.eq(receipt!.blockNumber);
+
+      // serversCount is a monotonic total; it does not decrease.
+      (await serversContract.serversCount()).should.eq(1);
+    });
+
+    it("should revert with DeadlineExpired for an expired deadline", async function () {
+      const block = await ethers.provider.getBlock("latest");
+      const expiredDeadline = BigInt(block!.timestamp - 1);
+      const deregistration: ServerDeregistration = {
+        ownerAddress: serverOwner1.address,
+        serverAddress: server1.address,
+        serverId,
+        deadline: expiredDeadline,
+      };
+      const signature = await signDeregistration(serverOwner1, deregistration);
+
+      await expect(
+        serversContract
+          .connect(relayer)
+          .deregisterServerWithSignature(deregistration, signature),
+      )
+        .to.be.revertedWithCustomError(serversContract, "DeadlineExpired")
+        .withArgs(expiredDeadline, anyValue);
+    });
+
+    it("should accept a deregistration at exactly the deadline (boundary)", async function () {
+      // The check is strict (`block.timestamp > deadline` reverts), so a tx
+      // mined exactly AT the deadline must succeed.
+      const deadline = BigInt(await time.latest()) + 100n;
+      const deregistration: ServerDeregistration = {
+        ownerAddress: serverOwner1.address,
+        serverAddress: server1.address,
+        serverId,
+        deadline,
+      };
+      const signature = await signDeregistration(serverOwner1, deregistration);
+
+      await time.setNextBlockTimestamp(deadline);
+      await expect(
+        serversContract
+          .connect(relayer)
+          .deregisterServerWithSignature(deregistration, signature),
+      ).to.emit(serversContract, "ServerDeregistered");
+    });
+
+    it("should revert getServer with ServerNotFound for an unknown id", async function () {
+      const unknownId = ethers.id("no-such-server");
+      await expect(serversContract.getServer(unknownId))
+        .to.be.revertedWithCustomError(serversContract, "ServerNotFound")
+        .withArgs(unknownId);
+    });
+
+    it("should revert with OwnerMismatch when signed by the wrong signer", async function () {
+      const deregistration: ServerDeregistration = {
+        ownerAddress: serverOwner1.address,
+        serverAddress: server1.address,
+        serverId,
+        deadline: await futureDeadline(),
+      };
+      const signature = await signDeregistration(serverOwner2, deregistration);
+
+      await expect(
+        serversContract
+          .connect(relayer)
+          .deregisterServerWithSignature(deregistration, signature),
+      )
+        .to.be.revertedWithCustomError(serversContract, "OwnerMismatch")
+        .withArgs(serverOwner1.address, serverOwner2.address);
+    });
+
+    it("should revert with NotServerOwner when a non-owner self-signs a deregistration", async function () {
+      // serverOwner2 signs a deregistration naming THEMSELVES as owner over
+      // serverOwner1's server: the signature is internally consistent (no
+      // OwnerMismatch) and the serverId is the active one (no StaleServerId),
+      // so only the stored-owner check stands between a third party and
+      // revoking someone else's server.
+      const deregistration: ServerDeregistration = {
+        ownerAddress: serverOwner2.address,
+        serverAddress: server1.address,
+        serverId,
+        deadline: await futureDeadline(),
+      };
+      const signature = await signDeregistration(serverOwner2, deregistration);
+
+      await expect(
+        serversContract
+          .connect(relayer)
+          .deregisterServerWithSignature(deregistration, signature),
+      )
+        .to.be.revertedWithCustomError(serversContract, "NotServerOwner")
+        .withArgs(serverId, serverOwner2.address, serverOwner1.address);
+
+      // The server is still active.
+      (await serversContract.activeServerId(server1.address)).should.eq(
+        serverId,
+      );
+    });
+
+    it("should revert with ServerNotFound when no active registration exists", async function () {
+      // server2 was never registered.
+      const fakeServerId = await serversContract.computeServerId(
+        server2.address,
+        PUBLIC_KEY_2,
+        SERVER_URL_2,
+      );
+      const deregistration: ServerDeregistration = {
+        ownerAddress: serverOwner1.address,
+        serverAddress: server2.address,
+        serverId: fakeServerId,
+        deadline: await futureDeadline(),
+      };
+      const signature = await signDeregistration(serverOwner1, deregistration);
+
+      await expect(
+        serversContract
+          .connect(relayer)
+          .deregisterServerWithSignature(deregistration, signature),
+      )
+        .to.be.revertedWithCustomError(serversContract, "ServerNotFound")
+        .withArgs(fakeServerId);
+    });
+
+    it("should revert with ServerNotFound when replaying a deregistration after revoke", async function () {
+      const { deregistration, signature } = await deregisterServer(
+        serverOwner1,
+        server1.address,
+        serverId,
+      );
+
+      // Replaying the same signed deregistration: the active pointer is
+      // cleared, so it fails as ServerNotFound.
+      await expect(
+        serversContract
+          .connect(relayer)
+          .deregisterServerWithSignature(deregistration, signature),
+      )
+        .to.be.revertedWithCustomError(serversContract, "ServerNotFound")
+        .withArgs(serverId);
+    });
+
+    it("should revert with StaleServerId when replaying an old deregistration against a re-registration", async function () {
+      // Deregister the original registration, keeping its signed payload.
+      const { deregistration: oldDeregistration, signature: oldSignature } =
+        await deregisterServer(serverOwner1, server1.address, serverId);
+
+      // Re-register the same address with a different url -> fresh serverId.
+      const { serverId: newId } = await registerServer(
+        serverOwner1,
+        server1.address,
+        PUBLIC_KEY_1,
+        SERVER_URL_2,
+      );
+      newId.should.not.eq(serverId);
+
+      // Replay the deregistration signed over the OLD serverId.
+      await expect(
+        serversContract
+          .connect(relayer)
+          .deregisterServerWithSignature(oldDeregistration, oldSignature),
+      )
+        .to.be.revertedWithCustomError(serversContract, "StaleServerId")
+        .withArgs(newId, serverId);
+    });
+  });
+
+  describe("ERC-2771 meta-transactions", () => {
+    it("should attribute _msgSender to the appended address for forwarder calls", async function () {
+      // The trusted forwarder appends the real sender (maintainer) as the
+      // last 20 bytes of calldata. pause() is MAINTAINER_ROLE-gated, so this
+      // only succeeds if the override block resolves the appended address.
+      const pauseWithSender = ethers.concat([
+        serversContract.interface.encodeFunctionData("pause"),
+        maintainer.address,
+      ]);
+
+      await trustedForwarder.sendTransaction({
+        to: await serversContract.getAddress(),
+        data: pauseWithSender,
+      });
+      (await serversContract.paused()).should.eq(true);
+
+      const unpauseWithSender = ethers.concat([
+        serversContract.interface.encodeFunctionData("unpause"),
+        maintainer.address,
+      ]);
+      await trustedForwarder.sendTransaction({
+        to: await serversContract.getAddress(),
+        data: unpauseWithSender,
+      });
+      (await serversContract.paused()).should.eq(false);
+    });
+
+    it("should ignore the appended address for non-forwarder callers", async function () {
+      // The same suffix trick from anyone else must NOT impersonate the
+      // maintainer — msg.sender (the relayer) is used and lacks the role.
+      const pauseWithSender = ethers.concat([
+        serversContract.interface.encodeFunctionData("pause"),
+        maintainer.address,
+      ]);
+
+      await expect(
+        relayer.sendTransaction({
+          to: await serversContract.getAddress(),
+          data: pauseWithSender,
+        }),
+      )
+        .to.be.revertedWithCustomError(
+          serversContract,
+          "AccessControlUnauthorizedAccount",
+        )
+        .withArgs(relayer.address, MAINTAINER_ROLE);
+      (await serversContract.paused()).should.eq(false);
+    });
+  });
+
+  describe("Pause / unpause / trusted forwarder", () => {
+    it("should allow maintainer to pause and unpause", async function () {
+      await serversContract.connect(maintainer).pause();
+      (await serversContract.paused()).should.eq(true);
+
+      await serversContract.connect(maintainer).unpause();
+      (await serversContract.paused()).should.eq(false);
+    });
+
+    it("should reject pause and unpause from non-maintainer", async function () {
+      await expect(serversContract.connect(serverOwner1).pause())
+        .to.be.revertedWithCustomError(
+          serversContract,
+          "AccessControlUnauthorizedAccount",
+        )
+        .withArgs(serverOwner1.address, MAINTAINER_ROLE);
+
+      await serversContract.connect(maintainer).pause();
+
+      await expect(serversContract.connect(serverOwner1).unpause())
+        .to.be.revertedWithCustomError(
+          serversContract,
+          "AccessControlUnauthorizedAccount",
+        )
+        .withArgs(serverOwner1.address, MAINTAINER_ROLE);
+    });
+
+    it("should reject register and deregister while paused", async function () {
+      const { serverId } = await registerServer(
+        serverOwner1,
+        server1.address,
+        PUBLIC_KEY_1,
+        SERVER_URL_1,
+      );
+
+      await serversContract.connect(maintainer).pause();
+
+      const registration: ServerRegistration = {
+        ownerAddress: serverOwner2.address,
+        serverAddress: server2.address,
+        publicKey: PUBLIC_KEY_2,
+        serverUrl: SERVER_URL_2,
+      };
+      const regSignature = await signRegistration(serverOwner2, registration);
+      await expect(
+        serversContract
+          .connect(relayer)
+          .registerServerWithSignature(registration, regSignature),
+      ).to.be.revertedWithCustomError(serversContract, "EnforcedPause");
+
+      const deregistration: ServerDeregistration = {
+        ownerAddress: serverOwner1.address,
+        serverAddress: server1.address,
+        serverId,
+        deadline: await futureDeadline(),
+      };
+      const deregSignature = await signDeregistration(
+        serverOwner1,
+        deregistration,
+      );
+      await expect(
+        serversContract
+          .connect(relayer)
+          .deregisterServerWithSignature(deregistration, deregSignature),
+      ).to.be.revertedWithCustomError(serversContract, "EnforcedPause");
+
+      // After unpausing, both operations succeed again.
+      await serversContract.connect(maintainer).unpause();
+      await serversContract
+        .connect(relayer)
+        .registerServerWithSignature(registration, regSignature).should.be
+        .fulfilled;
+      await serversContract
+        .connect(relayer)
+        .deregisterServerWithSignature(deregistration, deregSignature).should
+        .be.fulfilled;
+    });
+
+    it("should allow maintainer to update the trusted forwarder", async function () {
+      await serversContract
+        .connect(maintainer)
+        .updateTrustedForwarder(serverOwner2.address);
+      (await serversContract.trustedForwarder()).should.eq(
+        serverOwner2.address,
+      );
+    });
+
+    it("should reject updateTrustedForwarder from non-maintainer", async function () {
+      await expect(
+        serversContract
+          .connect(serverOwner1)
+          .updateTrustedForwarder(serverOwner1.address),
+      )
+        .to.be.revertedWithCustomError(
+          serversContract,
+          "AccessControlUnauthorizedAccount",
+        )
+        .withArgs(serverOwner1.address, MAINTAINER_ROLE);
+    });
+  });
+
+  describe("Upgrades", () => {
+    it("should reject upgradeToAndCall from non-admin", async function () {
+      const implFactory = await ethers.getContractFactory(
+        "DataPortabilityServersV2Implementation",
+      );
+      const newImpl = await implFactory.deploy();
+      await newImpl.waitForDeployment();
+
+      await expect(
+        serversContract
+          .connect(maintainer)
+          .upgradeToAndCall(await newImpl.getAddress(), "0x"),
+      )
+        .to.be.revertedWithCustomError(
+          serversContract,
+          "AccessControlUnauthorizedAccount",
+        )
+        .withArgs(maintainer.address, DEFAULT_ADMIN_ROLE);
+    });
+
+    it("should allow admin to upgrade via upgradeToAndCall and preserve state", async function () {
+      const { serverId } = await registerServer(
+        serverOwner1,
+        server1.address,
+        PUBLIC_KEY_1,
+        SERVER_URL_1,
+      );
+
+      const implFactory = await ethers.getContractFactory(
+        "DataPortabilityServersV2Implementation",
+      );
+      const newImpl = await implFactory.deploy();
+      await newImpl.waitForDeployment();
+
+      await serversContract
+        .connect(owner)
+        .upgradeToAndCall(await newImpl.getAddress(), "0x").should.be
+        .fulfilled;
+
+      // State survives the upgrade.
+      (await serversContract.serversCount()).should.eq(1);
+      (await serversContract.activeServerId(server1.address)).should.eq(
+        serverId,
+      );
+      const server = await serversContract.getServer(serverId);
+      server.ownerAddress.should.eq(serverOwner1.address);
+      (await serversContract.version()).should.eq(1);
+    });
+
+    it("should allow admin to upgrade via upgrades.upgradeProxy", async function () {
+      const { serverId } = await registerServer(
+        serverOwner1,
+        server1.address,
+        PUBLIC_KEY_1,
+        SERVER_URL_1,
+      );
+
+      const implFactory = await ethers.getContractFactory(
+        "DataPortabilityServersV2Implementation",
+        owner,
+      );
+
+      await upgrades.upgradeProxy(
+        await serversContract.getAddress(),
+        implFactory,
+        { redeployImplementation: "always" },
+      ).should.be.fulfilled;
+
+      (await serversContract.serversCount()).should.eq(1);
+      (await serversContract.activeServerId(server1.address)).should.eq(
+        serverId,
+      );
+      (await serversContract.version()).should.eq(1);
+    });
+  });
+});

--- a/test/protocol/feeRegistry.ts
+++ b/test/protocol/feeRegistry.ts
@@ -1,0 +1,537 @@
+import chai, { expect, should } from "chai";
+import chaiAsPromised from "chai-as-promised";
+import { ethers, upgrades } from "hardhat";
+import { FeeRegistryImplementation } from "../../typechain-types";
+import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers";
+
+chai.use(chaiAsPromised);
+should();
+
+describe("FeeRegistry", () => {
+  let deployer: HardhatEthersSigner;
+  let owner: HardhatEthersSigner;
+  let user1: HardhatEthersSigner;
+  let user2: HardhatEthersSigner;
+  let payee: HardhatEthersSigner;
+  let asset: HardhatEthersSigner; // any address works as an asset placeholder
+
+  let feeRegistry: FeeRegistryImplementation;
+
+  const DEFAULT_ADMIN_ROLE =
+    "0x0000000000000000000000000000000000000000000000000000000000000000";
+
+  const OP_NAME = "GRANT_REGISTRATION";
+  const OP_KEY = ethers.keccak256(ethers.toUtf8Bytes(OP_NAME));
+  const OTHER_OP_KEY = ethers.keccak256(
+    ethers.toUtf8Bytes("DATA_ACCESS_RECORD"),
+  );
+
+  const deploy = async () => {
+    [deployer, owner, user1, user2, payee, asset] = await ethers.getSigners();
+
+    const feeRegistryDeploy = await upgrades.deployProxy(
+      await ethers.getContractFactory("FeeRegistryImplementation"),
+      [owner.address],
+      {
+        kind: "uups",
+      },
+    );
+
+    feeRegistry = await ethers.getContractAt(
+      "FeeRegistryImplementation",
+      feeRegistryDeploy.target,
+    );
+  };
+
+  describe("Setup", () => {
+    beforeEach(async () => {
+      await deploy();
+    });
+
+    it("should have correct params after deploy", async function () {
+      (await feeRegistry.hasRole(DEFAULT_ADMIN_ROLE, owner)).should.eq(true);
+      (await feeRegistry.version()).should.eq(1);
+      (await feeRegistry.paused()).should.eq(false);
+    });
+
+    it("should not grant any role to the deployer", async function () {
+      (await feeRegistry.hasRole(DEFAULT_ADMIN_ROLE, deployer)).should.eq(
+        false,
+      );
+    });
+
+    it("should reject re-initialization of the proxy", async function () {
+      await expect(
+        feeRegistry.connect(owner).initialize(user1.address),
+      ).to.be.revertedWithCustomError(feeRegistry, "InvalidInitialization");
+    });
+
+    it("should reject initialization of the bare implementation", async function () {
+      const implementation = await (
+        await ethers.getContractFactory("FeeRegistryImplementation")
+      ).deploy();
+      await implementation.waitForDeployment();
+
+      await expect(
+        implementation.connect(owner).initialize(owner.address),
+      ).to.be.revertedWithCustomError(implementation, "InvalidInitialization");
+    });
+
+    it("should reject deployment with zero owner address", async function () {
+      const factory = await ethers.getContractFactory(
+        "FeeRegistryImplementation",
+      );
+      await expect(
+        upgrades.deployProxy(factory, [ethers.ZeroAddress], { kind: "uups" }),
+      ).to.be.revertedWithCustomError(factory, "ZeroAddress");
+    });
+
+    it("should allow admin to grant and revoke roles", async function () {
+      await feeRegistry
+        .connect(owner)
+        .grantRole(DEFAULT_ADMIN_ROLE, user1.address).should.be.fulfilled;
+      (await feeRegistry.hasRole(DEFAULT_ADMIN_ROLE, user1)).should.eq(true);
+
+      await feeRegistry
+        .connect(user1)
+        .revokeRole(DEFAULT_ADMIN_ROLE, owner.address).should.be.fulfilled;
+      (await feeRegistry.hasRole(DEFAULT_ADMIN_ROLE, owner)).should.eq(false);
+
+      await expect(
+        feeRegistry
+          .connect(owner)
+          .grantRole(DEFAULT_ADMIN_ROLE, user2.address),
+      )
+        .to.be.revertedWithCustomError(
+          feeRegistry,
+          "AccessControlUnauthorizedAccount",
+        )
+        .withArgs(owner.address, DEFAULT_ADMIN_ROLE);
+    });
+  });
+
+  describe("setFee", () => {
+    beforeEach(async () => {
+      await deploy();
+    });
+
+    it("should reject setFee from non-admin", async function () {
+      await expect(
+        feeRegistry
+          .connect(user1)
+          .setFee(OP_KEY, 100n, ethers.ZeroAddress, payee.address, true),
+      )
+        .to.be.revertedWithCustomError(
+          feeRegistry,
+          "AccessControlUnauthorizedAccount",
+        )
+        .withArgs(user1.address, DEFAULT_ADMIN_ROLE);
+    });
+
+    it("should set a fee, emit FeeSet and register the operation", async function () {
+      const amount = ethers.parseEther("1");
+
+      await expect(
+        feeRegistry
+          .connect(owner)
+          .setFee(OP_KEY, amount, asset.address, payee.address, true),
+      )
+        .to.emit(feeRegistry, "FeeSet")
+        .withArgs(OP_KEY, amount, asset.address, payee.address, true);
+
+      const fee = await feeRegistry.fees(OP_KEY);
+      fee.amount.should.eq(amount);
+      fee.asset.should.eq(asset.address);
+      fee.payee.should.eq(payee.address);
+      fee.enabled.should.eq(true);
+
+      (await feeRegistry.isFeeRegistered(OP_KEY)).should.eq(true);
+    });
+
+    it("should overwrite an existing fee", async function () {
+      await feeRegistry
+        .connect(owner)
+        .setFee(OP_KEY, 100n, asset.address, payee.address, true);
+
+      await expect(
+        feeRegistry
+          .connect(owner)
+          .setFee(OP_KEY, 250n, ethers.ZeroAddress, user2.address, false),
+      )
+        .to.emit(feeRegistry, "FeeSet")
+        .withArgs(OP_KEY, 250n, ethers.ZeroAddress, user2.address, false);
+
+      const fee = await feeRegistry.fees(OP_KEY);
+      fee.amount.should.eq(250n);
+      fee.asset.should.eq(ethers.ZeroAddress);
+      fee.payee.should.eq(user2.address);
+      fee.enabled.should.eq(false);
+
+      (await feeRegistry.isFeeRegistered(OP_KEY)).should.eq(true);
+    });
+
+    it("should reject an enabled fee with a zero payee", async function () {
+      await expect(
+        feeRegistry
+          .connect(owner)
+          .setFee(OP_KEY, 100n, asset.address, ethers.ZeroAddress, true),
+      ).to.be.revertedWithCustomError(feeRegistry, "InvalidPayee");
+    });
+
+    it("should allow a disabled fee with a zero payee", async function () {
+      await feeRegistry
+        .connect(owner)
+        .setFee(OP_KEY, 100n, asset.address, ethers.ZeroAddress, false).should
+        .be.fulfilled;
+
+      const fee = await feeRegistry.fees(OP_KEY);
+      fee.amount.should.eq(100n);
+      fee.payee.should.eq(ethers.ZeroAddress);
+      fee.enabled.should.eq(false);
+
+      (await feeRegistry.isFeeRegistered(OP_KEY)).should.eq(true);
+    });
+
+    it("should allow an enabled fee with amount 0 (free but configured)", async function () {
+      await feeRegistry
+        .connect(owner)
+        .setFee(OP_KEY, 0n, asset.address, payee.address, true).should.be
+        .fulfilled;
+
+      const fee = await feeRegistry.fees(OP_KEY);
+      fee.amount.should.eq(0n);
+      fee.enabled.should.eq(true);
+
+      (await feeRegistry.isFeeRegistered(OP_KEY)).should.eq(true);
+      (await feeRegistry.feeAmount(OP_KEY)).should.eq(0n);
+    });
+
+    it("should accept address(0) as the asset (native VANA convention)", async function () {
+      await feeRegistry
+        .connect(owner)
+        .setFee(OP_KEY, 5n, ethers.ZeroAddress, payee.address, true);
+
+      const fee = await feeRegistry.fees(OP_KEY);
+      fee.asset.should.eq(ethers.ZeroAddress);
+      fee.enabled.should.eq(true);
+    });
+  });
+
+  describe("setFeeByName", () => {
+    beforeEach(async () => {
+      await deploy();
+    });
+
+    it("should return keccak256(bytes(name)) as the operation key", async function () {
+      const returnedKey = await feeRegistry
+        .connect(owner)
+        .setFeeByName.staticCall(
+          OP_NAME,
+          100n,
+          asset.address,
+          payee.address,
+          true,
+        );
+
+      returnedKey.should.eq(OP_KEY);
+      returnedKey.should.eq(await feeRegistry.operationKey(OP_NAME));
+      returnedKey.should.eq(ethers.keccak256(ethers.toUtf8Bytes(OP_NAME)));
+    });
+
+    it("should store the fee under the derived key and emit FeeSet", async function () {
+      await expect(
+        feeRegistry
+          .connect(owner)
+          .setFeeByName(OP_NAME, 100n, asset.address, payee.address, true),
+      )
+        .to.emit(feeRegistry, "FeeSet")
+        .withArgs(OP_KEY, 100n, asset.address, payee.address, true);
+
+      const fee = await feeRegistry.fees(OP_KEY);
+      fee.amount.should.eq(100n);
+      fee.asset.should.eq(asset.address);
+      fee.payee.should.eq(payee.address);
+      fee.enabled.should.eq(true);
+
+      (await feeRegistry.isFeeRegistered(OP_KEY)).should.eq(true);
+    });
+
+    it("should reject setFeeByName from non-admin", async function () {
+      await expect(
+        feeRegistry
+          .connect(user1)
+          .setFeeByName(OP_NAME, 100n, asset.address, payee.address, true),
+      )
+        .to.be.revertedWithCustomError(
+          feeRegistry,
+          "AccessControlUnauthorizedAccount",
+        )
+        .withArgs(user1.address, DEFAULT_ADMIN_ROLE);
+    });
+
+    it("should reject an enabled fee with a zero payee via setFeeByName", async function () {
+      await expect(
+        feeRegistry
+          .connect(owner)
+          .setFeeByName(OP_NAME, 100n, asset.address, ethers.ZeroAddress, true),
+      ).to.be.revertedWithCustomError(feeRegistry, "InvalidPayee");
+    });
+  });
+
+  describe("operationKey", () => {
+    beforeEach(async () => {
+      await deploy();
+    });
+
+    it("should match keccak256 of the utf8 name", async function () {
+      (await feeRegistry.operationKey(OP_NAME)).should.eq(OP_KEY);
+      (await feeRegistry.operationKey("DATA_ACCESS_RECORD")).should.eq(
+        OTHER_OP_KEY,
+      );
+      (await feeRegistry.operationKey("")).should.eq(
+        ethers.keccak256(ethers.toUtf8Bytes("")),
+      );
+    });
+  });
+
+  describe("Views", () => {
+    beforeEach(async () => {
+      await deploy();
+    });
+
+    it("fees() should return the zero struct for unregistered operations", async function () {
+      const fee = await feeRegistry.fees(OP_KEY);
+      fee.amount.should.eq(0n);
+      fee.asset.should.eq(ethers.ZeroAddress);
+      fee.payee.should.eq(ethers.ZeroAddress);
+      fee.enabled.should.eq(false);
+
+      (await feeRegistry.isFeeRegistered(OP_KEY)).should.eq(false);
+    });
+
+    it("feeAmount() should return the amount when enabled", async function () {
+      await feeRegistry
+        .connect(owner)
+        .setFee(OP_KEY, 123n, asset.address, payee.address, true);
+
+      (await feeRegistry.feeAmount(OP_KEY)).should.eq(123n);
+    });
+
+    it("feeAmount() should return 0 when the fee is disabled", async function () {
+      await feeRegistry
+        .connect(owner)
+        .setFee(OP_KEY, 123n, asset.address, payee.address, false);
+
+      (await feeRegistry.feeAmount(OP_KEY)).should.eq(0n);
+      // still registered, just disabled
+      (await feeRegistry.isFeeRegistered(OP_KEY)).should.eq(true);
+    });
+
+    it("feeAmount() should return 0 for unregistered operations", async function () {
+      (await feeRegistry.feeAmount(OP_KEY)).should.eq(0n);
+    });
+  });
+
+  describe("clearFee", () => {
+    beforeEach(async () => {
+      await deploy();
+      await feeRegistry
+        .connect(owner)
+        .setFee(OP_KEY, 100n, asset.address, payee.address, true);
+    });
+
+    it("should clear a fee and emit FeeCleared", async function () {
+      await expect(feeRegistry.connect(owner).clearFee(OP_KEY))
+        .to.emit(feeRegistry, "FeeCleared")
+        .withArgs(OP_KEY);
+
+      const fee = await feeRegistry.fees(OP_KEY);
+      fee.amount.should.eq(0n);
+      fee.asset.should.eq(ethers.ZeroAddress);
+      fee.payee.should.eq(ethers.ZeroAddress);
+      fee.enabled.should.eq(false);
+
+      (await feeRegistry.isFeeRegistered(OP_KEY)).should.eq(false);
+      (await feeRegistry.feeAmount(OP_KEY)).should.eq(0n);
+    });
+
+    it("should reject clearFee from non-admin", async function () {
+      await expect(feeRegistry.connect(user1).clearFee(OP_KEY))
+        .to.be.revertedWithCustomError(
+          feeRegistry,
+          "AccessControlUnauthorizedAccount",
+        )
+        .withArgs(user1.address, DEFAULT_ADMIN_ROLE);
+    });
+
+    it("should reject clearing an unregistered operation", async function () {
+      await expect(feeRegistry.connect(owner).clearFee(OTHER_OP_KEY))
+        .to.be.revertedWithCustomError(feeRegistry, "FeeNotSet")
+        .withArgs(OTHER_OP_KEY);
+    });
+
+    it("should reject clearing the same fee twice", async function () {
+      await feeRegistry.connect(owner).clearFee(OP_KEY);
+
+      await expect(feeRegistry.connect(owner).clearFee(OP_KEY))
+        .to.be.revertedWithCustomError(feeRegistry, "FeeNotSet")
+        .withArgs(OP_KEY);
+    });
+
+    it("should allow re-setting a fee after clearing it", async function () {
+      await feeRegistry.connect(owner).clearFee(OP_KEY);
+
+      await feeRegistry
+        .connect(owner)
+        .setFee(OP_KEY, 999n, ethers.ZeroAddress, user2.address, true).should
+        .be.fulfilled;
+
+      const fee = await feeRegistry.fees(OP_KEY);
+      fee.amount.should.eq(999n);
+      fee.asset.should.eq(ethers.ZeroAddress);
+      fee.payee.should.eq(user2.address);
+      fee.enabled.should.eq(true);
+
+      (await feeRegistry.isFeeRegistered(OP_KEY)).should.eq(true);
+      (await feeRegistry.feeAmount(OP_KEY)).should.eq(999n);
+    });
+  });
+
+  describe("Pause", () => {
+    beforeEach(async () => {
+      await deploy();
+      await feeRegistry
+        .connect(owner)
+        .setFee(OP_KEY, 100n, asset.address, payee.address, true);
+    });
+
+    it("should allow admin to pause and unpause", async function () {
+      await feeRegistry.connect(owner).pause().should.be.fulfilled;
+      (await feeRegistry.paused()).should.eq(true);
+
+      await feeRegistry.connect(owner).unpause().should.be.fulfilled;
+      (await feeRegistry.paused()).should.eq(false);
+    });
+
+    it("should reject pause and unpause from non-admin", async function () {
+      await expect(feeRegistry.connect(user1).pause())
+        .to.be.revertedWithCustomError(
+          feeRegistry,
+          "AccessControlUnauthorizedAccount",
+        )
+        .withArgs(user1.address, DEFAULT_ADMIN_ROLE);
+
+      await feeRegistry.connect(owner).pause();
+
+      await expect(feeRegistry.connect(user1).unpause())
+        .to.be.revertedWithCustomError(
+          feeRegistry,
+          "AccessControlUnauthorizedAccount",
+        )
+        .withArgs(user1.address, DEFAULT_ADMIN_ROLE);
+    });
+
+    it("should block setFee, setFeeByName and clearFee when paused", async function () {
+      await feeRegistry.connect(owner).pause();
+
+      await expect(
+        feeRegistry
+          .connect(owner)
+          .setFee(OTHER_OP_KEY, 100n, asset.address, payee.address, true),
+      ).to.be.revertedWithCustomError(feeRegistry, "EnforcedPause");
+
+      await expect(
+        feeRegistry
+          .connect(owner)
+          .setFeeByName(OP_NAME, 100n, asset.address, payee.address, true),
+      ).to.be.revertedWithCustomError(feeRegistry, "EnforcedPause");
+
+      await expect(
+        feeRegistry.connect(owner).clearFee(OP_KEY),
+      ).to.be.revertedWithCustomError(feeRegistry, "EnforcedPause");
+    });
+
+    it("should keep views working while paused", async function () {
+      await feeRegistry.connect(owner).pause();
+
+      const fee = await feeRegistry.fees(OP_KEY);
+      fee.amount.should.eq(100n);
+      fee.enabled.should.eq(true);
+
+      (await feeRegistry.isFeeRegistered(OP_KEY)).should.eq(true);
+      (await feeRegistry.feeAmount(OP_KEY)).should.eq(100n);
+      (await feeRegistry.operationKey(OP_NAME)).should.eq(OP_KEY);
+      (await feeRegistry.version()).should.eq(1);
+    });
+
+    it("should restore write operations after unpause", async function () {
+      await feeRegistry.connect(owner).pause();
+      await feeRegistry.connect(owner).unpause();
+
+      await feeRegistry
+        .connect(owner)
+        .setFee(OTHER_OP_KEY, 7n, asset.address, payee.address, true);
+      const fee = await feeRegistry.fees(OTHER_OP_KEY);
+      fee.amount.should.eq(7n);
+      fee.enabled.should.eq(true);
+
+      await feeRegistry.connect(owner).clearFee(OTHER_OP_KEY);
+      (await feeRegistry.isFeeRegistered(OTHER_OP_KEY)).should.eq(false);
+    });
+  });
+
+  describe("Upgrade", () => {
+    beforeEach(async () => {
+      await deploy();
+    });
+
+    it("should reject upgradeToAndCall from non-admin", async function () {
+      const newImplementation = await (
+        await ethers.getContractFactory("FeeRegistryImplementation")
+      ).deploy();
+      await newImplementation.waitForDeployment();
+
+      await expect(
+        feeRegistry
+          .connect(user1)
+          .upgradeToAndCall(await newImplementation.getAddress(), "0x"),
+      )
+        .to.be.revertedWithCustomError(
+          feeRegistry,
+          "AccessControlUnauthorizedAccount",
+        )
+        .withArgs(user1.address, DEFAULT_ADMIN_ROLE);
+    });
+
+    it("should allow admin to upgrade and preserve state", async function () {
+      await feeRegistry
+        .connect(owner)
+        .setFee(OP_KEY, 100n, asset.address, payee.address, true);
+
+      const implBefore = await upgrades.erc1967.getImplementationAddress(
+        await feeRegistry.getAddress(),
+      );
+      const upgraded = await upgrades.upgradeProxy(
+        await feeRegistry.getAddress(),
+        (await ethers.getContractFactory("FeeRegistryImplementation")).connect(
+          owner,
+        ),
+        { redeployImplementation: "always" },
+      );
+      const implAfter = await upgrades.erc1967.getImplementationAddress(
+        await feeRegistry.getAddress(),
+      );
+      implAfter.should.not.eq(implBefore); // an upgrade actually happened
+
+      (await upgraded.version()).should.eq(1);
+
+      const fee = await feeRegistry.fees(OP_KEY);
+      fee.amount.should.eq(100n);
+      fee.asset.should.eq(asset.address);
+      fee.payee.should.eq(payee.address);
+      fee.enabled.should.eq(true);
+      (await feeRegistry.isFeeRegistered(OP_KEY)).should.eq(true);
+      (await feeRegistry.hasRole(DEFAULT_ADMIN_ROLE, owner)).should.eq(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Three live-on-Moksha capability extensions to the data-portability stack, plus the canonical full-stack deployer that was missing from the branch.

**Escrow — generalized op + settle bundle ([`6588fee`](../../commit/6588fee))**
- Expands `OpKind` with explicit values for data/server/builder/grant registration plus data access (was: a single `Registration`).
- New `runOpAndSettle(target, callData, ops)` lets the facilitator dispatch any admin-allowlisted `(target, selector)` pair atomically with the standard settle loop. Zero value forwarded. Target revert data bubbles verbatim. No `whenPaused` escape.
- New admin `setOpAllowed(target, selector, allowed)` maintains both an enumerable target set (`getAllowedTargets`) and a per-target enumerable selector set (`getAllowedSelectors`). Auto-add/auto-remove on first/last selector. Idempotent.
- Existing `registerAndSettle` / `recordAccessAndSettle` are untouched — additive change.

**PermissionsV2 — delegated signing ([`fe0040e`](../../commit/fe0040e))**
- `addPermissionWithSignature` now accepts an EIP-712 signature from either (a) the grantor or (b) a personal server currently registered to the grantor in `DataPortabilityServersV2`. Same trust model already used by `DataRegistryV2.recordDataAccess`.
- New `PermissionSignedByDelegate(id, grantor, delegate)` emitted on the delegated path so indexers can distinguish.
- Storage append: `dataPortabilityServers` reference + setter.
- If servers contract is unset, only grantor self-signing is accepted — pre-upgrade behavior preserved bit-for-bit.
- **Function selector unchanged** (`0xdb503733`) → escrow `runOpAndSettle` allowlist + gateway integration stay valid.

**DataRegistryV2 — delegated signing ([`2335bc7`](../../commit/2335bc7))**
- Same shape applied to `addDataWithSignature`. New `DataSignedByDelegate(id, owner, delegate)` event.
- No storage change — `dataPortabilityServers` was already wired for `recordDataAccess`.
- Selector unchanged. `expectedVersion` monotonicity preserved.

**Canonical full-stack deployer ([`e736a8f`](../../commit/e736a8f))**
- Single script lands FeeRegistry + ServersV2 + PermissionsV2 + DataRegistryV2 + Escrow at matching CREATE2 addresses on every chain. Bootstrap-then-transfer admin pattern, idempotent rerun.

## Trust note

A personal server registered to a user can now bind permissions AND register data on that user's behalf. This is the same delegation the user already grants for `recordDataAccess`. Revocation in `DataPortabilityServersV2` immediately removes signing authority on all three paths.

## Test plan

- [x] Hardhat compile clean
- [x] Moksha live behavior validates each change:
  - Escrow upgrade tx `0x9bdf3c0b…40d6f9` (runOpAndSettle); allowlist seeded via tx `0xf9d50b95…` (PermissionsV2 selector) and tx `0xe25c2565…` (DataRegistryV2 selector).
  - PermissionsV2 upgrade tx `0x6a5f5e82…58d`; servers wired at tx `0xb958a1a1…871a`.
  - DataRegistryV2 upgrade tx `0x597f9511…aa56`; `dataPortabilityServers` unchanged at `0xCae2CE0e…7Eab`.
- [x] Mainnet impls deployed + verified, awaiting `upgradeToAndCall` from admin `0x5ECA5208…3BaF4`:
  - Escrow: `0x3d675c462B5DB6Ab2850901f008fE0b949eA7B5A`
  - PermissionsV2: `0x4E71094c8cd2065F1C0C85e978d7f53B79B1AA84`
  - DataRegistryV2: `0x71E5EaD912D7E424C22DCBf98805d6C17C8CE339`
- [ ] No unit tests for V2 contracts in this repo yet — covered by live integration on Moksha. Worth tracking as a follow-up.

## Mainnet activation (after merge)

The admin wallet `0x5ECA5208…3BaF4` needs to send these txs against canonical proxies on Vana mainnet:

| Contract | Proxy | Action |
|---|---|---|
| Escrow | `0x07d7769081adc3a3DBe91f5E4B98E9A5a6B292e3` | `upgradeToAndCall(0x3d675c46…7B5A, 0x)` |
| PermissionsV2 | `0x4d3FA76064D88e0454cFc4CaD7e5FeC3e3124011` | `upgradeToAndCall(0x4E71094c…1AA84, 0x)` then `setDataPortabilityServers(0xCae2CE0e…7Eab)` |
| DataRegistryV2 | `0x8f1eFCdff3d0d5BB535e32620721c7EBed151867` | `upgradeToAndCall(0x71E5EaD9…E339, 0x)` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)