### PR TITLE
feat: add seeded L1 deposit contract with Foundry tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,3 +41,12 @@ VANA_BROWSER_URL=https://vanascan.io
 MOKSHA_RPC_URL=https://rpc.moksha.vana.org
 MOKSHA_API_URL=https://moksha.vanascan.io/api
 MOKSHA_BROWSER_URL=https://moksha.vanascan.io
+
+# DepositContractSeeded deployment (script/DeployDepositContractSeeded.s.sol)
+SOURCE_DEPOSIT_CONTRACT=0x17BbE91c315Bf14f38F6D35052a827cadfFe184e
+DEPOSIT_CONTRACT_OWNER=
+MIN_DEPOSIT_AMOUNT=1000000000000000000000
+EXPECTED_DEPOSIT_ROOT=0x60dff8f6a92d68799e7653acdcefa253a1c2603b4dd071d8265491b465172401
+# optional:
+# RESTRICTED=true
+# ALLOWED_VALIDATORS=0x<48-byte pubkey>,0x<48-byte pubkey>

--- a/.github/workflows/foundry-tests.yml
+++ b/.github/workflows/foundry-tests.yml
@@ -1,0 +1,35 @@
+name: Foundry tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  foundry-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # forge-std lives in lib/ as a git submodule
+          submodules: recursive
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "lts/*"
+          cache: npm
+
+      # remappings in foundry.toml resolve @openzeppelin from node_modules
+      - name: Install dependencies
+        run: npm ci --no-audit --no-fund
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+
+      - name: Run Foundry tests
+        run: forge test -vvv

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@ node_modules
 # Hardhat files
 /cache
 
+# Foundry files
+/out
+/cache_forge
+
 # TypeChain files
 /typechain
 /typechain-types

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ node_modules
 # Foundry files
 /out
 /cache_forge
+/broadcast
 
 # TypeChain files
 /typechain

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "lib/forge-std"]
+	path = lib/forge-std
+	url = https://github.com/foundry-rs/forge-std

--- a/contracts/chain/l1Deposit/DepositContractSeeded.sol
+++ b/contracts/chain/l1Deposit/DepositContractSeeded.sol
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: CC0-1.0
+pragma solidity ^0.8.20;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {Ownable2Step} from "@openzeppelin/contracts/access/Ownable2Step.sol";
+import {IDeposit} from "./interfaces/IDeposit.sol";
+import {ERC165} from "./interfaces/ERC165.sol";
+
+/// @notice Port of the canonical Ethereum deposit contract, with one change:
+///         the constructor seeds BOTH `deposit_count` and the incremental
+///         Merkle `branch`, so the deployed contract reproduces an existing
+///         contract's `get_deposit_root()` exactly.
+///
+///         Seeding the count alone (as in DepositContract.sol) yields a
+///         contract that reports the right count but a different root, because
+///         the tree holds no leaves. Copying the branch fixes that: for a count
+///         of N, `get_deposit_root()` folds branch[h] for every set bit of N,
+///         so an identical (count, branch) pair gives an identical root.
+contract DepositContractSeeded is Ownable2Step, IDeposit, ERC165 {
+    uint constant DEPOSIT_CONTRACT_TREE_DEPTH = 32;
+    uint constant MAX_DEPOSIT_COUNT = 2 ** DEPOSIT_CONTRACT_TREE_DEPTH - 1;
+
+    // Ownable/Ownable2Step occupy slots 0 (_owner) and 1 (_pendingOwner), so the
+    // deposit state below sits two slots higher than in the canonical contract.
+    // That does not affect seeding, which is done via constructor arguments;
+    // verify a deployment with `get_deposit_root()` / `get_branch(i)` instead of
+    // by comparing raw slots against the source contract.
+    bytes32[DEPOSIT_CONTRACT_TREE_DEPTH] branch;       // slots 2..33
+    uint256 deposit_count;                             // slot 34
+    bytes32[DEPOSIT_CONTRACT_TREE_DEPTH] zero_hashes;  // slots 35..66
+
+    /// @notice Minimum accepted deposit, replacing the canonical hard-coded
+    ///         1 ether floor. Settable by the owner; the deposit logic and the
+    ///         seeded tree are fixed at deployment, and the contract is not
+    ///         upgradeable, so this is the only mutable parameter.
+    uint256 public minDepositAmount;                   // slot 67
+
+    /// @notice While true, only allow-listed validator public keys may deposit.
+    bool public restricted;                            // slot 68
+
+    struct Validator {
+        bool isAllowed;
+    }
+
+    /// @notice Allow-list consulted only while `restricted` is true.
+    mapping(bytes pubkey => Validator validator) public validators;  // slot 69
+
+    event MinDepositAmountUpdated(uint256 newMinDepositAmount);
+    event RestrictedUpdated(bool newRestricted);
+    event AllowedValidatorsAdded(bytes validatorPublicKey);
+    event AllowedValidatorsRemoved(bytes validatorPublicKey);
+
+    constructor(
+        uint256 initial_deposit_count,
+        bytes32[DEPOSIT_CONTRACT_TREE_DEPTH] memory initial_branch,
+        uint256 _minDepositAmount,
+        address ownerAddress,
+        bool initialRestricted,
+        bytes[] memory initialAllowedValidators
+    ) Ownable(ownerAddress) {
+        for (uint height = 0; height < DEPOSIT_CONTRACT_TREE_DEPTH - 1; height++)
+            zero_hashes[height + 1] = sha256(
+                abi.encodePacked(zero_hashes[height], zero_hashes[height])
+            );
+        deposit_count = initial_deposit_count;
+        for (uint i = 0; i < DEPOSIT_CONTRACT_TREE_DEPTH; i++)
+            branch[i] = initial_branch[i];
+        minDepositAmount = _minDepositAmount;
+        restricted = initialRestricted;
+        for (uint i = 0; i < initialAllowedValidators.length; ++i)
+            validators[initialAllowedValidators[i]].isAllowed = true;
+    }
+
+    /**
+     * @notice Updates the minDepositAmount
+     *
+     * @param newMinDepositAmount                  new minDepositAmount
+     */
+    function updateMinDepositAmount(uint256 newMinDepositAmount) external onlyOwner {
+        minDepositAmount = newMinDepositAmount;
+
+        emit MinDepositAmountUpdated(newMinDepositAmount);
+    }
+
+    /**
+     * @notice Updates the restricted
+     *
+     * @param _restricted                  new restricted
+     */
+    function updateRestricted(bool _restricted) external onlyOwner {
+        restricted = _restricted;
+
+        emit RestrictedUpdated(_restricted);
+    }
+
+    function addAllowedValidators(bytes[] memory validatorPublicKeys) external onlyOwner {
+        for (uint i = 0; i < validatorPublicKeys.length; ++i) {
+            validators[validatorPublicKeys[i]].isAllowed = true;
+
+            emit AllowedValidatorsAdded(validatorPublicKeys[i]);
+        }
+    }
+
+    function removeAllowedValidators(bytes[] memory validatorPublicKeys) external onlyOwner {
+        for (uint i = 0; i < validatorPublicKeys.length; ++i) {
+            validators[validatorPublicKeys[i]].isAllowed = false;
+
+            emit AllowedValidatorsRemoved(validatorPublicKeys[i]);
+        }
+    }
+
+    function get_deposit_root() external view override returns (bytes32) {
+        bytes32 node;
+        uint size = deposit_count;
+        for (uint height = 0; height < DEPOSIT_CONTRACT_TREE_DEPTH; height++) {
+            if ((size & 1) == 1)
+                node = sha256(abi.encodePacked(branch[height], node));
+            else
+                node = sha256(abi.encodePacked(node, zero_hashes[height]));
+            size /= 2;
+        }
+        return sha256(
+            abi.encodePacked(node, to_little_endian_64(uint64(deposit_count)), bytes24(0))
+        );
+    }
+
+    function get_deposit_count() external view override returns (bytes memory) {
+        return to_little_endian_64(uint64(deposit_count));
+    }
+
+    /// @notice Read a branch slot, for verifying the seed took effect.
+    function get_branch(uint i) external view returns (bytes32) {
+        return branch[i];
+    }
+
+    function deposit(
+        bytes calldata pubkey,
+        bytes calldata withdrawal_credentials,
+        bytes calldata signature,
+        bytes32 deposit_data_root
+    ) external payable override {
+        if (restricted) {
+            require(validators[pubkey].isAllowed, "DepositContract: publicKey not allowed");
+        }
+
+        require(pubkey.length == 48, "DepositContract: invalid pubkey length");
+        require(
+            withdrawal_credentials.length == 32,
+            "DepositContract: invalid withdrawal_credentials length"
+        );
+        require(signature.length == 96, "DepositContract: invalid signature length");
+        require(msg.value >= minDepositAmount, "DepositContract: deposit value too low");
+        require(msg.value % 1 gwei == 0, "DepositContract: deposit value not multiple of gwei");
+        uint deposit_amount = msg.value / 1 gwei;
+        require(deposit_amount <= type(uint64).max, "DepositContract: deposit value too high");
+
+        bytes memory amount = to_little_endian_64(uint64(deposit_amount));
+
+        emit DepositEvent(
+            pubkey,
+            withdrawal_credentials,
+            amount,
+            signature,
+            to_little_endian_64(uint64(deposit_count))
+        );
+
+        bytes32 pubkey_root = sha256(abi.encodePacked(pubkey, bytes16(0)));
+        bytes32 signature_root = sha256(
+            abi.encodePacked(
+                sha256(abi.encodePacked(signature[:64])),
+                sha256(abi.encodePacked(signature[64:], bytes32(0)))
+            )
+        );
+        bytes32 node = sha256(
+            abi.encodePacked(
+                sha256(abi.encodePacked(pubkey_root, withdrawal_credentials)),
+                sha256(abi.encodePacked(amount, bytes24(0), signature_root))
+            )
+        );
+
+        require(
+            node == deposit_data_root,
+            "DepositContract: reconstructed DepositData does not match supplied deposit_data_root"
+        );
+        require(deposit_count < MAX_DEPOSIT_COUNT, "DepositContract: merkle tree full");
+
+        deposit_count += 1;
+        uint size = deposit_count;
+        for (uint height = 0; height < DEPOSIT_CONTRACT_TREE_DEPTH; height++) {
+            if ((size & 1) == 1) {
+                branch[height] = node;
+                return;
+            }
+            node = sha256(abi.encodePacked(branch[height], node));
+            size /= 2;
+        }
+        assert(false);
+    }
+
+    function supportsInterface(bytes4 interfaceId) external pure override returns (bool) {
+        return interfaceId == type(ERC165).interfaceId || interfaceId == type(IDeposit).interfaceId;
+    }
+
+    function to_little_endian_64(uint64 value) internal pure returns (bytes memory ret) {
+        ret = new bytes(8);
+        bytes8 bytesValue = bytes8(value);
+        ret[0] = bytesValue[7];
+        ret[1] = bytesValue[6];
+        ret[2] = bytesValue[5];
+        ret[3] = bytesValue[4];
+        ret[4] = bytesValue[3];
+        ret[5] = bytesValue[2];
+        ret[6] = bytesValue[1];
+        ret[7] = bytesValue[0];
+    }
+}

--- a/contracts/chain/l1Deposit/DepositContractSeeded.sol
+++ b/contracts/chain/l1Deposit/DepositContractSeeded.sol
@@ -6,6 +6,21 @@ import {Ownable2Step} from "@openzeppelin/contracts/access/Ownable2Step.sol";
 import {IDeposit} from "./interfaces/IDeposit.sol";
 import {ERC165} from "./interfaces/ERC165.sol";
 
+/// @dev Holds the deposit tree state and nothing else. Listed FIRST in the
+///      inheritance list below so these variables keep the canonical deposit
+///      contract's storage layout -- branch in slots 0..31, deposit_count in
+///      slot 32 -- readable with the same eth_getStorageAt calls as the
+///      original contract. Ownable2Step's _owner/_pendingOwner land AFTER
+///      them (slots 65..66) instead of at slots 0..1.
+abstract contract DepositTreeStorage {
+    uint constant DEPOSIT_CONTRACT_TREE_DEPTH = 32;
+    uint constant MAX_DEPOSIT_COUNT = 2 ** DEPOSIT_CONTRACT_TREE_DEPTH - 1;
+
+    bytes32[DEPOSIT_CONTRACT_TREE_DEPTH] branch;       // slots 0..31
+    uint256 deposit_count;                             // slot 32
+    bytes32[DEPOSIT_CONTRACT_TREE_DEPTH] zero_hashes;  // slots 33..64
+}
+
 /// @notice Port of the canonical Ethereum deposit contract, with one change:
 ///         the constructor seeds BOTH `deposit_count` and the incremental
 ///         Merkle `branch`, so the deployed contract reproduces an existing
@@ -16,18 +31,8 @@ import {ERC165} from "./interfaces/ERC165.sol";
 ///         the tree holds no leaves. Copying the branch fixes that: for a count
 ///         of N, `get_deposit_root()` folds branch[h] for every set bit of N,
 ///         so an identical (count, branch) pair gives an identical root.
-contract DepositContractSeeded is Ownable2Step, IDeposit, ERC165 {
-    uint constant DEPOSIT_CONTRACT_TREE_DEPTH = 32;
-    uint constant MAX_DEPOSIT_COUNT = 2 ** DEPOSIT_CONTRACT_TREE_DEPTH - 1;
-
-    // Ownable/Ownable2Step occupy slots 0 (_owner) and 1 (_pendingOwner), so the
-    // deposit state below sits two slots higher than in the canonical contract.
-    // That does not affect seeding, which is done via constructor arguments;
-    // verify a deployment with `get_deposit_root()` / `get_branch(i)` instead of
-    // by comparing raw slots against the source contract.
-    bytes32[DEPOSIT_CONTRACT_TREE_DEPTH] branch;       // slots 2..33
-    uint256 deposit_count;                             // slot 34
-    bytes32[DEPOSIT_CONTRACT_TREE_DEPTH] zero_hashes;  // slots 35..66
+contract DepositContractSeeded is DepositTreeStorage, Ownable2Step, IDeposit, ERC165 {
+    // Ownable2Step: _owner slot 65, _pendingOwner slot 66 (see DepositTreeStorage)
 
     /// @notice Minimum accepted deposit, replacing the canonical hard-coded
     ///         1 ether floor. Settable by the owner; the deposit logic and the

--- a/contracts/chain/l1Deposit/docs/min-deposit-amount-validation.md
+++ b/contracts/chain/l1Deposit/docs/min-deposit-amount-validation.md
@@ -1,0 +1,93 @@
+# Why `updateMinDepositAmount` has no input validation
+
+**Contract:** `DepositContractSeeded`
+**Decision:** deliberate — validation was considered and declined (2026-08).
+
+`updateMinDepositAmount` (and the constructor's `_minDepositAmount` argument)
+accept any value, including `0`. This is not an oversight. A non-zero check
+was proposed, tested, and rejected for the reasons below.
+
+## 1. `> 0` blocks exactly one bad value while admitting every other one
+
+The concern behind such a check is junk deposits growing the Merkle tree for
+free. But set `minDepositAmount = 1` — the smallest value a `> 0` guard
+permits — and a 1 gwei deposit passes (it satisfies the
+`msg.value % 1 gwei == 0` check by definition). Both cases were verified
+with tests during development:
+
+- `minDepositAmount = 0` → a 0-value deposit is accepted and appends a leaf;
+- `minDepositAmount = 1` → a 1 gwei deposit is accepted just the same.
+
+From the spam perspective those outcomes are equivalent. A guard that only
+excludes one point on the number line is not a floor; it reads like a
+protection without providing one, which is worse than nothing.
+
+## 2. The real protection would be a policy floor, not a validation
+
+What actually prevents cheap tree growth is a meaningful minimum — the
+canonical Ethereum contract's hard-coded `1 ether`, or Vana's operational
+value of 35,000 VANA (the value the original deposit contract at
+`0x17BbE91c315Bf14f38F6D35052a827cadfFe184e` enforced as both its min and
+max). If enforcement in code is ever wanted, the right shape is
+
+```solidity
+require(newMinDepositAmount >= MIN_DEPOSIT_FLOOR, "...");
+```
+
+with a named constant, applied in both the constructor and the setter.
+That is a governance decision about the floor value, not an input check.
+
+## 3. The value is mutable and the owner is trusted
+
+While `minDepositAmount` was `immutable` in an early revision, a bad deploy
+value would have been permanent, and validation was worth considering. Once
+the value became owner-settable, a mistake became a correctable operational
+error rather than a contract defect. The owner can already set the minimum
+to 1 wei deliberately, so a `> 0` check does not shrink the trust assumption
+placed in the owner — it only adds gas and code surface.
+
+This also matches the sibling `DepositImplementation`, whose
+`updateMinDepositAmount` performs no validation either.
+
+## The same reasoning covers an upper-bound check (`!= uint256.max`)
+
+A `!= type(uint256).max` check was also considered and declined:
+
+- The deposit path already has a hard ceiling of `type(uint64).max` gwei
+  (~18.4 billion VANA) per deposit, so **any** `minDepositAmount` above that
+  makes deposits impossible -- `uint256.max`, `uint256.max - 1`, `10**30`,
+  all equivalently. Excluding the single value `uint256.max` changes nothing.
+  A meaningful version would be
+  `require(newMin <= uint256(type(uint64).max) * 1 gwei)`.
+- Even the meaningful version blocks nothing the owner cannot already do
+  deliberately: an unreachable minimum is functionally a pause switch, and
+  `updateRestricted(true)` with an empty allowlist already provides one,
+  reversibly, through the front door.
+- There is no computational hazard: `minDepositAmount` is used in exactly one
+  operation, the comparison `msg.value >= minDepositAmount`. It is never
+  added, multiplied, or cast, so extreme values cannot overflow anything.
+
+## Residual risk: renouncing ownership freezes the value
+
+`renounceOwnership()` is intentionally left available so the contract can be
+made ownerless once its parameters are settled. Renouncing freezes
+`minDepositAmount` at its current value forever — the contract is not
+upgradeable and no recovery path exists. If the owner renounces while the
+value is accidentally `0`, that mistake becomes permanent.
+
+The mitigation is procedural, not a code check: **set the final value,
+verify it on-chain, then renounce.** A `> 0` guard would not help in this
+scenario anyway — renouncing with the value set to 35 VANA instead of
+35,000 VANA would be just as wrong, and no input validation catches it.
+
+## Summary
+
+The check was omitted not because zero is safe, but because this particular
+guard buys approximately nothing against the risks it appears to address:
+spam is addressed by the operational floor (35,000 VANA), an unreachable
+minimum duplicates the pause capability restricted mode already provides,
+deploy-time mistakes are addressed by mutability, and the
+renounce-with-wrong-value scenario is procedural and uncatchable by input
+validation. Both the lower bound (`> 0`) and the upper bound
+(`!= uint256.max`) fail the same test: each excludes a single point on the
+number line while admitting a continuum of values with the same effect.

--- a/foundry.lock
+++ b/foundry.lock
@@ -1,0 +1,8 @@
+{
+  "lib/forge-std": {
+    "tag": {
+      "name": "v1.16.2",
+      "rev": "bf647bd6046f2f7da30d0c2bf435e5c76a780c1b"
+    }
+  }
+}

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,0 +1,20 @@
+# Foundry is used only for Solidity unit tests (test/foundry).
+# Hardhat remains the build/deploy system for the repo, so `src` is scoped to
+# the contracts under test instead of the whole contracts/ tree, and the cache
+# is kept out of hardhat's ./cache.
+[profile.default]
+src = "contracts/chain/l1Deposit"
+test = "test/foundry"
+out = "out"
+cache_path = "cache_forge"
+libs = ["lib", "node_modules"]
+# match FIRST_COMPILER_SETTINGS in hardhat.config.ts
+solc = "0.8.24"
+via_ir = true
+optimizer = true
+optimizer_runs = 1
+remappings = [
+    "forge-std/=lib/forge-std/src/",
+    "@openzeppelin/contracts/=node_modules/@openzeppelin/contracts/",
+    "@openzeppelin/contracts-upgradeable/=node_modules/@openzeppelin/contracts-upgradeable/",
+]

--- a/foundry.toml
+++ b/foundry.toml
@@ -18,3 +18,9 @@ remappings = [
     "@openzeppelin/contracts/=node_modules/@openzeppelin/contracts/",
     "@openzeppelin/contracts-upgradeable/=node_modules/@openzeppelin/contracts-upgradeable/",
 ]
+
+# named endpoints: `--rpc-url vana` resolves VANA_RPC_URL from .env (forge
+# auto-loads .env from the project root; the shell does not)
+[rpc_endpoints]
+vana = "${VANA_RPC_URL}"
+moksha = "${MOKSHA_RPC_URL}"

--- a/script/DeployDepositContractSeeded.s.sol
+++ b/script/DeployDepositContractSeeded.s.sol
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import {Script} from "forge-std/Script.sol";
+import {console2} from "forge-std/console2.sol";
+import {DepositContractSeeded} from "../contracts/chain/l1Deposit/DepositContractSeeded.sol";
+
+/// @notice Deploys DepositContractSeeded seeded with the live state of an
+///         existing deposit contract, read on-chain at simulation time via
+///         eth_getStorageAt (slots 0..31 = branch, slot 32 = deposit_count).
+///         Because the source contract on Vana mainnet was disabled by
+///         upgrading it to a revert-all implementation, its storage is frozen,
+///         so reading at `latest` is exact.
+///
+///         After deployment the script re-reads the new contract and asserts
+///         count and every branch slot round-tripped, and — when
+///         EXPECTED_DEPOSIT_ROOT is set — that get_deposit_root() matches it.
+///
+/// Environment:
+///   SOURCE_DEPOSIT_CONTRACT  address of the contract to copy state from
+///                            (mainnet: 0x17BbE91c315Bf14f38F6D35052a827cadfFe184e)
+///   DEPOSIT_CONTRACT_OWNER   owner of the new contract
+///   MIN_DEPOSIT_AMOUNT       minimum deposit in wei
+///   RESTRICTED               optional bool, default false
+///   ALLOWED_VALIDATORS       optional comma-separated 48-byte hex pubkeys
+///   EXPECTED_DEPOSIT_ROOT    optional bytes32; mainnet pre-brick root:
+///                            0x60dff8f6a92d68799e7653acdcefa253a1c2603b4dd071d8265491b465172401
+///
+/// Usage:
+///   # dry run (simulation only)
+///   forge script script/DeployDepositContractSeeded.s.sol --rpc-url $VANA_RPC_URL
+///
+///   # deploy
+///   forge script script/DeployDepositContractSeeded.s.sol \
+///     --rpc-url $VANA_RPC_URL --broadcast --account <keystore-account>
+contract DeployDepositContractSeeded is Script {
+    uint constant TREE_DEPTH = 32;
+    uint constant DEPOSIT_COUNT_SLOT = 32;
+
+    function run() external returns (DepositContractSeeded deployed) {
+        // ---- read configuration ----
+        address source = vm.envAddress("SOURCE_DEPOSIT_CONTRACT");
+        address owner = vm.envAddress("DEPOSIT_CONTRACT_OWNER");
+        uint256 minDepositAmount = vm.envUint("MIN_DEPOSIT_AMOUNT");
+        bool restricted = vm.envOr("RESTRICTED", false);
+        bytes32 expectedRoot = vm.envOr("EXPECTED_DEPOSIT_ROOT", bytes32(0));
+        bytes[] memory allowedValidators = _parseAllowedValidators();
+
+        // ---- read seed state from the source contract ----
+        require(source.code.length > 0, "source has no code - wrong address?");
+        uint256 count = uint256(vm.load(source, bytes32(DEPOSIT_COUNT_SLOT)));
+        // A zero count means the source holds no deposits; this script exists
+        // for migrations, so treat that as a mis-configured address.
+        require(count > 0, "source deposit_count is zero - wrong address?");
+
+        bytes32[TREE_DEPTH] memory branch;
+        for (uint i = 0; i < TREE_DEPTH; i++) {
+            branch[i] = vm.load(source, bytes32(i));
+        }
+
+        console2.log("source:            ", source);
+        console2.log("seed deposit_count:", count);
+        console2.log("owner:             ", owner);
+        console2.log("minDepositAmount:  ", minDepositAmount);
+        console2.log("restricted:        ", restricted);
+        console2.log("allowed validators:", allowedValidators.length);
+
+        // ---- deploy ----
+        vm.startBroadcast();
+        deployed = new DepositContractSeeded(
+            count, branch, minDepositAmount, owner, restricted, allowedValidators
+        );
+        vm.stopBroadcast();
+
+        // ---- verify the seed took effect ----
+        require(_depositCount(deployed) == count, "deployed count mismatch");
+        for (uint i = 0; i < TREE_DEPTH; i++) {
+            require(deployed.get_branch(i) == branch[i], "deployed branch mismatch");
+        }
+        bytes32 root = deployed.get_deposit_root();
+        if (expectedRoot != bytes32(0)) {
+            require(root == expectedRoot, "deposit root does not match EXPECTED_DEPOSIT_ROOT");
+        } else {
+            console2.log("WARNING: EXPECTED_DEPOSIT_ROOT not set; root not checked");
+        }
+
+        console2.log("deployed:          ", address(deployed));
+        console2.log("deposit root:");
+        console2.logBytes32(root);
+    }
+
+    /// @dev Parse ALLOWED_VALIDATORS ("0x...,0x...") into 48-byte pubkeys.
+    function _parseAllowedValidators() internal view returns (bytes[] memory keys) {
+        string memory raw = vm.envOr("ALLOWED_VALIDATORS", string(""));
+        if (bytes(raw).length == 0) return new bytes[](0);
+        string[] memory parts = vm.split(raw, ",");
+        keys = new bytes[](parts.length);
+        for (uint i = 0; i < parts.length; i++) {
+            keys[i] = vm.parseBytes(parts[i]);
+            require(keys[i].length == 48, "allowed validator pubkey must be 48 bytes");
+        }
+    }
+
+    function _depositCount(DepositContractSeeded d) internal view returns (uint64 n) {
+        bytes memory le = d.get_deposit_count();
+        for (uint i = 0; i < 8; i++) n |= uint64(uint8(le[i])) << uint64(8 * i);
+    }
+}

--- a/test/foundry/DepositContractSeeded.t.sol
+++ b/test/foundry/DepositContractSeeded.t.sol
@@ -1,0 +1,652 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import {Test} from "forge-std/Test.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {DepositContractSeeded} from "../../contracts/chain/l1Deposit/DepositContractSeeded.sol";
+import {IDeposit} from "../../contracts/chain/l1Deposit/interfaces/IDeposit.sol";
+import {ERC165} from "../../contracts/chain/l1Deposit/interfaces/ERC165.sol";
+
+/// @notice Shared fixtures and helpers.
+///
+/// NOTE ON CHEATCODES: `_depositDataRoot` calls the sha256 precompile, which
+/// counts as an external call and would consume a pending `vm.prank` /
+/// `vm.expectRevert`. Always compute roots BEFORE arming a cheatcode.
+abstract contract DepositSeededBase is Test {
+    uint constant TREE_DEPTH = 32;
+
+    /// @dev Deposit root of the canonical empty tree (count = 0).
+    bytes32 constant EMPTY_TREE_ROOT =
+        0xd70a234731285c6804c2a4f56711ddb8c82c99740f207854891028af34e27e5e;
+
+    address owner = makeAddr("owner");
+    address depositor = makeAddr("depositor");
+
+    bytes wc; // withdrawal credentials, 32 bytes
+    bytes sig; // BLS signature placeholder, 96 bytes
+
+    function setUp() public virtual {
+        wc = _filled(32, 0x22);
+        sig = _filled(96, 0x33);
+        vm.deal(depositor, 1_000_000 ether);
+    }
+
+    // ---------- deployment helpers ----------
+
+    function _deployEmpty() internal returns (DepositContractSeeded) {
+        bytes32[TREE_DEPTH] memory branch;
+        return new DepositContractSeeded(0, branch, 1 ether, owner, false, new bytes[](0));
+    }
+
+    function _deploySeeded(
+        uint256 count,
+        bytes32[TREE_DEPTH] memory branch
+    ) internal returns (DepositContractSeeded) {
+        return new DepositContractSeeded(count, branch, 1 ether, owner, false, new bytes[](0));
+    }
+
+    // ---------- data helpers ----------
+
+    function _filled(uint len, bytes1 b) internal pure returns (bytes memory out) {
+        out = new bytes(len);
+        for (uint i = 0; i < len; i++) out[i] = b;
+    }
+
+    /// @dev Derive a unique 48-byte pubkey from a seed.
+    function _pubkey(uint256 seed) internal pure returns (bytes memory) {
+        return bytes.concat(
+            keccak256(abi.encode("pk", seed)),
+            bytes16(keccak256(abi.encode("pk2", seed)))
+        );
+    }
+
+    function _le64(uint64 v) internal pure returns (bytes memory ret) {
+        ret = new bytes(8);
+        bytes8 b = bytes8(v);
+        for (uint i = 0; i < 8; i++) ret[i] = b[7 - i];
+    }
+
+    /// @dev Mirror of the contract's SSZ DepositData hash-tree-root.
+    function _depositDataRoot(
+        bytes memory pubkey,
+        bytes memory withdrawalCredentials,
+        bytes memory signature,
+        uint256 valueWei
+    ) internal view returns (bytes32) {
+        bytes memory amount = _le64(uint64(valueWei / 1 gwei));
+        bytes32 pubkeyRoot = sha256(abi.encodePacked(pubkey, bytes16(0)));
+        bytes memory sigFirst64 = new bytes(64);
+        bytes memory sigLast32 = new bytes(32);
+        for (uint i = 0; i < 64; i++) sigFirst64[i] = signature[i];
+        for (uint i = 0; i < 32; i++) sigLast32[i] = signature[64 + i];
+        bytes32 sigRoot = sha256(
+            abi.encodePacked(
+                sha256(abi.encodePacked(sigFirst64)),
+                sha256(abi.encodePacked(sigLast32, bytes32(0)))
+            )
+        );
+        return sha256(
+            abi.encodePacked(
+                sha256(abi.encodePacked(pubkeyRoot, withdrawalCredentials)),
+                sha256(abi.encodePacked(amount, bytes24(0), sigRoot))
+            )
+        );
+    }
+
+    /// @dev Valid deposit of `valueWei` for pubkey derived from `seed`.
+    function _deposit(DepositContractSeeded d, uint256 seed, uint256 valueWei) internal {
+        bytes memory pk = _pubkey(seed);
+        bytes32 root = _depositDataRoot(pk, wc, sig, valueWei);
+        vm.prank(depositor);
+        d.deposit{value: valueWei}(pk, wc, sig, root);
+    }
+
+    function _count(DepositContractSeeded d) internal view returns (uint64 n) {
+        bytes memory le = d.get_deposit_count();
+        for (uint i = 0; i < 8; i++) n |= uint64(uint8(le[i])) << uint64(8 * i);
+    }
+
+    function _snapshotBranch(
+        DepositContractSeeded d
+    ) internal view returns (bytes32[TREE_DEPTH] memory branch) {
+        for (uint i = 0; i < TREE_DEPTH; i++) branch[i] = d.get_branch(i);
+    }
+
+    function _oneKey(bytes memory pk) internal pure returns (bytes[] memory a) {
+        a = new bytes[](1);
+        a[0] = pk;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Constructor / seeding
+// ---------------------------------------------------------------------------
+
+contract ConstructorTest is DepositSeededBase {
+    function test_emptyDeploymentMatchesCanonicalEmptyRoot() public {
+        DepositContractSeeded d = _deployEmpty();
+        assertEq(d.get_deposit_root(), EMPTY_TREE_ROOT);
+        assertEq(_count(d), 0);
+    }
+
+    function test_storesConstructorArguments() public {
+        bytes32[TREE_DEPTH] memory branch;
+        branch[0] = bytes32(uint256(0xAA));
+        branch[5] = bytes32(uint256(0xBB));
+        bytes memory pk = _pubkey(1);
+
+        DepositContractSeeded d =
+            new DepositContractSeeded(7, branch, 3 ether, owner, true, _oneKey(pk));
+
+        assertEq(d.owner(), owner);
+        assertEq(d.minDepositAmount(), 3 ether);
+        assertTrue(d.restricted());
+        assertTrue(d.validators(pk));
+        assertEq(_count(d), 7);
+        for (uint i = 0; i < TREE_DEPTH; i++) assertEq(d.get_branch(i), branch[i]);
+    }
+
+    function test_zeroOwnerReverts() public {
+        bytes32[TREE_DEPTH] memory branch;
+        vm.expectRevert(
+            abi.encodeWithSelector(Ownable.OwnableInvalidOwner.selector, address(0))
+        );
+        new DepositContractSeeded(0, branch, 1 ether, address(0), false, new bytes[](0));
+    }
+
+    function test_supportsInterface() public {
+        DepositContractSeeded d = _deployEmpty();
+        assertTrue(d.supportsInterface(type(ERC165).interfaceId));
+        assertTrue(d.supportsInterface(type(IDeposit).interfaceId));
+        // must match the canonical deposit contract's advertised id
+        assertEq(type(IDeposit).interfaceId, bytes4(0x85640907));
+        assertFalse(d.supportsInterface(bytes4(0xffffffff)));
+    }
+}
+
+contract SeedingTest is DepositSeededBase {
+    /// @dev The core property: seeding a new contract with (count, branch)
+    ///      read from a live contract reproduces its deposit root exactly,
+    ///      and the two contracts stay in lockstep on subsequent deposits.
+    function test_seedReproducesRootAndStaysInLockstep() public {
+        DepositContractSeeded source = _deployEmpty();
+        for (uint i = 0; i < 5; i++) _deposit(source, i, (i + 1) * 1 ether);
+
+        DepositContractSeeded seeded =
+            _deploySeeded(_count(source), _snapshotBranch(source));
+
+        assertEq(seeded.get_deposit_root(), source.get_deposit_root(), "seeded root");
+        assertEq(seeded.get_deposit_count(), source.get_deposit_count(), "seeded count");
+
+        // identical next deposits keep the trees identical
+        for (uint i = 5; i < 8; i++) {
+            _deposit(source, i, 2 ether);
+            _deposit(seeded, i, 2 ether);
+            assertEq(seeded.get_deposit_root(), source.get_deposit_root(), "post-seed root");
+        }
+    }
+
+    /// @dev Seeding the count alone (zero branch) yields the WRONG root —
+    ///      the failure mode the contract exists to prevent.
+    function test_countAloneDoesNotReproduceRoot() public {
+        DepositContractSeeded source = _deployEmpty();
+        for (uint i = 0; i < 3; i++) _deposit(source, i, 1 ether);
+
+        bytes32[TREE_DEPTH] memory emptyBranch;
+        DepositContractSeeded countOnly = _deploySeeded(_count(source), emptyBranch);
+
+        assertTrue(countOnly.get_deposit_root() != source.get_deposit_root());
+        assertEq(countOnly.get_deposit_count(), source.get_deposit_count());
+    }
+
+    /// @dev Event index continuity: a contract seeded at count N emits its
+    ///      first DepositEvent with index N, not 0.
+    function test_firstEventIndexContinuesFromSeed() public {
+        DepositContractSeeded source = _deployEmpty();
+        for (uint i = 0; i < 4; i++) _deposit(source, i, 1 ether);
+
+        DepositContractSeeded seeded =
+            _deploySeeded(_count(source), _snapshotBranch(source));
+
+        bytes memory pk = _pubkey(99);
+        bytes32 root = _depositDataRoot(pk, wc, sig, 1 ether);
+        vm.expectEmit();
+        emit IDeposit.DepositEvent(pk, wc, _le64(1e9), sig, _le64(4));
+        vm.prank(depositor);
+        seeded.deposit{value: 1 ether}(pk, wc, sig, root);
+    }
+
+    function testFuzz_seedReproducesRoot(uint8 rawN, uint64 salt) public {
+        uint n = bound(rawN, 1, 8);
+        DepositContractSeeded source = _deployEmpty();
+        for (uint i = 0; i < n; i++) {
+            uint amountGwei = bound(
+                uint256(keccak256(abi.encode(salt, i))), 1e9, 100e9
+            );
+            _deposit(source, uint256(salt) + i, amountGwei * 1 gwei);
+        }
+
+        DepositContractSeeded seeded =
+            _deploySeeded(_count(source), _snapshotBranch(source));
+        assertEq(seeded.get_deposit_root(), source.get_deposit_root());
+
+        _deposit(source, uint256(salt) + n, 1 ether);
+        _deposit(seeded, uint256(salt) + n, 1 ether);
+        assertEq(seeded.get_deposit_root(), source.get_deposit_root());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// deposit() validation
+// ---------------------------------------------------------------------------
+
+contract DepositValidationTest is DepositSeededBase {
+    DepositContractSeeded d;
+
+    function setUp() public override {
+        super.setUp();
+        d = _deployEmpty();
+    }
+
+    function test_validDepositUpdatesState() public {
+        bytes32 rootBefore = d.get_deposit_root();
+        _deposit(d, 1, 1 ether);
+        assertEq(_count(d), 1);
+        assertTrue(d.get_deposit_root() != rootBefore);
+        assertEq(address(d).balance, 1 ether);
+    }
+
+    function test_emitsDepositEvent() public {
+        bytes memory pk = _pubkey(1);
+        bytes32 root = _depositDataRoot(pk, wc, sig, 5 ether);
+        vm.expectEmit();
+        emit IDeposit.DepositEvent(pk, wc, _le64(5e9), sig, _le64(0));
+        vm.prank(depositor);
+        d.deposit{value: 5 ether}(pk, wc, sig, root);
+    }
+
+    function test_rejectsBadPubkeyLength() public {
+        vm.prank(depositor);
+        vm.expectRevert("DepositContract: invalid pubkey length");
+        d.deposit{value: 1 ether}(_filled(47, 0x11), wc, sig, bytes32(0));
+    }
+
+    function test_rejectsBadWithdrawalCredentialsLength() public {
+        vm.prank(depositor);
+        vm.expectRevert("DepositContract: invalid withdrawal_credentials length");
+        d.deposit{value: 1 ether}(_pubkey(1), _filled(31, 0x22), sig, bytes32(0));
+    }
+
+    function test_rejectsBadSignatureLength() public {
+        vm.prank(depositor);
+        vm.expectRevert("DepositContract: invalid signature length");
+        d.deposit{value: 1 ether}(_pubkey(1), wc, _filled(95, 0x33), bytes32(0));
+    }
+
+    function test_rejectsValueBelowMinimum() public {
+        vm.prank(depositor);
+        vm.expectRevert("DepositContract: deposit value too low");
+        d.deposit{value: 1 ether - 1 gwei}(_pubkey(1), wc, sig, bytes32(0));
+    }
+
+    function test_rejectsNonGweiMultiple() public {
+        vm.prank(depositor);
+        vm.expectRevert("DepositContract: deposit value not multiple of gwei");
+        d.deposit{value: 1 ether + 1}(_pubkey(1), wc, sig, bytes32(0));
+    }
+
+    function test_rejectsValueAboveUint64Gwei() public {
+        uint256 tooHigh = (uint256(type(uint64).max) + 1) * 1 gwei;
+        vm.deal(depositor, tooHigh);
+        vm.prank(depositor);
+        vm.expectRevert("DepositContract: deposit value too high");
+        d.deposit{value: tooHigh}(_pubkey(1), wc, sig, bytes32(0));
+    }
+
+    function test_rejectsWrongDepositDataRoot() public {
+        bytes memory pk = _pubkey(1);
+        bytes32 wrongRoot = _depositDataRoot(pk, wc, sig, 2 ether); // root for a different amount
+        vm.prank(depositor);
+        vm.expectRevert(
+            "DepositContract: reconstructed DepositData does not match supplied deposit_data_root"
+        );
+        d.deposit{value: 1 ether}(pk, wc, sig, wrongRoot);
+    }
+
+    function testFuzz_acceptsAnyValidAmount(uint256 rawGwei) public {
+        uint256 amountGwei = bound(rawGwei, 1e9, 1_000_000e9);
+        _deposit(d, 42, amountGwei * 1 gwei);
+        assertEq(_count(d), 1);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Ownership
+// ---------------------------------------------------------------------------
+
+contract OwnershipTest is DepositSeededBase {
+    DepositContractSeeded d;
+    address newOwner = makeAddr("newOwner");
+
+    function setUp() public override {
+        super.setUp();
+        d = _deployEmpty();
+    }
+
+    function test_twoStepTransfer() public {
+        vm.prank(owner);
+        d.transferOwnership(newOwner);
+        assertEq(d.owner(), owner, "unchanged until accepted");
+        assertEq(d.pendingOwner(), newOwner);
+
+        vm.prank(newOwner);
+        d.acceptOwnership();
+        assertEq(d.owner(), newOwner);
+        assertEq(d.pendingOwner(), address(0));
+    }
+
+    function test_onlyPendingOwnerCanAccept() public {
+        vm.prank(owner);
+        d.transferOwnership(newOwner);
+        vm.prank(depositor);
+        vm.expectRevert(
+            abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, depositor)
+        );
+        d.acceptOwnership();
+    }
+
+    function test_renounceLeavesNoOwnerAndFreezesAdmin() public {
+        vm.prank(owner);
+        d.renounceOwnership();
+        assertEq(d.owner(), address(0));
+
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, owner)
+        );
+        d.updateMinDepositAmount(2 ether);
+    }
+
+    function test_renounceClearsPendingTransfer() public {
+        vm.startPrank(owner);
+        d.transferOwnership(newOwner);
+        d.renounceOwnership();
+        vm.stopPrank();
+        assertEq(d.pendingOwner(), address(0));
+
+        vm.prank(newOwner);
+        vm.expectRevert(
+            abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, newOwner)
+        );
+        d.acceptOwnership();
+    }
+
+    function test_depositsUnaffectedByRenounce() public {
+        vm.prank(owner);
+        d.renounceOwnership();
+        _deposit(d, 1, 1 ether);
+        assertEq(_count(d), 1);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// minDepositAmount
+// ---------------------------------------------------------------------------
+
+contract MinDepositAmountTest is DepositSeededBase {
+    DepositContractSeeded d;
+
+    function setUp() public override {
+        super.setUp();
+        d = _deployEmpty();
+    }
+
+    function test_ownerCanUpdate_withEvent() public {
+        vm.expectEmit();
+        emit DepositContractSeeded.MinDepositAmountUpdated(5 ether);
+        vm.prank(owner);
+        d.updateMinDepositAmount(5 ether);
+        assertEq(d.minDepositAmount(), 5 ether);
+    }
+
+    function test_nonOwnerCannotUpdate() public {
+        vm.prank(depositor);
+        vm.expectRevert(
+            abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, depositor)
+        );
+        d.updateMinDepositAmount(5 ether);
+    }
+
+    function test_boundaryIsInclusive() public {
+        vm.prank(owner);
+        d.updateMinDepositAmount(2 ether);
+
+        _deposit(d, 1, 2 ether); // exactly the minimum passes
+
+        bytes memory pk = _pubkey(2);
+        bytes32 root = _depositDataRoot(pk, wc, sig, 2 ether - 1 gwei);
+        vm.prank(depositor);
+        vm.expectRevert("DepositContract: deposit value too low");
+        d.deposit{value: 2 ether - 1 gwei}(pk, wc, sig, root);
+    }
+
+    function test_updateAppliesToSubsequentDepositsOnly() public {
+        _deposit(d, 1, 1 ether);
+        vm.prank(owner);
+        d.updateMinDepositAmount(10 ether);
+
+        bytes memory pk = _pubkey(2);
+        bytes32 root = _depositDataRoot(pk, wc, sig, 1 ether);
+        vm.prank(depositor);
+        vm.expectRevert("DepositContract: deposit value too low");
+        d.deposit{value: 1 ether}(pk, wc, sig, root);
+        assertEq(_count(d), 1, "earlier deposit unaffected");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Restricted mode
+// ---------------------------------------------------------------------------
+
+contract RestrictedModeTest is DepositSeededBase {
+    DepositContractSeeded d;
+    bytes pkAllowed;
+    bytes pkOther;
+
+    function setUp() public override {
+        super.setUp();
+        d = _deployEmpty();
+        pkAllowed = _pubkey(1);
+        pkOther = _pubkey(2);
+    }
+
+    function _depositKey(bytes memory pk) internal {
+        bytes32 root = _depositDataRoot(pk, wc, sig, 1 ether);
+        vm.prank(depositor);
+        d.deposit{value: 1 ether}(pk, wc, sig, root);
+    }
+
+    function _expectNotAllowed(bytes memory pk) internal {
+        bytes32 root = _depositDataRoot(pk, wc, sig, 1 ether);
+        vm.prank(depositor);
+        vm.expectRevert("DepositContract: publicKey not allowed");
+        d.deposit{value: 1 ether}(pk, wc, sig, root);
+    }
+
+    function test_openByDefault() public {
+        assertFalse(d.restricted());
+        _depositKey(pkOther); // unlisted key deposits fine
+    }
+
+    function test_restrictedBlocksUnlistedKey() public {
+        vm.prank(owner);
+        d.updateRestricted(true);
+        _expectNotAllowed(pkOther);
+    }
+
+    function test_restrictedPermitsAllowedKeyOnly() public {
+        vm.startPrank(owner);
+        d.updateRestricted(true);
+        d.addAllowedValidators(_oneKey(pkAllowed));
+        vm.stopPrank();
+
+        _depositKey(pkAllowed);
+        _expectNotAllowed(pkOther);
+    }
+
+    function test_allowedKeyMayDepositRepeatedly() public {
+        vm.startPrank(owner);
+        d.updateRestricted(true);
+        d.addAllowedValidators(_oneKey(pkAllowed));
+        vm.stopPrank();
+
+        _depositKey(pkAllowed);
+        _depositKey(pkAllowed);
+        assertEq(_count(d), 2);
+    }
+
+    function test_removeRevokesAccess() public {
+        vm.startPrank(owner);
+        d.updateRestricted(true);
+        d.addAllowedValidators(_oneKey(pkAllowed));
+        d.removeAllowedValidators(_oneKey(pkAllowed));
+        vm.stopPrank();
+
+        assertFalse(d.validators(pkAllowed));
+        _expectNotAllowed(pkAllowed);
+    }
+
+    function test_allowlistIgnoredWhileOpen() public {
+        vm.prank(owner);
+        d.addAllowedValidators(_oneKey(pkAllowed));
+        _depositKey(pkOther); // unlisted, mode open
+    }
+
+    function test_disablingRestrictionReopensDeposits() public {
+        vm.startPrank(owner);
+        d.updateRestricted(true);
+        d.updateRestricted(false);
+        vm.stopPrank();
+        _depositKey(pkOther);
+    }
+
+    function test_batchAddRemove_withEvents() public {
+        bytes[] memory keys = new bytes[](2);
+        keys[0] = pkAllowed;
+        keys[1] = pkOther;
+
+        vm.expectEmit();
+        emit DepositContractSeeded.AllowedValidatorsAdded(pkAllowed);
+        vm.expectEmit();
+        emit DepositContractSeeded.AllowedValidatorsAdded(pkOther);
+        vm.prank(owner);
+        d.addAllowedValidators(keys);
+        assertTrue(d.validators(pkAllowed));
+        assertTrue(d.validators(pkOther));
+
+        vm.expectEmit();
+        emit DepositContractSeeded.AllowedValidatorsRemoved(pkAllowed);
+        vm.expectEmit();
+        emit DepositContractSeeded.AllowedValidatorsRemoved(pkOther);
+        vm.prank(owner);
+        d.removeAllowedValidators(keys);
+        assertFalse(d.validators(pkAllowed));
+        assertFalse(d.validators(pkOther));
+    }
+
+    function test_updateRestrictedEmitsEvent() public {
+        vm.expectEmit();
+        emit DepositContractSeeded.RestrictedUpdated(true);
+        vm.prank(owner);
+        d.updateRestricted(true);
+    }
+
+    function test_controlsAreOwnerOnly() public {
+        vm.startPrank(depositor);
+        vm.expectRevert(
+            abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, depositor)
+        );
+        d.updateRestricted(true);
+        vm.expectRevert(
+            abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, depositor)
+        );
+        d.addAllowedValidators(_oneKey(pkAllowed));
+        vm.expectRevert(
+            abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, depositor)
+        );
+        d.removeAllowedValidators(_oneKey(pkAllowed));
+        vm.stopPrank();
+    }
+
+    function test_deployAlreadyRestrictedWithSeedList() public {
+        bytes32[TREE_DEPTH] memory branch;
+        DepositContractSeeded r =
+            new DepositContractSeeded(0, branch, 1 ether, owner, true, _oneKey(pkAllowed));
+        assertTrue(r.restricted());
+        assertTrue(r.validators(pkAllowed));
+        assertFalse(r.validators(pkOther));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Vana mainnet seed snapshot
+// ---------------------------------------------------------------------------
+
+/// @notice Seeds the contract with the real, final state of the original Vana
+///         mainnet deposit contract and checks the root is reproduced exactly.
+///
+///         Source: proxy 0x17BbE91c315Bf14f38F6D35052a827cadfFe184e (chain 1480).
+///         That contract was disabled at block 9,475,269 by upgrading it to a
+///         revert-all implementation (0xabc8637b553635654539b19d6cb53d64d4274325),
+///         so its storage is frozen forever and these hard-coded values are
+///         stable: `branch` read via eth_getStorageAt slots 0..31, count from
+///         slot 32, and the expected root/count from an archive call at block
+///         9,475,268 -- the last block the old implementation answered.
+contract MainnetSeedTest is DepositSeededBase {
+    address constant MAINNET_DEPOSIT_CONTRACT = 0x17BbE91c315Bf14f38F6D35052a827cadfFe184e;
+    uint256 constant MAINNET_DEPOSIT_COUNT = 32;
+    bytes32 constant MAINNET_DEPOSIT_ROOT =
+        0x60dff8f6a92d68799e7653acdcefa253a1c2603b4dd071d8265491b465172401;
+
+    function _mainnetBranch() internal pure returns (bytes32[TREE_DEPTH] memory branch) {
+        // count = 32 = 0b100000, so only branch[5] feeds the root; slots 0..4
+        // hold stale values from earlier deposits and are copied for fidelity.
+        branch[0] = 0xf0092552cdb7afcba0eb4e5cfed7fefed2ce6382824cd5b0df010651c1696432;
+        branch[1] = 0xe30a60e758e63fec18949b8acf3fe2b19f8245397e67218bd9f5ff752a26a960;
+        branch[2] = 0x88ff06e39ba53cd7fdfd337cc4005c3656833cf88cea7821231e412c954f74f7;
+        branch[3] = 0x941faed977cc7348cd7f286e8bfdf223404c649bfa5c70b15e7bfd3e8f567d14;
+        branch[4] = 0x8d72689445263059145597c22f9709ae40f79254492fbb527f98ceef94517fb4;
+        branch[5] = 0x623286af5249c193c954b552e1b1b8894896945d6878a4d0f2d982fa99c1cae0;
+        // branch[6..31] are zero on mainnet
+    }
+
+    function _deployMainnetSeeded() internal returns (DepositContractSeeded) {
+        return new DepositContractSeeded(
+            MAINNET_DEPOSIT_COUNT, _mainnetBranch(), 1 ether, owner, false, new bytes[](0)
+        );
+    }
+
+    function test_reproducesMainnetRootAndCount() public {
+        DepositContractSeeded d = _deployMainnetSeeded();
+        assertEq(d.get_deposit_root(), MAINNET_DEPOSIT_ROOT, "mainnet root");
+        assertEq(d.get_deposit_count(), _le64(32), "mainnet count");
+        for (uint i = 0; i < TREE_DEPTH; i++) {
+            assertEq(d.get_branch(i), _mainnetBranch()[i], "branch slot");
+        }
+    }
+
+    function test_depositsContinueFromMainnetState() public {
+        DepositContractSeeded d = _deployMainnetSeeded();
+
+        // the first post-migration deposit must be indexed 32, not 0
+        bytes memory pk = _pubkey(1);
+        bytes32 root = _depositDataRoot(pk, wc, sig, 35_000 ether);
+        vm.expectEmit();
+        emit IDeposit.DepositEvent(pk, wc, _le64(35_000e9), sig, _le64(32));
+        vm.prank(depositor);
+        d.deposit{value: 35_000 ether}(pk, wc, sig, root);
+
+        assertEq(_count(d), 33);
+        assertTrue(d.get_deposit_root() != MAINNET_DEPOSIT_ROOT, "root advanced");
+    }
+}

--- a/test/foundry/DepositContractSeeded.t.sol
+++ b/test/foundry/DepositContractSeeded.t.sol
@@ -154,6 +154,29 @@ contract ConstructorTest is DepositSeededBase {
         new DepositContractSeeded(0, branch, 1 ether, address(0), false, new bytes[](0));
     }
 
+    /// @dev The deposit tree must keep the canonical contract's storage slots
+    ///      (branch 0..31, count 32) so the same eth_getStorageAt tooling works
+    ///      on the old and the new contract. DepositTreeStorage is listed first
+    ///      in the inheritance list to guarantee this; Ownable state follows.
+    function test_storageLayoutMatchesCanonicalContract() public {
+        bytes32[TREE_DEPTH] memory branch;
+        branch[0] = bytes32(uint256(0xAA));
+        branch[5] = bytes32(uint256(0xBB));
+        branch[31] = bytes32(uint256(0xCC));
+        DepositContractSeeded d =
+            new DepositContractSeeded(7, branch, 1 ether, owner, false, new bytes[](0));
+
+        assertEq(vm.load(address(d), bytes32(uint256(0))), branch[0], "branch[0] at slot 0");
+        assertEq(vm.load(address(d), bytes32(uint256(5))), branch[5], "branch[5] at slot 5");
+        assertEq(vm.load(address(d), bytes32(uint256(31))), branch[31], "branch[31] at slot 31");
+        assertEq(uint256(vm.load(address(d), bytes32(uint256(32)))), 7, "count at slot 32");
+        assertEq(
+            address(uint160(uint256(vm.load(address(d), bytes32(uint256(65)))))),
+            owner,
+            "_owner at slot 65"
+        );
+    }
+
     function test_supportsInterface() public {
         DepositContractSeeded d = _deployEmpty();
         assertTrue(d.supportsInterface(type(ERC165).interfaceId));


### PR DESCRIPTION
## Summary

Adds **`DepositContractSeeded`** — a non-upgradeable port of the canonical Ethereum deposit contract whose constructor seeds both `deposit_count` **and** the incremental Merkle `branch`, so a fresh deployment reproduces the deposit root of the original mainnet deposit contract exactly and deposits continue from index 32 rather than 0.

### Context

The original deposit contract (proxy `0x17BbE91c315Bf14f38F6D35052a827cadfFe184e`) was disabled at block 9,475,269 by upgrading it to a revert-all implementation, freezing its storage permanently at:

- `deposit_count = 32`
- root `0x60dff8f6a92d68799e7653acdcefa253a1c2603b4dd071d8265491b465172401` (archive-read at block 9,475,268, the last block the old implementation answered)

Seeding the count alone is not enough — the root folds `branch[h]` for every set bit of the count — so the constructor takes and stores the full 32-slot branch as well.

### Contract

On top of the unmodified canonical deposit logic:

- **`Ownable2Step`** owner (two-step transfer; renounce left available so the contract can be made ownerless once parameters are settled)
- **`minDepositAmount`** replaces the hard-coded 1 ether floor, owner-settable
- **Restricted mode**: owner-toggled; while on, only allow-listed validator pubkeys may deposit (mirrors `DepositImplementation`'s design: same state/event/function names)
- **`get_branch(i)`** view for verifying seeded state post-deploy
- `IDeposit` + `ERC165` from the existing local interfaces; interface id `0x85640907` matches the canonical contract

### Testing (Foundry — new to this repo)

- `foundry.toml` scoped to `contracts/chain/l1Deposit` (repo-wide builds stay on Hardhat); solc 0.8.24 / viaIR / runs 1, matching `FIRST_COMPILER_SETTINGS`; OZ resolved from `node_modules`, `forge-std` as a git submodule
- 40 tests in `test/foundry/DepositContractSeeded.t.sol`, including:
  - seed-reproduces-root + lockstep-on-subsequent-deposits (concrete + fuzz)
  - **mainnet snapshot test**: seeds with the real frozen state (count 32, branch from storage slots 0..31) and asserts the root equals the archive-read pre-brick root — these constants are also exactly the constructor args for the mainnet deployment
  - deposit validation, ownership, minDepositAmount, restricted-mode suites
- New CI workflow runs `forge test -vvv` on PRs and pushes to `main`

### Notes for reviewers

- After pulling: `git submodule update --init` (forge-std)
- Deliberate choices: no validation on `updateMinDepositAmount`, renounce not blocked, and no one-deposit-per-pubkey rule in restricted mode (unlike `DepositImplementation`'s `hasDeposit`)
- `npx hardhat compile` still green across the full repo (278 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)