### PR TITLE
feat(escrow,dataRegistry): batch access recording + settlement in one tx

### DIFF
--- a/contracts/data/dataRegistryV2/DataRegistryV2Implementation.sol
+++ b/contracts/data/dataRegistryV2/DataRegistryV2Implementation.sol
@@ -20,6 +20,8 @@ import "./interfaces/DataRegistryV2StorageV1.sol";
  *           - `recordDataAccess` is gated by ACCESS_RECORDER_ROLE AND requires an
  *             EIP-712 signature from one of the owner's trusted personal
  *             servers (verified via DataPortabilityServers)
+ *           - `recordDataAccessBatch` applies the same checks per item and
+ *             skips (never reverts on) a failing item — see IDataRegistryV2
  *           - EIP-712 delegated writes via `addDataWithSignature` with
  *             per-data-point version monotonicity for replay protection
  */
@@ -40,8 +42,11 @@ contract DataRegistryV2Implementation is
     ///      single SSTORE for the `scope` field.
     uint256 private constant MAX_SCOPE_BYTES = 256;
 
-    /// @notice Role required to submit `recordDataAccess` calls.
+    /// @notice Role required to submit `recordDataAccess` / `recordDataAccessBatch` calls.
     bytes32 public constant ACCESS_RECORDER_ROLE = keccak256("ACCESS_RECORDER_ROLE");
+
+    /// @inheritdoc IDataRegistryV2
+    uint256 public constant override MAX_ACCESS_BATCH = 200;
 
     bytes32 public constant override ADD_DATA_TYPEHASH =
         keccak256(
@@ -391,19 +396,10 @@ contract DataRegistryV2Implementation is
         if (_usedRecordIds[recordId]) revert RecordIdAlreadyUsed(recordId);
 
         // Recover the signer (must be one of the owner's trusted personal servers).
-        bytes32 digest = _hashTypedDataV4(
-            keccak256(
-                abi.encode(
-                    RECORD_ACCESS_TYPEHASH,
-                    ownerAddress,
-                    keccak256(bytes(scope)),
-                    version_,
-                    accessor,
-                    recordId
-                )
-            )
+        address server = ECDSA.recover(
+            _recordAccessDigest(ownerAddress, scope, version_, accessor, recordId),
+            signature
         );
-        address server = ECDSA.recover(digest, signature);
         if (server == address(0)) revert InvalidSignature();
         if (!_isTrustedServer(ownerAddress, server)) revert UntrustedServer(ownerAddress, server);
 
@@ -411,6 +407,105 @@ contract DataRegistryV2Implementation is
         DataPoint storage d = _dataPoints[id];
         if (version_ == 0 || version_ > d.currentVersion) revert UnknownVersion(id, version_);
 
+        _commitAccess(d, id, version_, accessor, server, recordId);
+    }
+
+    /// @inheritdoc IDataRegistryV2
+    /// @dev Same checks as `recordDataAccess`, in the same order, but a
+    ///      failing check skips the item (emitting `DataAccessSkipped` with
+    ///      the selector `recordDataAccess` would have reverted with) instead
+    ///      of reverting the call. `ECDSA.tryRecover` replaces `recover` so a
+    ///      malformed signature cannot abort the batch; every recover error
+    ///      maps to `InvalidSignature`. State is only written through
+    ///      `_commitAccess`, shared with the single-record path, so a batch of
+    ///      one and a single call produce identical state and identical
+    ///      `DataAccessRecorded` events.
+    function recordDataAccessBatch(AccessRecord[] calldata records)
+        external
+        override
+        whenNotPaused
+        onlyRole(ACCESS_RECORDER_ROLE)
+        returns (bool[] memory recorded)
+    {
+        if (address(dataPortabilityServers) == address(0)) revert DataPortabilityServersNotSet();
+        uint256 len = records.length;
+        if (len == 0) revert EmptyBatch();
+        if (len > MAX_ACCESS_BATCH) revert BatchTooLarge(len, MAX_ACCESS_BATCH);
+
+        recorded = new bool[](len);
+        for (uint256 i = 0; i < len; ) {
+            AccessRecord calldata r = records[i];
+            bytes4 reason = _tryRecordAccess(r);
+            if (reason == bytes4(0)) {
+                recorded[i] = true;
+            } else {
+                emit DataAccessSkipped(r.recordId, i, reason);
+            }
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
+    /// @dev One item of `recordDataAccessBatch`. Returns `bytes4(0)` and
+    ///      commits the access when every check passes; otherwise returns the
+    ///      selector of the error the single-record path raises for the same
+    ///      failure and leaves state untouched. Check order mirrors
+    ///      `recordDataAccess`: recordId reuse, signature, trusted server,
+    ///      version.
+    function _tryRecordAccess(AccessRecord calldata r) internal returns (bytes4) {
+        if (_usedRecordIds[r.recordId]) return RecordIdAlreadyUsed.selector;
+
+        (address server, ECDSA.RecoverError err, ) = ECDSA.tryRecover(
+            _recordAccessDigest(r.ownerAddress, r.scope, r.version, r.accessor, r.recordId),
+            r.signature
+        );
+        if (err != ECDSA.RecoverError.NoError || server == address(0)) return InvalidSignature.selector;
+        if (!_isTrustedServer(r.ownerAddress, server)) return UntrustedServer.selector;
+
+        bytes32 id = _dataPointId(r.ownerAddress, r.scope);
+        DataPoint storage d = _dataPoints[id];
+        if (r.version == 0 || r.version > d.currentVersion) return UnknownVersion.selector;
+
+        _commitAccess(d, id, r.version, r.accessor, server, r.recordId);
+        return bytes4(0);
+    }
+
+    /// @dev EIP-712 digest a trusted server signs for one access record.
+    function _recordAccessDigest(
+        address ownerAddress,
+        string calldata scope,
+        uint256 version_,
+        address accessor,
+        bytes32 recordId
+    ) internal view returns (bytes32) {
+        return
+            _hashTypedDataV4(
+                keccak256(
+                    abi.encode(
+                        RECORD_ACCESS_TYPEHASH,
+                        ownerAddress,
+                        keccak256(bytes(scope)),
+                        version_,
+                        accessor,
+                        recordId
+                    )
+                )
+            );
+    }
+
+    /// @dev The single state-mutating tail shared by `recordDataAccess` and
+    ///      `recordDataAccessBatch`: marks the recordId used, bumps both
+    ///      counters, emits `DataAccessRecorded`. Callers have already
+    ///      validated the record.
+    function _commitAccess(
+        DataPoint storage d,
+        bytes32 id,
+        uint256 version_,
+        address accessor,
+        address server,
+        bytes32 recordId
+    ) internal {
         _usedRecordIds[recordId] = true;
 
         uint256 newVersionCount;

--- a/contracts/data/dataRegistryV2/DataRegistryV2Implementation.sol
+++ b/contracts/data/dataRegistryV2/DataRegistryV2Implementation.sol
@@ -452,9 +452,17 @@ contract DataRegistryV2Implementation is
     ///      selector of the error the single-record path raises for the same
     ///      failure and leaves state untouched. Check order mirrors
     ///      `recordDataAccess`: recordId reuse, signature, trusted server,
-    ///      version.
+    ///      version — preceded by two calldata-length guards that the single
+    ///      path does not need (it reverts, so it pays nothing further).
     function _tryRecordAccess(AccessRecord calldata r) internal returns (bytes4) {
         if (_usedRecordIds[r.recordId]) return RecordIdAlreadyUsed.selector;
+
+        // Cheap calldata-length checks before anything is hashed or copied to
+        // memory, so an oversized item costs its calldata and nothing more.
+        // No data point can exist with a scope above MAX_SCOPE_BYTES
+        // (`_addData` rejects it), and only 65-byte signatures can recover.
+        if (bytes(r.scope).length > MAX_SCOPE_BYTES) return ScopeTooLong.selector;
+        if (r.signature.length != 65) return InvalidSignature.selector;
 
         (address server, ECDSA.RecoverError err, ) = ECDSA.tryRecover(
             _recordAccessDigest(r.ownerAddress, r.scope, r.version, r.accessor, r.recordId),

--- a/contracts/data/dataRegistryV2/interfaces/IDataRegistryV2.sol
+++ b/contracts/data/dataRegistryV2/interfaces/IDataRegistryV2.sol
@@ -49,6 +49,18 @@ interface IDataRegistryV2 {
         uint256 totalAccesses;
     }
 
+    /// @notice One access record for `recordDataAccessBatch`. Field-for-field
+    ///         the parameter list of `recordDataAccess`; the EIP-712 payload
+    ///         the server signs is unchanged (`RECORD_ACCESS_TYPEHASH`).
+    struct AccessRecord {
+        address ownerAddress;
+        string scope;
+        uint256 version;
+        address accessor;
+        bytes32 recordId;
+        bytes signature;
+    }
+
     // ====================== Errors ======================
 
     error ZeroAddress();
@@ -63,6 +75,8 @@ interface IDataRegistryV2 {
     error DataPortabilityServersNotSet();
     error UntrustedServer(address owner, address server);
     error RecordIdAlreadyUsed(bytes32 recordId);
+    error EmptyBatch();
+    error BatchTooLarge(uint256 size, uint256 max);
 
     // ====================== Events ======================
 
@@ -92,6 +106,18 @@ interface IDataRegistryV2 {
         uint256 versionAccessCount,
         uint256 dataPointTotalAccesses
     );
+
+    /// @notice Emitted by `recordDataAccessBatch` for every item it did NOT
+    ///         record. `reason` is the 4-byte selector of the error the
+    ///         single-record `recordDataAccess` would have reverted with for
+    ///         the same input: `RecordIdAlreadyUsed`, `InvalidSignature`,
+    ///         `UntrustedServer` or `UnknownVersion`. Exactly one of
+    ///         `DataAccessRecorded` / `DataAccessSkipped` is emitted per item,
+    ///         so a receipt alone tells which recordIds landed.
+    /// @param recordId Caller-chosen id of the skipped item.
+    /// @param index    Position of the item in the submitted batch.
+    /// @param reason   Error selector, see above.
+    event DataAccessSkipped(bytes32 indexed recordId, uint256 index, bytes4 reason);
 
     /// @notice Emitted alongside `DataVersionAdded` when the EIP-712 signature
     ///         on `addDataWithSignature` was produced by a delegate (personal
@@ -127,6 +153,11 @@ interface IDataRegistryV2 {
     ///         RecordDataAccess(address ownerAddress,string scope,uint256 version,
     ///         address accessor,bytes32 recordId)
     function RECORD_ACCESS_TYPEHASH() external view returns (bytes32);
+
+    /// @notice Hard cap on `recordDataAccessBatch` length. A gas bound, not a
+    ///         semantic one: sized so a full batch fits a 60M-gas block with
+    ///         margin. Batches above it revert with `BatchTooLarge`.
+    function MAX_ACCESS_BATCH() external view returns (uint256);
 
     /// @notice EIP-712 typehash for `setStatusWithSignature`. Type:
     ///         SetStatus(address ownerAddress,string scope,uint8 newStatus,
@@ -288,4 +319,32 @@ interface IDataRegistryV2 {
         bytes32 recordId,
         bytes calldata signature
     ) external;
+
+    /// @notice Record up to `MAX_ACCESS_BATCH` accesses in one call.
+    ///         Skip-and-emit per item: each record is validated exactly as
+    ///         `recordDataAccess` validates its arguments, in the same order.
+    ///         A record that passes is committed and emits
+    ///         `DataAccessRecorded`, identical to the single-record path. A
+    ///         record that fails is skipped, emits `DataAccessSkipped` with
+    ///         the selector of the error the single-record path would have
+    ///         raised, and does not touch state. Items are independent: a
+    ///         skipped item never affects another item, and a duplicate
+    ///         recordId within the batch records the first occurrence and
+    ///         skips the rest.
+    /// @dev    Batch-level preconditions revert the whole call, as they would
+    ///         a single call: caller lacks ACCESS_RECORDER_ROLE, contract
+    ///         paused, `dataPortabilityServers` unset. Additionally an empty
+    ///         batch reverts with `EmptyBatch` and an oversized one with
+    ///         `BatchTooLarge`.
+    ///
+    ///         Each record carries its own server signature over its own
+    ///         payload; there is no batch-level signature. A malformed
+    ///         signature (wrong length, high-s, zero recovery) is reported as
+    ///         `InvalidSignature` rather than the ECDSA library's typed
+    ///         errors, so the batch path never reverts on one bad item.
+    /// @param  records  Records to process, in order.
+    /// @return recorded `recorded[i]` is true iff `records[i]` was committed.
+    function recordDataAccessBatch(AccessRecord[] calldata records)
+        external
+        returns (bool[] memory recorded);
 }

--- a/contracts/data/dataRegistryV2/interfaces/IDataRegistryV2.sol
+++ b/contracts/data/dataRegistryV2/interfaces/IDataRegistryV2.sol
@@ -111,7 +111,11 @@ interface IDataRegistryV2 {
     ///         record. `reason` is the 4-byte selector of the error the
     ///         single-record `recordDataAccess` would have reverted with for
     ///         the same input: `RecordIdAlreadyUsed`, `InvalidSignature`,
-    ///         `UntrustedServer` or `UnknownVersion`. Exactly one of
+    ///         `UntrustedServer` or `UnknownVersion` — plus `ScopeTooLong`
+    ///         for a scope above the registry's 256-byte cap, which the batch
+    ///         path rejects before hashing (no data point can carry such a
+    ///         scope, so the single path would end in `UnknownVersion` or
+    ///         `UntrustedServer` after doing the work). Exactly one of
     ///         `DataAccessRecorded` / `DataAccessSkipped` is emitted per item,
     ///         so a receipt alone tells which recordIds landed.
     /// @param recordId Caller-chosen id of the skipped item.
@@ -342,6 +346,9 @@ interface IDataRegistryV2 {
     ///         signature (wrong length, high-s, zero recovery) is reported as
     ///         `InvalidSignature` rather than the ECDSA library's typed
     ///         errors, so the batch path never reverts on one bad item.
+    ///         Signature length and scope length are checked on calldata
+    ///         before any hashing or memory copy, so an oversized item costs
+    ///         the caller its calldata and a skip event, nothing more.
     /// @param  records  Records to process, in order.
     /// @return recorded `recorded[i]` is true iff `records[i]` was committed.
     function recordDataAccessBatch(AccessRecord[] calldata records)

--- a/contracts/dataPortability/dataPortabilityEscrow/DataPortabilityEscrowImplementation.sol
+++ b/contracts/dataPortability/dataPortabilityEscrow/DataPortabilityEscrowImplementation.sol
@@ -45,6 +45,9 @@ contract DataPortabilityEscrowImplementation is
 
     bytes32 public constant FACILITATOR_ROLE = keccak256("FACILITATOR_ROLE");
 
+    /// @inheritdoc IDataPortabilityEscrow
+    uint256 public constant override MAX_ACCESS_BATCH = 200;
+
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
         _disableInitializers();
@@ -383,6 +386,68 @@ contract DataPortabilityEscrowImplementation is
             SettleOp calldata op = ops[i];
             _payout(op.from, op.to, op.asset, op.amount);
             emit Settled(op.from, op.to, op.ref, op.asset, op.amount, op.opKind);
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
+    // ====================== Facilitator: batch record access + settle ======================
+
+    /// @inheritdoc IDataPortabilityEscrow
+    /// @dev One registry call for the whole batch, then the settle loop per
+    ///      recorded item. The registry's `recordDataAccessBatch` never
+    ///      reverts on a single bad record (it returns `recorded[i] = false`
+    ///      and emits `DataAccessSkipped`), so a skipped item simply has no
+    ///      legs executed. `_payout` is unchanged, so a leg failure reverts
+    ///      the entire batch as it does in `recordAccessAndSettle`.
+    ///
+    ///      Records are copied calldata → memory because the registry takes
+    ///      one array and the bundle shape interleaves records with ops.
+    function recordAccessAndSettleBatch(AccessBundle[] calldata bundles)
+        external
+        override
+        onlyRole(FACILITATOR_ROLE)
+        whenNotPaused
+        nonReentrant
+        returns (bool[] memory recorded)
+    {
+        if (address(dataRegistry) == address(0)) revert DataRegistryNotSet();
+        uint256 len = bundles.length;
+        if (len == 0) revert EmptyBatch();
+        if (len > MAX_ACCESS_BATCH) revert BatchTooLarge(len, MAX_ACCESS_BATCH);
+
+        IDataRegistryV2.AccessRecord[] memory records = new IDataRegistryV2.AccessRecord[](len);
+        for (uint256 i = 0; i < len; ) {
+            records[i] = bundles[i].record;
+            unchecked {
+                ++i;
+            }
+        }
+
+        // Step 1: record every access the registry accepts. Reverts only on
+        // batch-level preconditions (servers unset, paused, role) — per-item
+        // failures come back as `recorded[i] == false`.
+        recorded = dataRegistry.recordDataAccessBatch(records);
+
+        // Step 2: settle the legs of every recorded item, in batch order.
+        // Same `_payout` + `Settled` shape as every other bundle here, with
+        // an `AccessSettled` marker in front so the receipt groups legs per
+        // read without the calldata.
+        for (uint256 i = 0; i < len; ) {
+            if (recorded[i]) {
+                SettleOp[] calldata ops = bundles[i].ops;
+                uint256 opsLen = ops.length;
+                emit AccessSettled(i, bundles[i].record.recordId, opsLen);
+                for (uint256 j = 0; j < opsLen; ) {
+                    SettleOp calldata op = ops[j];
+                    _payout(op.from, op.to, op.asset, op.amount);
+                    emit Settled(op.from, op.to, op.ref, op.asset, op.amount, op.opKind);
+                    unchecked {
+                        ++j;
+                    }
+                }
+            }
             unchecked {
                 ++i;
             }

--- a/contracts/dataPortability/dataPortabilityEscrow/DataPortabilityEscrowImplementation.sol
+++ b/contracts/dataPortability/dataPortabilityEscrow/DataPortabilityEscrowImplementation.sol
@@ -48,6 +48,11 @@ contract DataPortabilityEscrowImplementation is
     /// @inheritdoc IDataPortabilityEscrow
     uint256 public constant override MAX_ACCESS_BATCH = 200;
 
+    /// @inheritdoc IDataPortabilityEscrow
+    /// @dev A data access pays one fee leg today; 8 leaves room for a split
+    ///      (owner / protocol / referrer) without making the batch unbounded.
+    uint256 public constant override MAX_ACCESS_BUNDLE_OPS = 8;
+
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
         _disableInitializers();
@@ -419,6 +424,8 @@ contract DataPortabilityEscrowImplementation is
 
         IDataRegistryV2.AccessRecord[] memory records = new IDataRegistryV2.AccessRecord[](len);
         for (uint256 i = 0; i < len; ) {
+            uint256 opsLen = bundles[i].ops.length;
+            if (opsLen > MAX_ACCESS_BUNDLE_OPS) revert TooManyOps(i, opsLen, MAX_ACCESS_BUNDLE_OPS);
             records[i] = bundles[i].record;
             unchecked {
                 ++i;
@@ -433,7 +440,9 @@ contract DataPortabilityEscrowImplementation is
         // Step 2: settle the legs of every recorded item, in batch order.
         // Same `_payout` + `Settled` shape as every other bundle here, with
         // an `AccessSettled` marker in front so the receipt groups legs per
-        // read without the calldata.
+        // read without the calldata. Token / recipient logs interleave with
+        // `Settled`; the grouping rule is "this contract's `Settled` events
+        // after the marker", see IDataPortabilityEscrow.AccessSettled.
         for (uint256 i = 0; i < len; ) {
             if (recorded[i]) {
                 SettleOp[] calldata ops = bundles[i].ops;

--- a/contracts/dataPortability/dataPortabilityEscrow/interfaces/IDataPortabilityEscrow.sol
+++ b/contracts/dataPortability/dataPortabilityEscrow/interfaces/IDataPortabilityEscrow.sol
@@ -99,6 +99,7 @@ interface IDataPortabilityEscrow {
     error CallDataTooShort();
     error EmptyBatch();
     error BatchTooLarge(uint256 size, uint256 max);
+    error TooManyOps(uint256 index, uint256 count, uint256 max);
 
     // ====================== Events ======================
 
@@ -154,11 +155,15 @@ interface IDataPortabilityEscrow {
 
     /// @notice Emitted by `recordAccessAndSettleBatch` for each item whose
     ///         record was committed, immediately BEFORE that item's `Settled`
-    ///         events. The `opCount` Settled events that follow belong to
-    ///         `recordId`, so a receipt alone groups payment legs per read.
-    ///         Not emitted for skipped items (the registry emits
-    ///         `DataAccessSkipped` for those) and not emitted by the
-    ///         single-record `recordAccessAndSettle`.
+    ///         events. The next `opCount` `Settled` events EMITTED BY THIS
+    ///         CONTRACT belong to `recordId`, so a receipt alone groups
+    ///         payment legs per read. Logs from other contracts interleave
+    ///         (an ERC-20 leg emits the token's `Transfer` between the marker
+    ///         and its `Settled`; a native leg's recipient may emit anything),
+    ///         so consumers must filter on this contract's address and the
+    ///         `Settled` topic, never count raw logs. Not emitted for skipped
+    ///         items (the registry emits `DataAccessSkipped` for those) and
+    ///         not emitted by the single-record `recordAccessAndSettle`.
     /// @param index    Position of the item in the submitted batch.
     /// @param recordId The committed access record's id.
     /// @param opCount  Number of `Settled` events that follow for this item.
@@ -186,6 +191,10 @@ interface IDataPortabilityEscrow {
     /// @notice Hard cap on `recordAccessAndSettleBatch` length. Never above
     ///         the registry's `MAX_ACCESS_BATCH`.
     function MAX_ACCESS_BATCH() external view returns (uint256);
+
+    /// @notice Hard cap on `ops.length` of one `AccessBundle`. Together with
+    ///         `MAX_ACCESS_BATCH` it bounds the work of one batch call.
+    function MAX_ACCESS_BUNDLE_OPS() external view returns (uint256);
 
     /// @notice Enumerate every target address that currently has at least one allowed selector.
     function getAllowedTargets() external view returns (address[] memory);
@@ -334,11 +343,13 @@ interface IDataPortabilityEscrow {
     ///             the facilitator's own earlier transactions.
     ///         A receipt is therefore self-describing: per item exactly one
     ///         of `DataAccessRecorded` / `DataAccessSkipped`, and for
-    ///         recorded items the `Settled` events between its
-    ///         `AccessSettled` marker and the next marker are its legs.
+    ///         recorded items the escrow-emitted `Settled` events between its
+    ///         `AccessSettled` marker and the next marker are its legs (see
+    ///         `AccessSettled` for the filtering rule).
     /// @dev    Reverts with `DataRegistryNotSet`, `EmptyBatch`,
-    ///         `BatchTooLarge`, or the registry's batch-level errors
-    ///         (`DataPortabilityServersNotSet`, `EnforcedPause`).
+    ///         `BatchTooLarge`, `TooManyOps` (a bundle with more than
+    ///         `MAX_ACCESS_BUNDLE_OPS` legs), or the registry's batch-level
+    ///         errors (`DataPortabilityServersNotSet`, `EnforcedPause`).
     /// @param  bundles  Items to process, in order.
     /// @return recorded `recorded[i]` is true iff `bundles[i].record` was
     ///                  committed (and its ops executed).

--- a/contracts/dataPortability/dataPortabilityEscrow/interfaces/IDataPortabilityEscrow.sol
+++ b/contracts/dataPortability/dataPortabilityEscrow/interfaces/IDataPortabilityEscrow.sol
@@ -73,6 +73,18 @@ interface IDataPortabilityEscrow {
         bytes32 ref;
     }
 
+    /// @notice One item of `recordAccessAndSettleBatch`: an access record and
+    ///         the payment legs that pay for exactly that access.
+    /// @param record The access record, as `DataRegistryV2.recordDataAccess`
+    ///               takes it (owner, scope, version, accessor, recordId,
+    ///               server signature).
+    /// @param ops    Payouts executed only if `record` is committed; may be
+    ///               empty.
+    struct AccessBundle {
+        IDataRegistryV2.AccessRecord record;
+        SettleOp[] ops;
+    }
+
     // ====================== Errors ======================
 
     error ZeroAmount();
@@ -85,6 +97,8 @@ interface IDataPortabilityEscrow {
     error DataRegistryNotSet();
     error OpNotAllowed(address target, bytes4 selector);
     error CallDataTooShort();
+    error EmptyBatch();
+    error BatchTooLarge(uint256 size, uint256 max);
 
     // ====================== Events ======================
 
@@ -138,6 +152,18 @@ interface IDataPortabilityEscrow {
     /// @notice Emitted for each call dispatched through `runOpAndSettle`.
     event OpExecuted(address indexed target, bytes4 indexed selector, bytes returnData);
 
+    /// @notice Emitted by `recordAccessAndSettleBatch` for each item whose
+    ///         record was committed, immediately BEFORE that item's `Settled`
+    ///         events. The `opCount` Settled events that follow belong to
+    ///         `recordId`, so a receipt alone groups payment legs per read.
+    ///         Not emitted for skipped items (the registry emits
+    ///         `DataAccessSkipped` for those) and not emitted by the
+    ///         single-record `recordAccessAndSettle`.
+    /// @param index    Position of the item in the submitted batch.
+    /// @param recordId The committed access record's id.
+    /// @param opCount  Number of `Settled` events that follow for this item.
+    event AccessSettled(uint256 indexed index, bytes32 indexed recordId, uint256 opCount);
+
     // ====================== Views ======================
 
     function version() external pure returns (uint256);
@@ -156,6 +182,10 @@ interface IDataPortabilityEscrow {
 
     /// @notice True iff the `(target, selector)` pair is allowed for `runOpAndSettle`.
     function isAllowedOp(address target, bytes4 selector) external view returns (bool);
+
+    /// @notice Hard cap on `recordAccessAndSettleBatch` length. Never above
+    ///         the registry's `MAX_ACCESS_BATCH`.
+    function MAX_ACCESS_BATCH() external view returns (uint256);
 
     /// @notice Enumerate every target address that currently has at least one allowed selector.
     function getAllowedTargets() external view returns (address[] memory);
@@ -279,6 +309,42 @@ interface IDataPortabilityEscrow {
         bytes calldata serverSignature,
         SettleOp[] calldata ops
     ) external;
+
+    /// @notice Record up to `MAX_ACCESS_BATCH` accesses and settle each one's
+    ///         payment legs in a single transaction.
+    ///
+    ///         Failure semantics — skip-and-emit per item, all-or-nothing
+    ///         within an item:
+    ///           - The registry validates every record independently
+    ///             (`DataRegistryV2.recordDataAccessBatch`). A record it
+    ///             rejects (duplicate recordId, bad signature, untrusted
+    ///             server, unknown version) is skipped: it emits
+    ///             `DataAccessSkipped` on the registry, and NONE of its `ops`
+    ///             are executed. Other items are unaffected.
+    ///           - A record it commits emits `DataAccessRecorded` on the
+    ///             registry, then `AccessSettled(index, recordId, opCount)`
+    ///             here, then one `Settled` per op — the same events as
+    ///             `recordAccessAndSettle` plus the `AccessSettled` marker.
+    ///           - A payment leg that cannot execute (`ZeroAmount`,
+    ///             `ZeroAddress`, `InsufficientBalance`, transfer failure)
+    ///             reverts the WHOLE batch, exactly as it reverts the single
+    ///             call: escrow balances only move through the facilitator,
+    ///             so the facilitator can simulate this away before
+    ///             broadcasting, whereas a record rejection can be raced by
+    ///             the facilitator's own earlier transactions.
+    ///         A receipt is therefore self-describing: per item exactly one
+    ///         of `DataAccessRecorded` / `DataAccessSkipped`, and for
+    ///         recorded items the `Settled` events between its
+    ///         `AccessSettled` marker and the next marker are its legs.
+    /// @dev    Reverts with `DataRegistryNotSet`, `EmptyBatch`,
+    ///         `BatchTooLarge`, or the registry's batch-level errors
+    ///         (`DataPortabilityServersNotSet`, `EnforcedPause`).
+    /// @param  bundles  Items to process, in order.
+    /// @return recorded `recorded[i]` is true iff `bundles[i].record` was
+    ///                  committed (and its ops executed).
+    function recordAccessAndSettleBatch(AccessBundle[] calldata bundles)
+        external
+        returns (bool[] memory recorded);
 
     /// @notice Atomically register a permission and execute associated payouts.
     ///         Both succeed or both revert.

--- a/deploy/dataPortability/dataPortabilityEscrow-upgrade-batchAccess.ts
+++ b/deploy/dataPortability/dataPortabilityEscrow-upgrade-batchAccess.ts
@@ -1,0 +1,84 @@
+import { deployments, ethers } from "hardhat";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { DeployFunction } from "hardhat-deploy/types";
+import { verifyContract } from "../helpers";
+
+/**
+ * Upgrades DataPortabilityEscrow to add `recordAccessAndSettleBatch`
+ * (N access records + their payment legs in one tx), the `AccessSettled`
+ * marker event, the `EmptyBatch` / `BatchTooLarge` errors and the
+ * `MAX_ACCESS_BATCH` constant.
+ *
+ * Storage layout unchanged (no new state variables) — safe UUPS upgrade.
+ * No new roles: FACILITATOR_ROLE gates the new entry point exactly as it
+ * gates `recordAccessAndSettle`.
+ *
+ * DO NOT RUN before the Nethermind audit slot for this upgrade has cleared.
+ * Run AFTER `DataRegistryV2UpgradeBatchAccess`: the new escrow function
+ * calls `dataRegistry.recordDataAccessBatch`, which the pre-upgrade registry
+ * does not have (the call would revert with no data).
+ */
+const ESCROW_PROXY_DEFAULT = "0xcF50fAb402e2025a92e1bF811049820b6428910A";
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const [deployer] = await ethers.getSigners();
+  const proxyAddress = process.env.DATA_PORTABILITY_ESCROW_PROXY ?? ESCROW_PROXY_DEFAULT;
+
+  console.log("Deployer:               ", deployer.address);
+  console.log("Escrow proxy:           ", proxyAddress);
+
+  console.log("\n=== Deploying new DataPortabilityEscrowImplementation ===");
+  const implDeploy = await deployments.deploy("DataPortabilityEscrowImplementation", {
+    from: deployer.address,
+    args: [],
+    log: true,
+  });
+  console.log("New implementation:     ", implDeploy.address);
+
+  const IMPL_SLOT = "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc";
+  const beforeImplRaw = await ethers.provider.getStorage(proxyAddress, IMPL_SLOT);
+  const beforeImpl = ethers.getAddress("0x" + beforeImplRaw.slice(-40));
+  console.log("Previous impl:          ", beforeImpl);
+
+  if (beforeImpl.toLowerCase() === implDeploy.address.toLowerCase()) {
+    console.log("Already at this implementation.");
+  } else {
+    console.log("\n=== Calling upgradeToAndCall on proxy ===");
+    const proxyAsUUPS = await ethers.getContractAt(
+      "DataPortabilityEscrowImplementation",
+      proxyAddress,
+    );
+    const tx = await proxyAsUUPS.connect(deployer).upgradeToAndCall(implDeploy.address, "0x");
+    console.log("upgrade tx:            ", tx.hash);
+    await tx.wait();
+
+    const afterImplRaw = await ethers.provider.getStorage(proxyAddress, IMPL_SLOT);
+    const afterImpl = ethers.getAddress("0x" + afterImplRaw.slice(-40));
+    if (afterImpl.toLowerCase() !== implDeploy.address.toLowerCase()) {
+      throw new Error(`Upgrade did not take effect: ${afterImpl}`);
+    }
+    console.log("New impl in proxy:      ", afterImpl);
+  }
+
+  const escrow = await ethers.getContractAt("DataPortabilityEscrowImplementation", proxyAddress);
+  const registryAddress: string = await escrow.dataRegistry();
+  console.log("dataRegistry pointer:   ", registryAddress, "(unchanged)");
+  console.log("permissions pointer:    ", await escrow.permissions(), "(unchanged)");
+  console.log("MAX_ACCESS_BATCH:       ", (await escrow.MAX_ACCESS_BATCH()).toString());
+
+  // Guard: the wired registry must already expose the batch entry point.
+  const registry = await ethers.getContractAt("DataRegistryV2Implementation", registryAddress);
+  const registryMax = await registry.MAX_ACCESS_BATCH();
+  console.log("registry MAX_ACCESS_BATCH", registryMax.toString());
+
+  console.log("\n=== Verifying new impl on Blockscout ===");
+  await verifyContract(implDeploy.address, []);
+
+  console.log("\n=== Upgrade summary ===");
+  console.log("Proxy:                       ", proxyAddress);
+  console.log("Previous impl:               ", beforeImpl);
+  console.log("New impl:                    ", implDeploy.address);
+};
+
+export default func;
+func.tags = ["DataPortabilityEscrowUpgradeBatchAccess"];

--- a/deploy/dataPortability/dataRegistryV2-upgrade-batchAccess.ts
+++ b/deploy/dataPortability/dataRegistryV2-upgrade-batchAccess.ts
@@ -1,0 +1,76 @@
+import { deployments, ethers } from "hardhat";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { DeployFunction } from "hardhat-deploy/types";
+import { verifyContract } from "../helpers";
+
+/**
+ * Upgrades DataRegistryV2 to add `recordDataAccessBatch` (skip-and-emit
+ * batch of `recordDataAccess`), the `DataAccessSkipped` event, the
+ * `EmptyBatch` / `BatchTooLarge` errors and the `MAX_ACCESS_BATCH` constant.
+ *
+ * Storage layout unchanged (no new state variables; constants, events and
+ * errors only) — safe UUPS upgrade. `recordDataAccess` keeps its exact
+ * revert behaviour; only its state-mutating tail was factored into
+ * `_commitAccess`, shared with the batch path.
+ *
+ * DO NOT RUN before the Nethermind audit slot for this upgrade has cleared.
+ * Run this BEFORE the escrow upgrade: the escrow's
+ * `recordAccessAndSettleBatch` calls `recordDataAccessBatch` and reverts on
+ * a registry that does not have it yet.
+ */
+const PROXY_DEFAULT = "0x0850226E939A5C949633200cf0b1F4665CA74931";
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const [deployer] = await ethers.getSigners();
+  const proxyAddress = process.env.DATA_REGISTRY_V2_PROXY ?? PROXY_DEFAULT;
+
+  console.log("Deployer:            ", deployer.address);
+  console.log("DataRegistryV2 proxy:", proxyAddress);
+
+  console.log("\n=== Deploying new DataRegistryV2Implementation ===");
+  const implDeploy = await deployments.deploy("DataRegistryV2Implementation", {
+    from: deployer.address,
+    args: [],
+    log: true,
+  });
+  console.log("New implementation:  ", implDeploy.address);
+
+  const IMPL_SLOT = "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc";
+  const beforeImplRaw = await ethers.provider.getStorage(proxyAddress, IMPL_SLOT);
+  const beforeImpl = ethers.getAddress("0x" + beforeImplRaw.slice(-40));
+  console.log("Previous impl:       ", beforeImpl);
+
+  if (beforeImpl.toLowerCase() === implDeploy.address.toLowerCase()) {
+    console.log("Already at this implementation.");
+  } else {
+    console.log("\n=== Calling upgradeToAndCall on proxy ===");
+    const proxyAsUUPS = await ethers.getContractAt(
+      "DataRegistryV2Implementation",
+      proxyAddress,
+    );
+    const tx = await proxyAsUUPS.connect(deployer).upgradeToAndCall(implDeploy.address, "0x");
+    console.log("upgrade tx:         ", tx.hash);
+    await tx.wait();
+
+    const afterImplRaw = await ethers.provider.getStorage(proxyAddress, IMPL_SLOT);
+    const afterImpl = ethers.getAddress("0x" + afterImplRaw.slice(-40));
+    console.log("New impl in proxy:  ", afterImpl);
+    if (afterImpl.toLowerCase() !== implDeploy.address.toLowerCase()) {
+      throw new Error(`Upgrade did not take effect`);
+    }
+  }
+
+  const registry = await ethers.getContractAt("DataRegistryV2Implementation", proxyAddress);
+  console.log("MAX_ACCESS_BATCH:    ", (await registry.MAX_ACCESS_BATCH()).toString());
+
+  console.log("\n=== Verifying on Blockscout ===");
+  await verifyContract(implDeploy.address, []);
+
+  console.log("\n=== Upgrade summary ===");
+  console.log("Proxy:                  ", proxyAddress);
+  console.log("Previous impl:          ", beforeImpl);
+  console.log("New impl:               ", implDeploy.address);
+};
+
+export default func;
+func.tags = ["DataRegistryV2UpgradeBatchAccess"];

--- a/scripts/gas/measureBatchOnFork.ts
+++ b/scripts/gas/measureBatchOnFork.ts
@@ -9,7 +9,8 @@
  *
  * Scenario (the expensive, realistic shape):
  *   - N distinct data owners, each with its own freshly registered trusted
- *     server and its own data point (16-byte scope), first access each
+ *     server (production-length public key + relay URL) and its own data
+ *     point (16-byte scope), first access each
  *   - one USDC.e leg per item, prod fee (10,000 units), prod payer → prod payee
  *
  *   VANA_RPC_URL=https://rpc.vana.org npx hardhat run scripts/gas/measureBatchOnFork.ts
@@ -26,6 +27,12 @@ const PAYEE = "0xa5105914755cF2158be2D2C5c2392C4ba963f78F"; // fee recipient in 
 const FEE = 10_000n;
 const IMPL_SLOT = "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc";
 const SIZES = [1, 10, 25, 50, 100, 200];
+// Production server registrations carry a 132-char uncompressed public key
+// and a ~47-char relay URL (measured on the server that signed tx 0xfc0bb1…).
+// `_isTrustedServer` copies both strings out of storage per record, so the
+// fixtures must match or the per-read cost is understated by ~16k gas.
+const prodPublicKey = (i: number) => "0x04" + i.toString(16).padStart(130, "0");
+const prodServerUrl = (i: number) => `https://${i.toString(16).padStart(24, "0")}.relay.vana.com`;
 
 const setSlot = (addr: string, slot: string, value: string) =>
   network.provider.request({ method: "hardhat_setStorageAt", params: [addr, slot, value] });
@@ -39,6 +46,13 @@ async function main() {
     method: "hardhat_reset",
     params: [{ forking: { jsonRpcUrl: rpc, blockNumber: forkBlock } }],
   });
+  // Hardhat's default block gas limit is 30M; mainnet blocks are 60M.
+  await network.provider.request({ method: "evm_setBlockGasLimit", params: [ethers.toBeHex(60_000_000)] });
+
+  // Before swapping implementations: prepare one item and measure the single
+  // path on the DEPLOYED implementations, so the new code is compared with
+  // what mainnet runs today on identical input (same fork block, same state).
+  const deployedSingleGas = await measureDeployedSingle();
 
   // Deploy the new implementations and point the proxies at them.
   const regImpl = await (await ethers.getContractFactory("DataRegistryV2Implementation")).deploy();
@@ -99,8 +113,8 @@ async function main() {
     const registration = {
       ownerAddress: dataOwner.address,
       serverAddress: server.address,
-      publicKey: "pk-" + i,
-      serverUrl: "https://ps-" + i + ".example",
+      publicKey: prodPublicKey(i),
+      serverUrl: prodServerUrl(i),
     };
     const regSig = await dataOwner.signTypedData(
       serversDomain,
@@ -164,14 +178,15 @@ async function main() {
       .connect(relayer)
       .recordAccessAndSettle(r.ownerAddress, r.scope, r.version, r.accessor, r.recordId, r.signature, items[0].ops);
     const rc = await tx.wait();
-    console.log(`\nrecordAccessAndSettle (single, upgraded impl, real USDC.e): gas=${rc!.gasUsed} calldata=${(tx.data.length - 2) / 2}B`);
+    console.log(`\nrecordAccessAndSettle (single, DEPLOYED impl, real USDC.e, same input shape): gas=${deployedSingleGas}`);
+    console.log(`recordAccessAndSettle (single, THIS BRANCH impl, real USDC.e): gas=${rc!.gasUsed} calldata=${(tx.data.length - 2) / 2}B`);
     await revert(s);
   }
 
   const rows: { n: number; gas: bigint; calldata: number }[] = [];
   for (const n of SIZES) {
     const s = await snapshot();
-    const tx = await escrow.connect(relayer).recordAccessAndSettleBatch(items.slice(0, n), { gasLimit: 59_000_000 });
+    const tx = await escrow.connect(relayer).recordAccessAndSettleBatch(items.slice(0, n), { gasLimit: 58_000_000 });
     const rc = await tx.wait();
     if (rc!.status !== 1) throw new Error("batch reverted");
     const recordedLogs = rc!.logs.filter((l) => l.address.toLowerCase() === REGISTRY.toLowerCase()).length;
@@ -193,6 +208,64 @@ async function main() {
     );
     prev = row;
   }
+}
+
+async function measureDeployedSingle(): Promise<bigint> {
+  const snap = (await network.provider.request({ method: "evm_snapshot", params: [] })) as string;
+  const registry = await ethers.getContractAt("DataRegistryV2Implementation", REGISTRY);
+  const escrow = await ethers.getContractAt("DataPortabilityEscrowImplementation", ESCROW);
+  const servers = await ethers.getContractAt("DataPortabilityServersV2Implementation", SERVERS);
+  const abi = ethers.AbiCoder.defaultAbiCoder();
+  const balSlot = ethers.keccak256(
+    abi.encode(["address", "bytes32"], [USDC_E, ethers.keccak256(abi.encode(["address", "uint256"], [PAYER, 0]))]),
+  );
+  const before = await escrow.balanceOf(PAYER, USDC_E);
+  await setSlot(ESCROW, balSlot, ethers.toBeHex(before + FEE * 10n, 32));
+  await network.provider.request({ method: "hardhat_impersonateAccount", params: [RELAYER] });
+  await network.provider.request({ method: "hardhat_setBalance", params: [RELAYER, ethers.toBeHex(10n ** 21n)] });
+  const relayer = await ethers.getSigner(RELAYER);
+  const chainId = (await ethers.provider.getNetwork()).chainId;
+  const serversDomain = { name: "Vana Data Portability", version: "1", chainId, verifyingContract: SERVERS };
+  const registryDomain = { name: "Vana Data Portability", version: "1", chainId, verifyingContract: REGISTRY };
+  const dataOwner = ethers.Wallet.createRandom();
+  const server = ethers.Wallet.createRandom();
+  const scope = "linkedin.profil0";
+  const registration = { ownerAddress: dataOwner.address, serverAddress: server.address, publicKey: prodPublicKey(999999), serverUrl: prodServerUrl(999999) };
+  const regSig = await dataOwner.signTypedData(
+    serversDomain,
+    { ServerRegistration: [
+      { name: "ownerAddress", type: "address" }, { name: "serverAddress", type: "address" },
+      { name: "publicKey", type: "string" }, { name: "serverUrl", type: "string" } ] },
+    registration,
+  );
+  await servers.connect(relayer).registerServerWithSignature(registration, regSig);
+  const dataHash = ethers.id("data-ref");
+  const metadataHash = ethers.id("meta-ref");
+  const addSig = await dataOwner.signTypedData(
+    registryDomain,
+    { AddData: [
+      { name: "ownerAddress", type: "address" }, { name: "scope", type: "string" }, { name: "dataHash", type: "bytes32" },
+      { name: "metadataHash", type: "bytes32" }, { name: "expectedVersion", type: "uint256" } ] },
+    { ownerAddress: dataOwner.address, scope, dataHash, metadataHash, expectedVersion: 1n },
+  );
+  await registry.connect(relayer).addDataWithSignature(dataOwner.address, scope, dataHash, metadataHash, 1n, addSig);
+  const recordId = ethers.id("fork-record-ref-" + Date.now());
+  const record = { ownerAddress: dataOwner.address, scope, version: 1n, accessor: PAYER, recordId };
+  const signature = await server.signTypedData(
+    registryDomain,
+    { RecordDataAccess: [
+      { name: "ownerAddress", type: "address" }, { name: "scope", type: "string" }, { name: "version", type: "uint256" },
+      { name: "accessor", type: "address" }, { name: "recordId", type: "bytes32" } ] },
+    record,
+  );
+  const tx = await escrow
+    .connect(relayer)
+    .recordAccessAndSettle(record.ownerAddress, record.scope, record.version, record.accessor, record.recordId, signature, [
+      { from: PAYER, to: PAYEE, asset: USDC_E, amount: FEE, opKind: 5n, ref: ethers.id("grant-ref") },
+    ]);
+  const rc = await tx.wait();
+  await network.provider.request({ method: "evm_revert", params: [snap] });
+  return rc!.gasUsed;
 }
 
 main().catch((e) => {

--- a/scripts/gas/measureBatchOnFork.ts
+++ b/scripts/gas/measureBatchOnFork.ts
@@ -1,0 +1,201 @@
+/**
+ * Measures `recordAccessAndSettleBatch` gas on a Hardhat fork of Vana
+ * mainnet with the REAL deployed stack (ServersV2, USDC.e FiatTokenV2 proxy,
+ * the production payer / payee of tx 0xfc0bb1…) and the upgraded
+ * DataRegistryV2 + DataPortabilityEscrow implementations from this branch.
+ *
+ * Nothing is broadcast. The upgrade is applied by writing the ERC-1967
+ * implementation slot of each proxy on the fork, so no admin key is needed.
+ *
+ * Scenario (the expensive, realistic shape):
+ *   - N distinct data owners, each with its own freshly registered trusted
+ *     server and its own data point (16-byte scope), first access each
+ *   - one USDC.e leg per item, prod fee (10,000 units), prod payer → prod payee
+ *
+ *   VANA_RPC_URL=https://rpc.vana.org npx hardhat run scripts/gas/measureBatchOnFork.ts
+ */
+import { ethers, network } from "hardhat";
+
+const REGISTRY = "0x8f1eFCdff3d0d5BB535e32620721c7EBed151867";
+const ESCROW = "0x07d7769081adc3a3DBe91f5E4B98E9A5a6B292e3";
+const SERVERS = "0xCae2CE0e9caa6643ed28186cF57bd40Bd9E17Eab";
+const USDC_E = "0xF1815bd50389c46847f0Bda824eC8da914045D14";
+const RELAYER = "0x80534af0b80ae88d653cae0a8f5d2667439538a0"; // FACILITATOR_ROLE holder (prod)
+const PAYER = "0x2903623Cf9b275601BdF711A37Fa55e219FF6EeF"; // builder in tx 0xfc0bb1…
+const PAYEE = "0xa5105914755cF2158be2D2C5c2392C4ba963f78F"; // fee recipient in tx 0xfc0bb1…
+const FEE = 10_000n;
+const IMPL_SLOT = "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc";
+const SIZES = [1, 10, 25, 50, 100, 200];
+
+const setSlot = (addr: string, slot: string, value: string) =>
+  network.provider.request({ method: "hardhat_setStorageAt", params: [addr, slot, value] });
+
+async function main() {
+  const rpc = process.env.VANA_RPC_URL || "https://rpc.vana.org";
+  const remote = new ethers.JsonRpcProvider(rpc);
+  const forkBlock = (await remote.getBlockNumber()) - 10;
+  console.log("fork block", forkBlock);
+  await network.provider.request({
+    method: "hardhat_reset",
+    params: [{ forking: { jsonRpcUrl: rpc, blockNumber: forkBlock } }],
+  });
+
+  // Deploy the new implementations and point the proxies at them.
+  const regImpl = await (await ethers.getContractFactory("DataRegistryV2Implementation")).deploy();
+  const escImpl = await (await ethers.getContractFactory("DataPortabilityEscrowImplementation")).deploy();
+  await regImpl.waitForDeployment();
+  await escImpl.waitForDeployment();
+  const pad = (a: string) => ethers.zeroPadValue(a, 32);
+  const oldReg = await ethers.provider.getStorage(REGISTRY, IMPL_SLOT);
+  const oldEsc = await ethers.provider.getStorage(ESCROW, IMPL_SLOT);
+  await setSlot(REGISTRY, IMPL_SLOT, pad(await regImpl.getAddress()));
+  await setSlot(ESCROW, IMPL_SLOT, pad(await escImpl.getAddress()));
+  console.log("registry impl", "0x" + oldReg.slice(-40), "→", await regImpl.getAddress());
+  console.log("escrow impl  ", "0x" + oldEsc.slice(-40), "→", await escImpl.getAddress());
+
+  const registry = await ethers.getContractAt("DataRegistryV2Implementation", REGISTRY);
+  const escrow = await ethers.getContractAt("DataPortabilityEscrowImplementation", ESCROW);
+  const servers = await ethers.getContractAt("DataPortabilityServersV2Implementation", SERVERS);
+  const usdc = await ethers.getContractAt("IERC20", USDC_E);
+
+  // Sanity: wiring as deployed.
+  console.log("escrow.dataRegistry", await escrow.dataRegistry());
+  console.log("registry.servers   ", await registry.dataPortabilityServers());
+  console.log("relayer has FACILITATOR_ROLE", await escrow.hasRole(await escrow.FACILITATOR_ROLE(), RELAYER));
+  console.log("escrow has ACCESS_RECORDER_ROLE", await registry.hasRole(await registry.ACCESS_RECORDER_ROLE(), ESCROW));
+  console.log("MAX_ACCESS_BATCH", (await escrow.MAX_ACCESS_BATCH()).toString());
+
+  // Fund the payer's escrow balance for the largest batch (storage write on
+  // `_balances[PAYER][USDC_E]`, slot 0 of DataPortabilityEscrowStorageV1) and
+  // make sure the escrow holds enough USDC.e to pay out.
+  const abi = ethers.AbiCoder.defaultAbiCoder();
+  const balSlot = ethers.keccak256(
+    abi.encode(["address", "bytes32"], [USDC_E, ethers.keccak256(abi.encode(["address", "uint256"], [PAYER, 0]))]),
+  );
+  const before = await escrow.balanceOf(PAYER, USDC_E);
+  const need = FEE * BigInt(Math.max(...SIZES)) * 2n;
+  await setSlot(ESCROW, balSlot, ethers.toBeHex(before + need, 32));
+  console.log("payer escrow USDC.e", before.toString(), "→", (await escrow.balanceOf(PAYER, USDC_E)).toString());
+  const escrowUsdc = await usdc.balanceOf(ESCROW);
+  console.log("escrow USDC.e token balance", escrowUsdc.toString());
+  if (escrowUsdc < need) throw new Error("escrow holds too little USDC.e for the payout");
+
+  // Relayer: impersonate + fund gas.
+  await network.provider.request({ method: "hardhat_impersonateAccount", params: [RELAYER] });
+  await network.provider.request({ method: "hardhat_setBalance", params: [RELAYER, ethers.toBeHex(10n ** 21n)] });
+  const relayer = await ethers.getSigner(RELAYER);
+
+  // Build N distinct owners / servers / data points on the fork.
+  const chainId = (await ethers.provider.getNetwork()).chainId;
+  const serversDomain = { name: "Vana Data Portability", version: "1", chainId, verifyingContract: SERVERS };
+  const registryDomain = { name: "Vana Data Portability", version: "1", chainId, verifyingContract: REGISTRY };
+  const grantRef = ethers.id("grant-ref");
+  const items: any[] = [];
+  const N = Math.max(...SIZES);
+  for (let i = 0; i < N; i++) {
+    const dataOwner = ethers.Wallet.createRandom();
+    const server = ethers.Wallet.createRandom();
+    const scope = `linkedin.profil${String(i % 10)}`; // 16 bytes, prod-length
+    const registration = {
+      ownerAddress: dataOwner.address,
+      serverAddress: server.address,
+      publicKey: "pk-" + i,
+      serverUrl: "https://ps-" + i + ".example",
+    };
+    const regSig = await dataOwner.signTypedData(
+      serversDomain,
+      {
+        ServerRegistration: [
+          { name: "ownerAddress", type: "address" },
+          { name: "serverAddress", type: "address" },
+          { name: "publicKey", type: "string" },
+          { name: "serverUrl", type: "string" },
+        ],
+      },
+      registration,
+    );
+    await servers.connect(relayer).registerServerWithSignature(registration, regSig);
+    const dataHash = ethers.id("data-" + i);
+    const metadataHash = ethers.id("meta-" + i);
+    const addSig = await dataOwner.signTypedData(
+      registryDomain,
+      {
+        AddData: [
+          { name: "ownerAddress", type: "address" },
+          { name: "scope", type: "string" },
+          { name: "dataHash", type: "bytes32" },
+          { name: "metadataHash", type: "bytes32" },
+          { name: "expectedVersion", type: "uint256" },
+        ],
+      },
+      { ownerAddress: dataOwner.address, scope, dataHash, metadataHash, expectedVersion: 1n },
+    );
+    await registry.connect(relayer).addDataWithSignature(dataOwner.address, scope, dataHash, metadataHash, 1n, addSig);
+    const recordId = ethers.id("fork-record-" + i + "-" + forkBlock);
+    const record = { ownerAddress: dataOwner.address, scope, version: 1n, accessor: PAYER, recordId };
+    const signature = await server.signTypedData(
+      registryDomain,
+      {
+        RecordDataAccess: [
+          { name: "ownerAddress", type: "address" },
+          { name: "scope", type: "string" },
+          { name: "version", type: "uint256" },
+          { name: "accessor", type: "address" },
+          { name: "recordId", type: "bytes32" },
+        ],
+      },
+      record,
+    );
+    items.push({
+      record: { ...record, signature },
+      ops: [{ from: PAYER, to: PAYEE, asset: USDC_E, amount: FEE, opKind: 5n, ref: grantRef }],
+    });
+    if ((i + 1) % 50 === 0) console.log("prepared", i + 1, "items");
+  }
+
+  const snapshot = async () => (await network.provider.request({ method: "evm_snapshot", params: [] })) as string;
+  const revert = async (id: string) => network.provider.request({ method: "evm_revert", params: [id] });
+
+  // Reference: single path with the upgraded impl, same item shape.
+  {
+    const s = await snapshot();
+    const r = items[0].record;
+    const tx = await escrow
+      .connect(relayer)
+      .recordAccessAndSettle(r.ownerAddress, r.scope, r.version, r.accessor, r.recordId, r.signature, items[0].ops);
+    const rc = await tx.wait();
+    console.log(`\nrecordAccessAndSettle (single, upgraded impl, real USDC.e): gas=${rc!.gasUsed} calldata=${(tx.data.length - 2) / 2}B`);
+    await revert(s);
+  }
+
+  const rows: { n: number; gas: bigint; calldata: number }[] = [];
+  for (const n of SIZES) {
+    const s = await snapshot();
+    const tx = await escrow.connect(relayer).recordAccessAndSettleBatch(items.slice(0, n), { gasLimit: 59_000_000 });
+    const rc = await tx.wait();
+    if (rc!.status !== 1) throw new Error("batch reverted");
+    const recordedLogs = rc!.logs.filter((l) => l.address.toLowerCase() === REGISTRY.toLowerCase()).length;
+    if (recordedLogs !== n) throw new Error(`expected ${n} registry logs, got ${recordedLogs}`);
+    rows.push({ n, gas: rc!.gasUsed, calldata: (tx.data.length - 2) / 2 });
+    await revert(s);
+  }
+
+  const BLOCK = 60_000_000n;
+  console.log("\n| batch | gasUsed | gas/read | marginal gas/read vs prev | calldata bytes | % of 60M block |");
+  console.log("|---:|---:|---:|---:|---:|---:|");
+  let prev: { n: number; gas: bigint } | null = null;
+  for (const row of rows) {
+    const marginal = prev ? (row.gas - prev.gas) / BigInt(row.n - prev.n) : null;
+    console.log(
+      `| ${row.n} | ${row.gas.toLocaleString("en-US")} | ${(row.gas / BigInt(row.n)).toLocaleString("en-US")} | ${
+        marginal === null ? "—" : marginal.toLocaleString("en-US")
+      } | ${row.calldata.toLocaleString("en-US")} | ${(Number((row.gas * 10000n) / BLOCK) / 100).toFixed(2)}% |`,
+    );
+    prev = row;
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/gas/replayMainnetAccessTx.ts
+++ b/scripts/gas/replayMainnetAccessTx.ts
@@ -1,0 +1,58 @@
+/**
+ * Replays a mainnet `recordAccessAndSettle` tx on a Hardhat fork of Vana
+ * mainnet, pinned to the block before the tx landed, and prints gasUsed.
+ *
+ * Read-only against mainnet (fork + impersonation, nothing broadcast).
+ *
+ *   VANA_RPC_URL=https://rpc.vana.org \
+ *   TX_HASH=0xfc0bb12e707315da1d8376a2a624d636a0089c17fc757c14d114ab3ab450c20b \
+ *   npx hardhat run scripts/gas/replayMainnetAccessTx.ts
+ */
+import { ethers, network } from "hardhat";
+
+async function main() {
+  const rpc = process.env.VANA_RPC_URL || "https://rpc.vana.org";
+  const txHash =
+    process.env.TX_HASH ||
+    "0xfc0bb12e707315da1d8376a2a624d636a0089c17fc757c14d114ab3ab450c20b";
+
+  const remote = new ethers.JsonRpcProvider(rpc);
+  const tx = await remote.getTransaction(txHash);
+  const receipt = await remote.getTransactionReceipt(txHash);
+  if (!tx || !receipt) throw new Error("tx or receipt not found on remote");
+  console.log("remote block      ", receipt.blockNumber);
+  console.log("remote gasUsed    ", receipt.gasUsed.toString());
+  console.log("remote logs       ", receipt.logs.length);
+  console.log("calldata bytes    ", (tx.data.length - 2) / 2);
+
+  await network.provider.request({
+    method: "hardhat_reset",
+    params: [{ forking: { jsonRpcUrl: rpc, blockNumber: receipt.blockNumber - 1 } }],
+  });
+  await network.provider.request({ method: "hardhat_impersonateAccount", params: [tx.from] });
+  await network.provider.request({
+    method: "hardhat_setBalance",
+    params: [tx.from, "0x" + (10n ** 20n).toString(16)],
+  });
+  const signer = await ethers.getSigner(tx.from);
+  const sent = await signer.sendTransaction({
+    to: tx.to!,
+    data: tx.data,
+    value: tx.value,
+    gasLimit: tx.gasLimit,
+  });
+  const local = await sent.wait();
+  if (!local) throw new Error("no local receipt");
+  console.log("fork status       ", local.status);
+  console.log("fork gasUsed      ", local.gasUsed.toString());
+  console.log("fork logs         ", local.logs.length);
+  console.log(
+    "match             ",
+    local.gasUsed === receipt.gasUsed ? "EXACT" : `DIFF ${local.gasUsed - receipt.gasUsed}`,
+  );
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/test/data/dataRegistryV2.ts
+++ b/test/data/dataRegistryV2.ts
@@ -1,7 +1,7 @@
 import chai, { expect, should } from "chai";
 import chaiAsPromised from "chai-as-promised";
 import { ethers, upgrades } from "hardhat";
-import { time } from "@nomicfoundation/hardhat-network-helpers";
+import { takeSnapshot, time } from "@nomicfoundation/hardhat-network-helpers";
 import {
   DataRegistryV2Implementation,
   DataPortabilityServersV2Implementation,
@@ -1790,6 +1790,461 @@ describe("DataRegistryV2", () => {
   });
 
   // ====================== Pause ======================
+
+  describe("recordDataAccessBatch", () => {
+    const rid = (label: string) => ethers.keccak256(ethers.toUtf8Bytes(label));
+
+    let RecordIdAlreadyUsedSel: string;
+    let InvalidSignatureSel: string;
+    let UntrustedServerSel: string;
+    let UnknownVersionSel: string;
+
+    const record = async (
+      signer: HardhatEthersSigner,
+      ownerAddress: string,
+      scope: string,
+      version: bigint,
+      accessor: string,
+      recordId: string,
+    ) => ({
+      ownerAddress,
+      scope,
+      version,
+      accessor,
+      recordId,
+      signature: await signRecordDataAccess(
+        signer,
+        ownerAddress,
+        scope,
+        version,
+        accessor,
+        recordId,
+      ),
+    });
+
+    beforeEach(async () => {
+      await deploy();
+      await registry.connect(user1).addData(SCOPE, DATA_HASH, META_HASH);
+      await registry
+        .connect(owner)
+        .grantRole(ACCESS_RECORDER_ROLE, recorder.address);
+      RecordIdAlreadyUsedSel = registry.interface.getError(
+        "RecordIdAlreadyUsed",
+      )!.selector;
+      InvalidSignatureSel =
+        registry.interface.getError("InvalidSignature")!.selector;
+      UntrustedServerSel =
+        registry.interface.getError("UntrustedServer")!.selector;
+      UnknownVersionSel =
+        registry.interface.getError("UnknownVersion")!.selector;
+    });
+
+    const setupTrustedServer = async () => {
+      await wireServers();
+      await registerServer(user1, server1);
+    };
+
+    // Registry-emitted logs of a tx, normalized so two txs can be compared
+    // for byte-identical event content (topics + data), ignoring tx/block
+    // metadata.
+    const registryLogs = async (txHash: string) => {
+      const rc = await ethers.provider.getTransactionReceipt(txHash);
+      const addr = (await registry.getAddress()).toLowerCase();
+      return rc!.logs
+        .filter((l) => l.address.toLowerCase() === addr)
+        .map((l) => ({ topics: [...l.topics], data: l.data }));
+    };
+
+    it("should reject a caller without ACCESS_RECORDER_ROLE", async function () {
+      await setupTrustedServer();
+      const r = await record(
+        server1,
+        user1.address,
+        SCOPE,
+        1n,
+        other.address,
+        rid("b-role"),
+      );
+      await expect(
+        registry.connect(user1).recordDataAccessBatch([r]),
+      ).to.be.revertedWithCustomError(
+        registry,
+        "AccessControlUnauthorizedAccount",
+      );
+    });
+
+    it("should revert when the servers registry is unset", async function () {
+      const r = await record(
+        server1,
+        user1.address,
+        SCOPE,
+        1n,
+        other.address,
+        rid("b-noservers"),
+      );
+      await expect(
+        registry.connect(recorder).recordDataAccessBatch([r]),
+      ).to.be.revertedWithCustomError(registry, "DataPortabilityServersNotSet");
+    });
+
+    it("should revert when paused", async function () {
+      await setupTrustedServer();
+      const r = await record(
+        server1,
+        user1.address,
+        SCOPE,
+        1n,
+        other.address,
+        rid("b-paused"),
+      );
+      await registry.connect(owner).pause();
+      await expect(
+        registry.connect(recorder).recordDataAccessBatch([r]),
+      ).to.be.revertedWithCustomError(registry, "EnforcedPause");
+    });
+
+    it("should revert on an empty batch", async function () {
+      await setupTrustedServer();
+      await expect(
+        registry.connect(recorder).recordDataAccessBatch([]),
+      ).to.be.revertedWithCustomError(registry, "EmptyBatch");
+    });
+
+    it("should accept MAX_ACCESS_BATCH items and reject one more", async function () {
+      await setupTrustedServer();
+      const max = Number(await registry.MAX_ACCESS_BATCH());
+      max.should.eq(200);
+      const records = [];
+      for (let i = 0; i <= max; i++) {
+        records.push(
+          await record(
+            server1,
+            user1.address,
+            SCOPE,
+            1n,
+            other.address,
+            rid(`b-max-${i}`),
+          ),
+        );
+      }
+      await expect(
+        registry.connect(recorder).recordDataAccessBatch(records),
+      )
+        .to.be.revertedWithCustomError(registry, "BatchTooLarge")
+        .withArgs(max + 1, max);
+
+      const full = records.slice(0, max);
+      const recorded = await registry
+        .connect(recorder)
+        .recordDataAccessBatch.staticCall(full);
+      recorded.length.should.eq(max);
+      recorded.every((x: boolean) => x).should.eq(true);
+      await registry.connect(recorder).recordDataAccessBatch(full);
+      (await registry.totalAccesses(user1.address, SCOPE)).should.eq(max);
+      (await registry.accessCount(user1.address, SCOPE, 1)).should.eq(max);
+      (await registry.isRecordIdUsed(rid(`b-max-${max - 1}`))).should.eq(true);
+      (await registry.isRecordIdUsed(rid(`b-max-${max}`))).should.eq(false);
+    });
+
+    it("batch of 1 should produce byte-identical events and state to recordDataAccess", async function () {
+      await setupTrustedServer();
+      const recordId = rid("b-equiv");
+      const r = await record(
+        server1,
+        user1.address,
+        SCOPE,
+        1n,
+        other.address,
+        recordId,
+      );
+
+      const snap = await takeSnapshot();
+      const singleTx = await registry
+        .connect(recorder)
+        .recordDataAccess(
+          r.ownerAddress,
+          r.scope,
+          r.version,
+          r.accessor,
+          r.recordId,
+          r.signature,
+        );
+      const singleLogs = await registryLogs(singleTx.hash);
+      const singleInfo = await registry.dataPoints(user1.address, SCOPE);
+      const singleCount = await registry.accessCount(user1.address, SCOPE, 1);
+      await snap.restore();
+
+      const recorded = await registry
+        .connect(recorder)
+        .recordDataAccessBatch.staticCall([r]);
+      recorded.should.deep.eq([true]);
+      const batchTx = await registry
+        .connect(recorder)
+        .recordDataAccessBatch([r]);
+      const batchLogs = await registryLogs(batchTx.hash);
+
+      singleLogs.length.should.eq(1);
+      batchLogs.should.deep.eq(singleLogs);
+      (await registry.dataPoints(user1.address, SCOPE)).totalAccesses.should.eq(
+        singleInfo.totalAccesses,
+      );
+      (await registry.accessCount(user1.address, SCOPE, 1)).should.eq(
+        singleCount,
+      );
+      (await registry.isRecordIdUsed(recordId)).should.eq(true);
+    });
+
+    it("batch of 1 should skip with the selector recordDataAccess reverts with", async function () {
+      await setupTrustedServer();
+      await registerServer(user2, server2); // server2 belongs to user2, not user1
+
+      // (a) duplicate recordId
+      const dup = await record(
+        server1,
+        user1.address,
+        SCOPE,
+        1n,
+        other.address,
+        rid("b-sel-dup"),
+      );
+      await registry
+        .connect(recorder)
+        .recordDataAccess(
+          dup.ownerAddress,
+          dup.scope,
+          dup.version,
+          dup.accessor,
+          dup.recordId,
+          dup.signature,
+        );
+      await expect(
+        registry
+          .connect(recorder)
+          .recordDataAccess(
+            dup.ownerAddress,
+            dup.scope,
+            dup.version,
+            dup.accessor,
+            dup.recordId,
+            dup.signature,
+          ),
+      ).to.be.revertedWithCustomError(registry, "RecordIdAlreadyUsed");
+
+      // (b) untrusted server
+      const untrusted = await record(
+        server2,
+        user1.address,
+        SCOPE,
+        1n,
+        other.address,
+        rid("b-sel-untrusted"),
+      );
+      await expect(
+        registry
+          .connect(recorder)
+          .recordDataAccess(
+            untrusted.ownerAddress,
+            untrusted.scope,
+            untrusted.version,
+            untrusted.accessor,
+            untrusted.recordId,
+            untrusted.signature,
+          ),
+      ).to.be.revertedWithCustomError(registry, "UntrustedServer");
+
+      // (c) unknown version
+      const unknown = await record(
+        server1,
+        user1.address,
+        SCOPE,
+        2n,
+        other.address,
+        rid("b-sel-unknown"),
+      );
+      await expect(
+        registry
+          .connect(recorder)
+          .recordDataAccess(
+            unknown.ownerAddress,
+            unknown.scope,
+            unknown.version,
+            unknown.accessor,
+            unknown.recordId,
+            unknown.signature,
+          ),
+      ).to.be.revertedWithCustomError(registry, "UnknownVersion");
+
+      // (d) malformed signature: single path reverts inside ECDSA; the batch
+      //     reports it as InvalidSignature so one bad item cannot abort the batch.
+      const malformed = { ...unknown, version: 1n, recordId: rid("b-sel-bad"), signature: "0x1234" };
+      await expect(
+        registry
+          .connect(recorder)
+          .recordDataAccess(
+            malformed.ownerAddress,
+            malformed.scope,
+            malformed.version,
+            malformed.accessor,
+            malformed.recordId,
+            malformed.signature,
+          ),
+      ).to.be.revertedWithCustomError(registry, "ECDSAInvalidSignatureLength");
+
+      const cases: [typeof dup, string][] = [
+        [dup, RecordIdAlreadyUsedSel],
+        [untrusted, UntrustedServerSel],
+        [unknown, UnknownVersionSel],
+        [malformed, InvalidSignatureSel],
+      ];
+      for (const [r, sel] of cases) {
+        const recorded = await registry
+          .connect(recorder)
+          .recordDataAccessBatch.staticCall([r]);
+        recorded.should.deep.eq([false]);
+        await expect(registry.connect(recorder).recordDataAccessBatch([r]))
+          .to.emit(registry, "DataAccessSkipped")
+          .withArgs(r.recordId, 0, sel);
+        (await registry.isRecordIdUsed(r.recordId)).should.eq(
+          r === dup, // only the duplicate was used before this batch
+        );
+      }
+      (await registry.totalAccesses(user1.address, SCOPE)).should.eq(1);
+    });
+
+    it("should record the first occurrence of a duplicate recordId inside a batch and skip the rest", async function () {
+      await setupTrustedServer();
+      const recordId = rid("b-dup-in");
+      const a = await record(server1, user1.address, SCOPE, 1n, other.address, recordId);
+      const b = await record(server1, user1.address, SCOPE, 1n, user2.address, recordId);
+      const c = await record(server1, user1.address, SCOPE, 1n, other.address, rid("b-dup-in-2"));
+
+      const recorded = await registry
+        .connect(recorder)
+        .recordDataAccessBatch.staticCall([a, b, c]);
+      recorded.should.deep.eq([true, false, true]);
+
+      const tx = registry.connect(recorder).recordDataAccessBatch([a, b, c]);
+      const id = dpId(user1.address, SCOPE);
+      await expect(tx)
+        .to.emit(registry, "DataAccessRecorded")
+        .withArgs(id, 1n, other.address, server1.address, recordId, 1n, 1n);
+      await expect(tx)
+        .to.emit(registry, "DataAccessSkipped")
+        .withArgs(recordId, 1, RecordIdAlreadyUsedSel);
+      await expect(tx)
+        .to.emit(registry, "DataAccessRecorded")
+        .withArgs(id, 1n, other.address, server1.address, c.recordId, 2n, 2n);
+      (await registry.totalAccesses(user1.address, SCOPE)).should.eq(2);
+    });
+
+    it("should skip a recordId already used by an earlier batch", async function () {
+      await setupTrustedServer();
+      const recordId = rid("b-dup-across");
+      const a = await record(server1, user1.address, SCOPE, 1n, other.address, recordId);
+      const b = await record(server1, user1.address, SCOPE, 1n, other.address, rid("b-dup-across-2"));
+
+      await registry.connect(recorder).recordDataAccessBatch([a]);
+      const recorded = await registry
+        .connect(recorder)
+        .recordDataAccessBatch.staticCall([a, b]);
+      recorded.should.deep.eq([false, true]);
+      await expect(registry.connect(recorder).recordDataAccessBatch([a, b]))
+        .to.emit(registry, "DataAccessSkipped")
+        .withArgs(recordId, 0, RecordIdAlreadyUsedSel);
+      (await registry.totalAccesses(user1.address, SCOPE)).should.eq(2);
+    });
+
+    it("should skip only the item signed by an untrusted server", async function () {
+      await setupTrustedServer();
+      const good1 = await record(server1, user1.address, SCOPE, 1n, other.address, rid("b-ut-1"));
+      const bad = await record(server2, user1.address, SCOPE, 1n, other.address, rid("b-ut-2"));
+      const good2 = await record(server1, user1.address, SCOPE, 1n, other.address, rid("b-ut-3"));
+
+      const recorded = await registry
+        .connect(recorder)
+        .recordDataAccessBatch.staticCall([good1, bad, good2]);
+      recorded.should.deep.eq([true, false, true]);
+      await expect(registry.connect(recorder).recordDataAccessBatch([good1, bad, good2]))
+        .to.emit(registry, "DataAccessSkipped")
+        .withArgs(bad.recordId, 1, UntrustedServerSel);
+      (await registry.isRecordIdUsed(bad.recordId)).should.eq(false);
+      (await registry.totalAccesses(user1.address, SCOPE)).should.eq(2);
+    });
+
+    it("should skip only the item with an unknown version", async function () {
+      await setupTrustedServer();
+      const good = await record(server1, user1.address, SCOPE, 1n, other.address, rid("b-uv-1"));
+      const tooHigh = await record(server1, user1.address, SCOPE, 2n, other.address, rid("b-uv-2"));
+      const zero = await record(server1, user1.address, SCOPE, 0n, other.address, rid("b-uv-3"));
+
+      const recorded = await registry
+        .connect(recorder)
+        .recordDataAccessBatch.staticCall([tooHigh, good, zero]);
+      recorded.should.deep.eq([false, true, false]);
+      const tx = registry.connect(recorder).recordDataAccessBatch([tooHigh, good, zero]);
+      await expect(tx)
+        .to.emit(registry, "DataAccessSkipped")
+        .withArgs(tooHigh.recordId, 0, UnknownVersionSel);
+      await expect(tx)
+        .to.emit(registry, "DataAccessSkipped")
+        .withArgs(zero.recordId, 2, UnknownVersionSel);
+      (await registry.accessCount(user1.address, SCOPE, 1)).should.eq(1);
+      (await registry.accessCount(user1.address, SCOPE, 2)).should.eq(0);
+    });
+
+    it("should handle a mixed-owner batch with per-owner trusted servers", async function () {
+      await wireServers();
+      await registerServer(user1, server1);
+      await registerServer(user2, server2);
+      await registry.connect(user2).addData(SCOPE, DATA_HASH_2, META_HASH_2);
+
+      const u1a = await record(server1, user1.address, SCOPE, 1n, other.address, rid("b-mix-1"));
+      const u2a = await record(server2, user2.address, SCOPE, 1n, other.address, rid("b-mix-2"));
+      const cross = await record(server2, user1.address, SCOPE, 1n, other.address, rid("b-mix-3")); // user2's server signing for user1
+      const u1b = await record(server1, user1.address, SCOPE, 1n, user2.address, rid("b-mix-4"));
+
+      const recorded = await registry
+        .connect(recorder)
+        .recordDataAccessBatch.staticCall([u1a, u2a, cross, u1b]);
+      recorded.should.deep.eq([true, true, false, true]);
+      const tx = registry.connect(recorder).recordDataAccessBatch([u1a, u2a, cross, u1b]);
+      await expect(tx)
+        .to.emit(registry, "DataAccessRecorded")
+        .withArgs(dpId(user2.address, SCOPE), 1n, other.address, server2.address, u2a.recordId, 1n, 1n);
+      await expect(tx)
+        .to.emit(registry, "DataAccessSkipped")
+        .withArgs(cross.recordId, 2, UntrustedServerSel);
+      (await registry.totalAccesses(user1.address, SCOPE)).should.eq(2);
+      (await registry.totalAccesses(user2.address, SCOPE)).should.eq(1);
+    });
+
+    it("should emit exactly one of DataAccessRecorded / DataAccessSkipped per item", async function () {
+      await setupTrustedServer();
+      const items = [
+        await record(server1, user1.address, SCOPE, 1n, other.address, rid("b-one-1")),
+        await record(server2, user1.address, SCOPE, 1n, other.address, rid("b-one-2")),
+        await record(server1, user1.address, SCOPE, 1n, other.address, rid("b-one-3")),
+        await record(server1, user1.address, SCOPE, 9n, other.address, rid("b-one-4")),
+      ];
+      const tx = await registry.connect(recorder).recordDataAccessBatch(items);
+      const rc = await tx.wait();
+      const parsed = rc!.logs
+        .map((l) => registry.interface.parseLog({ topics: [...l.topics], data: l.data }))
+        .filter((x) => x !== null);
+      parsed.length.should.eq(items.length);
+      const names = parsed.map((x) => x!.name);
+      names.should.deep.eq([
+        "DataAccessRecorded",
+        "DataAccessSkipped",
+        "DataAccessRecorded",
+        "DataAccessSkipped",
+      ]);
+      parsed[0]!.args.recordId.should.eq(items[0].recordId);
+      parsed[1]!.args.recordId.should.eq(items[1].recordId);
+      parsed[1]!.args.index.should.eq(1n);
+      parsed[3]!.args.index.should.eq(3n);
+    });
+  });
 
   describe("Pause", () => {
     beforeEach(async () => {

--- a/test/data/dataRegistryV2.ts
+++ b/test/data/dataRegistryV2.ts
@@ -2111,6 +2111,24 @@ describe("DataRegistryV2", () => {
       (await registry.totalAccesses(user1.address, SCOPE)).should.eq(1);
     });
 
+    it("should skip an over-long scope and an odd-length signature on calldata length alone", async function () {
+      await setupTrustedServer();
+      const longScope = "x".repeat(257);
+      const tooLong = await record(server1, user1.address, longScope, 1n, other.address, rid("b-len-1"));
+      const good = await record(server1, user1.address, SCOPE, 1n, other.address, rid("b-len-2"));
+      const badSig = { ...good, recordId: rid("b-len-3"), signature: "0x" + "ab".repeat(64) }; // 64 bytes
+      const ScopeTooLongSel = registry.interface.getError("ScopeTooLong")!.selector;
+
+      const recorded = await registry
+        .connect(recorder)
+        .recordDataAccessBatch.staticCall([tooLong, good, badSig]);
+      recorded.should.deep.eq([false, true, false]);
+      const tx = registry.connect(recorder).recordDataAccessBatch([tooLong, good, badSig]);
+      await expect(tx).to.emit(registry, "DataAccessSkipped").withArgs(tooLong.recordId, 0, ScopeTooLongSel);
+      await expect(tx).to.emit(registry, "DataAccessSkipped").withArgs(badSig.recordId, 2, InvalidSignatureSel);
+      (await registry.totalAccesses(user1.address, SCOPE)).should.eq(1);
+    });
+
     it("should record the first occurrence of a duplicate recordId inside a batch and skip the rest", async function () {
       await setupTrustedServer();
       const recordId = rid("b-dup-in");

--- a/test/dataPortability/dataPortabilityEscrow.ts
+++ b/test/dataPortability/dataPortabilityEscrow.ts
@@ -3,6 +3,7 @@ import chaiAsPromised from "chai-as-promised";
 import { ethers, upgrades } from "hardhat";
 import {
   loadFixture,
+  takeSnapshot,
   time,
 } from "@nomicfoundation/hardhat-network-helpers";
 import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers";
@@ -2010,6 +2011,472 @@ describe("DataPortabilityEscrow", () => {
               [],
             ),
         ).to.be.revertedWithCustomError(escrow, "EnforcedPause");
+      });
+    });
+  });
+
+  describe("recordAccessAndSettleBatch (integration with DataRegistryV2)", () => {
+    let servers: DataPortabilityServersV2Implementation;
+    let registry: DataRegistryV2Implementation;
+    let server2: ethers.Wallet; // user2's trusted server (fresh key, never funded)
+    const scope = "vana.profile";
+    const scope2 = "vana.health";
+    const dataHash = ethers.id("data-1");
+    const metadataHash = ethers.id("meta-1");
+    const rid = (label: string) => ethers.id(label);
+
+    let RecordIdAlreadyUsedSel: string;
+    let UntrustedServerSel: string;
+    let UnknownVersionSel: string;
+
+    const eip712Domain = async (verifyingContract: string) => ({
+      name: "Vana Data Portability",
+      version: "1",
+      chainId: (await ethers.provider.getNetwork()).chainId,
+      verifyingContract,
+    });
+
+    const RecordDataAccessTypes = {
+      RecordDataAccess: [
+        { name: "ownerAddress", type: "address" },
+        { name: "scope", type: "string" },
+        { name: "version", type: "uint256" },
+        { name: "accessor", type: "address" },
+        { name: "recordId", type: "bytes32" },
+      ],
+    };
+
+    const registerServer = async (
+      serverOwner: HardhatEthersSigner,
+      serverSignerAddress: string,
+    ) => {
+      const registration = {
+        ownerAddress: serverOwner.address,
+        serverAddress: serverSignerAddress,
+        publicKey: "pubkey-" + serverSignerAddress.slice(2, 8),
+        serverUrl: "https://server.example",
+      };
+      const regSignature = await serverOwner.signTypedData(
+        await eip712Domain(await servers.getAddress()),
+        {
+          ServerRegistration: [
+            { name: "ownerAddress", type: "address" },
+            { name: "serverAddress", type: "address" },
+            { name: "publicKey", type: "string" },
+            { name: "serverUrl", type: "string" },
+          ],
+        },
+        registration,
+      );
+      await servers
+        .connect(relayer)
+        .registerServerWithSignature(registration, regSignature);
+    };
+
+    const record = async (
+      signer: HardhatEthersSigner | ethers.Wallet,
+      params: {
+        ownerAddress: string;
+        scope?: string;
+        version?: bigint;
+        accessor?: string;
+        recordId: string;
+      },
+    ) => {
+      const r = {
+        ownerAddress: params.ownerAddress,
+        scope: params.scope ?? scope,
+        version: params.version ?? 1n,
+        accessor: params.accessor ?? user2.address,
+        recordId: params.recordId,
+      };
+      const signature = await signer.signTypedData(
+        await eip712Domain(await registry.getAddress()),
+        RecordDataAccessTypes,
+        r,
+      );
+      return { ...r, signature };
+    };
+
+    const leg = (from: string, amount: bigint, ref = ZERO_REF, asset = NATIVE) => ({
+      from,
+      to: payee.address,
+      asset,
+      amount,
+      opKind: OpKind.DataAccess,
+      ref,
+    });
+
+    // Every log of a receipt, parsed against both contracts, in receipt order.
+    const parsedLogs = async (txHash: string) => {
+      const rc = await ethers.provider.getTransactionReceipt(txHash);
+      const regAddr = (await registry.getAddress()).toLowerCase();
+      const escAddr = (await escrow.getAddress()).toLowerCase();
+      return rc!.logs.map((l) => {
+        const addr = l.address.toLowerCase();
+        const iface =
+          addr === regAddr
+            ? registry.interface
+            : addr === escAddr
+              ? escrow.interface
+              : null;
+        const parsed = iface
+          ? iface.parseLog({ topics: [...l.topics], data: l.data })
+          : null;
+        return {
+          contract: addr === regAddr ? "registry" : addr === escAddr ? "escrow" : "other",
+          name: parsed?.name ?? "?",
+          args: parsed?.args,
+          topics: [...l.topics],
+          data: l.data,
+        };
+      });
+    };
+
+    beforeEach(async () => {
+      const ServersFactory = await ethers.getContractFactory(
+        "DataPortabilityServersV2Implementation",
+      );
+      const serversDeploy = await upgrades.deployProxy(
+        ServersFactory,
+        [ethers.ZeroAddress, owner.address],
+        { kind: "uups" },
+      );
+      servers = await ethers.getContractAt(
+        "DataPortabilityServersV2Implementation",
+        serversDeploy.target,
+      );
+
+      const RegistryFactory = await ethers.getContractFactory(
+        "DataRegistryV2Implementation",
+      );
+      const registryDeploy = await upgrades.deployProxy(
+        RegistryFactory,
+        [owner.address],
+        { kind: "uups" },
+      );
+      registry = await ethers.getContractAt(
+        "DataRegistryV2Implementation",
+        registryDeploy.target,
+      );
+      await registry
+        .connect(owner)
+        .setDataPortabilityServers(await servers.getAddress());
+      await registry
+        .connect(owner)
+        .grantRole(
+          await registry.ACCESS_RECORDER_ROLE(),
+          await escrow.getAddress(),
+        );
+
+      server2 = ethers.Wallet.createRandom();
+      await registerServer(user1, serverSigner.address);
+      await registerServer(user2, server2.address);
+
+      await registry.connect(user1).addData(scope, dataHash, metadataHash);
+      await registry.connect(user2).addData(scope2, dataHash, metadataHash);
+
+      await depositNativeFor(user1, parseEther("5"));
+      await depositNativeFor(user2, parseEther("5"));
+
+      RecordIdAlreadyUsedSel = registry.interface.getError("RecordIdAlreadyUsed")!.selector;
+      UntrustedServerSel = registry.interface.getError("UntrustedServer")!.selector;
+      UnknownVersionSel = registry.interface.getError("UnknownVersion")!.selector;
+    });
+
+    it("should revert when the data registry is unset", async function () {
+      const r = await record(serverSigner, { ownerAddress: user1.address, recordId: rid("e-unset") });
+      await expect(
+        escrow.connect(facilitator).recordAccessAndSettleBatch([{ record: r, ops: [] }]),
+      ).to.be.revertedWithCustomError(escrow, "DataRegistryNotSet");
+    });
+
+    describe("with registry wired", () => {
+      beforeEach(async () => {
+        await escrow.connect(owner).setDataRegistry(await registry.getAddress());
+      });
+
+      it("should only be callable by the facilitator and respect pause", async function () {
+        const r = await record(serverSigner, { ownerAddress: user1.address, recordId: rid("e-gate") });
+        await expect(
+          escrow.connect(user1).recordAccessAndSettleBatch([{ record: r, ops: [] }]),
+        ).to.be.revertedWithCustomError(escrow, "AccessControlUnauthorizedAccount");
+        await escrow.connect(owner).pause();
+        await expect(
+          escrow.connect(facilitator).recordAccessAndSettleBatch([{ record: r, ops: [] }]),
+        ).to.be.revertedWithCustomError(escrow, "EnforcedPause");
+      });
+
+      it("should revert on an empty batch", async function () {
+        await expect(
+          escrow.connect(facilitator).recordAccessAndSettleBatch([]),
+        ).to.be.revertedWithCustomError(escrow, "EmptyBatch");
+      });
+
+      it("should bubble the registry's batch-level revert (paused registry)", async function () {
+        const r = await record(serverSigner, { ownerAddress: user1.address, recordId: rid("e-regpause") });
+        await registry.connect(owner).pause();
+        await expect(
+          escrow.connect(facilitator).recordAccessAndSettleBatch([{ record: r, ops: [] }]),
+        ).to.be.revertedWithCustomError(registry, "EnforcedPause");
+      });
+
+      it("should accept MAX_ACCESS_BATCH items and reject one more", async function () {
+        const max = Number(await escrow.MAX_ACCESS_BATCH());
+        max.should.eq(200);
+        (await registry.MAX_ACCESS_BATCH()).should.eq(BigInt(max));
+        const bundles = [];
+        for (let i = 0; i <= max; i++) {
+          bundles.push({
+            record: await record(serverSigner, { ownerAddress: user1.address, recordId: rid(`e-max-${i}`) }),
+            ops: [leg(user1.address, parseEther("0.01"))],
+          });
+        }
+        await expect(escrow.connect(facilitator).recordAccessAndSettleBatch(bundles))
+          .to.be.revertedWithCustomError(escrow, "BatchTooLarge")
+          .withArgs(max + 1, max);
+
+        const full = bundles.slice(0, max);
+        const recorded = await escrow.connect(facilitator).recordAccessAndSettleBatch.staticCall(full);
+        recorded.length.should.eq(max);
+        recorded.every((x: boolean) => x).should.eq(true);
+        await escrow.connect(facilitator).recordAccessAndSettleBatch(full);
+        (await registry.totalAccesses(user1.address, scope)).should.eq(max);
+        (await escrow.balanceOf(user1.address, NATIVE)).should.eq(
+          parseEther("5") - parseEther("0.01") * BigInt(max),
+        );
+      });
+
+      it("batch of 1 should match recordAccessAndSettle: identical registry + Settled events, plus one AccessSettled marker", async function () {
+        const grantRef = rid("grant-ref");
+        const r = await record(serverSigner, { ownerAddress: user1.address, recordId: rid("e-equiv") });
+        const ops = [leg(user1.address, parseEther("1"), grantRef)];
+
+        const snap = await takeSnapshot();
+        const singleTx = await escrow
+          .connect(facilitator)
+          .recordAccessAndSettle(r.ownerAddress, r.scope, r.version, r.accessor, r.recordId, r.signature, ops);
+        const singleLogs = await parsedLogs(singleTx.hash);
+        const singleBal = await escrow.balanceOf(user1.address, NATIVE);
+        const singlePayee = await ethers.provider.getBalance(payee.address);
+        const singleTotal = await registry.totalAccesses(user1.address, scope);
+        await snap.restore();
+
+        const recorded = await escrow
+          .connect(facilitator)
+          .recordAccessAndSettleBatch.staticCall([{ record: r, ops }]);
+        recorded.should.deep.eq([true]);
+        const batchTx = await escrow
+          .connect(facilitator)
+          .recordAccessAndSettleBatch([{ record: r, ops }]);
+        const batchLogs = await parsedLogs(batchTx.hash);
+
+        singleLogs.map((l) => l.name).should.deep.eq(["DataAccessRecorded", "Settled"]);
+        batchLogs.map((l) => l.name).should.deep.eq(["DataAccessRecorded", "AccessSettled", "Settled"]);
+        // byte-identical shared events
+        const strip = (l: { topics: string[]; data: string }) => ({ topics: l.topics, data: l.data });
+        strip(batchLogs[0]).should.deep.eq(strip(singleLogs[0]));
+        strip(batchLogs[2]).should.deep.eq(strip(singleLogs[1]));
+        batchLogs[1].args!.index.should.eq(0n);
+        batchLogs[1].args!.recordId.should.eq(r.recordId);
+        batchLogs[1].args!.opCount.should.eq(1n);
+
+        (await escrow.balanceOf(user1.address, NATIVE)).should.eq(singleBal);
+        (await ethers.provider.getBalance(payee.address)).should.eq(singlePayee);
+        (await registry.totalAccesses(user1.address, scope)).should.eq(singleTotal);
+      });
+
+      it("should skip the second occurrence of a duplicate recordId inside a batch and not pay its legs", async function () {
+        const recordId = rid("e-dup-in");
+        const a = await record(serverSigner, { ownerAddress: user1.address, recordId });
+        const b = await record(serverSigner, { ownerAddress: user1.address, recordId, accessor: payee.address });
+        const c = await record(serverSigner, { ownerAddress: user1.address, recordId: rid("e-dup-in-2") });
+        const bundles = [
+          { record: a, ops: [leg(user1.address, parseEther("1"))] },
+          { record: b, ops: [leg(user1.address, parseEther("1"))] },
+          { record: c, ops: [leg(user1.address, parseEther("1"))] },
+        ];
+        const recorded = await escrow.connect(facilitator).recordAccessAndSettleBatch.staticCall(bundles);
+        recorded.should.deep.eq([true, false, true]);
+        const tx = await escrow.connect(facilitator).recordAccessAndSettleBatch(bundles);
+        const logs = await parsedLogs(tx.hash);
+        logs.map((l) => l.name).should.deep.eq([
+          "DataAccessRecorded",
+          "DataAccessSkipped",
+          "DataAccessRecorded",
+          "AccessSettled",
+          "Settled",
+          "AccessSettled",
+          "Settled",
+        ]);
+        logs[1].args!.reason.should.eq(RecordIdAlreadyUsedSel);
+        logs[3].args!.index.should.eq(0n);
+        logs[5].args!.index.should.eq(2n);
+        (await escrow.balanceOf(user1.address, NATIVE)).should.eq(parseEther("3"));
+        (await registry.totalAccesses(user1.address, scope)).should.eq(2);
+      });
+
+      it("should skip a recordId already used by an earlier batch (or single call) and not pay its legs", async function () {
+        const recordId = rid("e-dup-across");
+        const a = await record(serverSigner, { ownerAddress: user1.address, recordId });
+        const b = await record(serverSigner, { ownerAddress: user1.address, recordId: rid("e-dup-across-2") });
+        await escrow.connect(facilitator).recordAccessAndSettleBatch([{ record: a, ops: [leg(user1.address, parseEther("1"))] }]);
+
+        const bundles = [
+          { record: a, ops: [leg(user1.address, parseEther("1"))] },
+          { record: b, ops: [leg(user1.address, parseEther("1"))] },
+        ];
+        const recorded = await escrow.connect(facilitator).recordAccessAndSettleBatch.staticCall(bundles);
+        recorded.should.deep.eq([false, true]);
+        await expect(escrow.connect(facilitator).recordAccessAndSettleBatch(bundles))
+          .to.emit(registry, "DataAccessSkipped")
+          .withArgs(recordId, 0, RecordIdAlreadyUsedSel);
+        (await escrow.balanceOf(user1.address, NATIVE)).should.eq(parseEther("3"));
+        (await registry.totalAccesses(user1.address, scope)).should.eq(2);
+
+        // A single call on the same recordId still reverts as before.
+        await expect(
+          escrow.connect(facilitator).recordAccessAndSettle(a.ownerAddress, a.scope, a.version, a.accessor, a.recordId, a.signature, []),
+        ).to.be.revertedWithCustomError(registry, "RecordIdAlreadyUsed");
+      });
+
+      it("should skip only the item signed by an untrusted server and not pay its legs", async function () {
+        const good = await record(serverSigner, { ownerAddress: user1.address, recordId: rid("e-ut-1") });
+        const bad = await record(server2, { ownerAddress: user1.address, recordId: rid("e-ut-2") }); // user2's server, user1's data
+        const good2 = await record(serverSigner, { ownerAddress: user1.address, recordId: rid("e-ut-3") });
+        const bundles = [
+          { record: good, ops: [leg(user1.address, parseEther("1"))] },
+          { record: bad, ops: [leg(user1.address, parseEther("1"))] },
+          { record: good2, ops: [leg(user1.address, parseEther("1"))] },
+        ];
+        const recorded = await escrow.connect(facilitator).recordAccessAndSettleBatch.staticCall(bundles);
+        recorded.should.deep.eq([true, false, true]);
+        await expect(escrow.connect(facilitator).recordAccessAndSettleBatch(bundles))
+          .to.emit(registry, "DataAccessSkipped")
+          .withArgs(bad.recordId, 1, UntrustedServerSel);
+        (await registry.isRecordIdUsed(bad.recordId)).should.eq(false);
+        (await escrow.balanceOf(user1.address, NATIVE)).should.eq(parseEther("3"));
+      });
+
+      it("should skip only the item with an unknown version and not pay its legs", async function () {
+        const good = await record(serverSigner, { ownerAddress: user1.address, recordId: rid("e-uv-1") });
+        const bad = await record(serverSigner, { ownerAddress: user1.address, version: 2n, recordId: rid("e-uv-2") });
+        const bundles = [
+          { record: bad, ops: [leg(user1.address, parseEther("1"))] },
+          { record: good, ops: [leg(user1.address, parseEther("1"))] },
+        ];
+        const recorded = await escrow.connect(facilitator).recordAccessAndSettleBatch.staticCall(bundles);
+        recorded.should.deep.eq([false, true]);
+        await expect(escrow.connect(facilitator).recordAccessAndSettleBatch(bundles))
+          .to.emit(registry, "DataAccessSkipped")
+          .withArgs(bad.recordId, 0, UnknownVersionSel);
+        (await escrow.balanceOf(user1.address, NATIVE)).should.eq(parseEther("4"));
+        (await registry.accessCount(user1.address, scope, 2)).should.eq(0);
+      });
+
+      it("should settle a mixed-owner batch against each item's own payer", async function () {
+        const u1 = await record(serverSigner, { ownerAddress: user1.address, recordId: rid("e-mix-1") });
+        const u2 = await record(server2, { ownerAddress: user2.address, scope: scope2, accessor: user1.address, recordId: rid("e-mix-2") });
+        const cross = await record(serverSigner, { ownerAddress: user2.address, scope: scope2, recordId: rid("e-mix-3") }); // user1's server, user2's data
+        const bundles = [
+          { record: u1, ops: [leg(user2.address, parseEther("1"))] }, // user2 (accessor) pays for reading user1
+          { record: u2, ops: [leg(user1.address, parseEther("2"))] }, // user1 (accessor) pays for reading user2
+          { record: cross, ops: [leg(user1.address, parseEther("1"))] },
+        ];
+        const recorded = await escrow.connect(facilitator).recordAccessAndSettleBatch.staticCall(bundles);
+        recorded.should.deep.eq([true, true, false]);
+        const tx = escrow.connect(facilitator).recordAccessAndSettleBatch(bundles);
+        await expect(tx)
+          .to.emit(registry, "DataAccessRecorded")
+          .withArgs(await registry.dataPointId(user2.address, scope2), 1n, user1.address, server2.address, u2.recordId, 1n, 1n);
+        await expect(tx).to.emit(registry, "DataAccessSkipped").withArgs(cross.recordId, 2, UntrustedServerSel);
+        (await escrow.balanceOf(user1.address, NATIVE)).should.eq(parseEther("3"));
+        (await escrow.balanceOf(user2.address, NATIVE)).should.eq(parseEther("4"));
+        (await registry.totalAccesses(user1.address, scope)).should.eq(1);
+        (await registry.totalAccesses(user2.address, scope2)).should.eq(1);
+      });
+
+      it("should revert the whole batch when any payment leg fails, recording nothing", async function () {
+        const a = await record(serverSigner, { ownerAddress: user1.address, recordId: rid("e-leg-1") });
+        const b = await record(serverSigner, { ownerAddress: user1.address, recordId: rid("e-leg-2") });
+        await expect(
+          escrow.connect(facilitator).recordAccessAndSettleBatch([
+            { record: a, ops: [leg(user1.address, parseEther("1"))] },
+            { record: b, ops: [leg(user1.address, parseEther("100"))] },
+          ]),
+        ).to.be.revertedWithCustomError(escrow, "InsufficientBalance");
+        (await registry.isRecordIdUsed(a.recordId)).should.eq(false);
+        (await registry.isRecordIdUsed(b.recordId)).should.eq(false);
+        (await escrow.balanceOf(user1.address, NATIVE)).should.eq(parseEther("5"));
+
+        await expect(
+          escrow.connect(facilitator).recordAccessAndSettleBatch([
+            { record: a, ops: [leg(user1.address, 0n)] },
+          ]),
+        ).to.be.revertedWithCustomError(escrow, "ZeroAmount");
+      });
+
+      it("should group Settled legs per read in receipt order via AccessSettled markers", async function () {
+        const a = await record(serverSigner, { ownerAddress: user1.address, recordId: rid("e-grp-1") });
+        const skipped = await record(serverSigner, { ownerAddress: user1.address, version: 7n, recordId: rid("e-grp-2") });
+        const noLegs = await record(serverSigner, { ownerAddress: user1.address, recordId: rid("e-grp-3") });
+        const twoLegs = await record(server2, { ownerAddress: user2.address, scope: scope2, recordId: rid("e-grp-4") });
+        const refA = rid("ref-a");
+        const refB = rid("ref-b");
+        const bundles = [
+          { record: a, ops: [leg(user1.address, parseEther("1"), refA)] },
+          { record: skipped, ops: [leg(user1.address, parseEther("1"))] },
+          { record: noLegs, ops: [] },
+          { record: twoLegs, ops: [leg(user2.address, parseEther("1"), refB), leg(user2.address, parseEther("0.5"), refB)] },
+        ];
+        const tx = await escrow.connect(facilitator).recordAccessAndSettleBatch(bundles);
+        const logs = await parsedLogs(tx.hash);
+        logs.map((l) => `${l.contract}:${l.name}`).should.deep.eq([
+          "registry:DataAccessRecorded",
+          "registry:DataAccessSkipped",
+          "registry:DataAccessRecorded",
+          "registry:DataAccessRecorded",
+          "escrow:AccessSettled",
+          "escrow:Settled",
+          "escrow:AccessSettled",
+          "escrow:AccessSettled",
+          "escrow:Settled",
+          "escrow:Settled",
+        ]);
+        // Reconstruct per-read grouping from the receipt alone.
+        const groups: Record<string, { ref: string; amount: bigint }[]> = {};
+        let current: string | null = null;
+        for (const l of logs) {
+          if (l.name === "AccessSettled") {
+            current = l.args!.recordId;
+            groups[current!] = [];
+            Number(l.args!.opCount).should.eq(bundles[Number(l.args!.index)].ops.length);
+          } else if (l.name === "Settled") {
+            groups[current!].push({ ref: l.args!.ref, amount: l.args!.amount });
+          }
+        }
+        Object.keys(groups).should.deep.eq([a.recordId, noLegs.recordId, twoLegs.recordId]);
+        groups[a.recordId].should.deep.eq([{ ref: refA, amount: parseEther("1") }]);
+        groups[noLegs.recordId].should.deep.eq([]);
+        groups[twoLegs.recordId].should.deep.eq([
+          { ref: refB, amount: parseEther("1") },
+          { ref: refB, amount: parseEther("0.5") },
+        ]);
+      });
+
+      it("should settle ERC-20 legs in a batch", async function () {
+        await depositTokenFor(user1, parseEther("10"));
+        const tokenAddr = await token.getAddress();
+        const a = await record(serverSigner, { ownerAddress: user1.address, recordId: rid("e-erc20-1") });
+        const b = await record(serverSigner, { ownerAddress: user1.address, recordId: rid("e-erc20-2") });
+        const payeeBefore = await token.balanceOf(payee.address);
+        await escrow.connect(facilitator).recordAccessAndSettleBatch([
+          { record: a, ops: [leg(user1.address, parseEther("1"), ZERO_REF, tokenAddr)] },
+          { record: b, ops: [leg(user1.address, parseEther("2"), ZERO_REF, tokenAddr)] },
+        ]);
+        (await escrow.balanceOf(user1.address, tokenAddr)).should.eq(parseEther("7"));
+        (await token.balanceOf(payee.address)).should.eq(payeeBefore + parseEther("3"));
+        (await registry.totalAccesses(user1.address, scope)).should.eq(2);
       });
     });
   });

--- a/test/dataPortability/dataPortabilityEscrow.ts
+++ b/test/dataPortability/dataPortabilityEscrow.ts
@@ -2247,6 +2247,22 @@ describe("DataPortabilityEscrow", () => {
         );
       });
 
+      it("should reject a bundle with more than MAX_ACCESS_BUNDLE_OPS legs", async function () {
+        const max = Number(await escrow.MAX_ACCESS_BUNDLE_OPS());
+        max.should.eq(8);
+        const r = await record(serverSigner, { ownerAddress: user1.address, recordId: rid("e-ops") });
+        const ops = Array.from({ length: max + 1 }, () => leg(user1.address, parseEther("0.1")));
+        await expect(escrow.connect(facilitator).recordAccessAndSettleBatch([{ record: r, ops }]))
+          .to.be.revertedWithCustomError(escrow, "TooManyOps")
+          .withArgs(0, max + 1, max);
+        (await registry.isRecordIdUsed(r.recordId)).should.eq(false);
+
+        const recorded = await escrow
+          .connect(facilitator)
+          .recordAccessAndSettleBatch.staticCall([{ record: r, ops: ops.slice(0, max) }]);
+        recorded.should.deep.eq([true]);
+      });
+
       it("batch of 1 should match recordAccessAndSettle: identical registry + Settled events, plus one AccessSettled marker", async function () {
         const grantRef = rid("grant-ref");
         const r = await record(serverSigner, { ownerAddress: user1.address, recordId: rid("e-equiv") });
@@ -2416,7 +2432,9 @@ describe("DataPortabilityEscrow", () => {
         ).to.be.revertedWithCustomError(escrow, "ZeroAmount");
       });
 
-      it("should group Settled legs per read in receipt order via AccessSettled markers", async function () {
+      it("should group Settled legs per read in receipt order via AccessSettled markers (ERC-20 Transfer logs interleave)", async function () {
+        await depositTokenFor(user2, parseEther("10"));
+        const tokenAddr = await token.getAddress();
         const a = await record(serverSigner, { ownerAddress: user1.address, recordId: rid("e-grp-1") });
         const skipped = await record(serverSigner, { ownerAddress: user1.address, version: 7n, recordId: rid("e-grp-2") });
         const noLegs = await record(serverSigner, { ownerAddress: user1.address, recordId: rid("e-grp-3") });
@@ -2427,7 +2445,8 @@ describe("DataPortabilityEscrow", () => {
           { record: a, ops: [leg(user1.address, parseEther("1"), refA)] },
           { record: skipped, ops: [leg(user1.address, parseEther("1"))] },
           { record: noLegs, ops: [] },
-          { record: twoLegs, ops: [leg(user2.address, parseEther("1"), refB), leg(user2.address, parseEther("0.5"), refB)] },
+          // one ERC-20 leg (emits the token's Transfer between the marker and Settled) + one native leg
+          { record: twoLegs, ops: [leg(user2.address, parseEther("1"), refB, tokenAddr), leg(user2.address, parseEther("0.5"), refB)] },
         ];
         const tx = await escrow.connect(facilitator).recordAccessAndSettleBatch(bundles);
         const logs = await parsedLogs(tx.hash);
@@ -2440,13 +2459,16 @@ describe("DataPortabilityEscrow", () => {
           "escrow:Settled",
           "escrow:AccessSettled",
           "escrow:AccessSettled",
+          "other:?", // ERC-20 Transfer emitted by the token inside _payout
           "escrow:Settled",
           "escrow:Settled",
         ]);
-        // Reconstruct per-read grouping from the receipt alone.
+        // Reconstruct per-read grouping from the receipt alone, filtering on
+        // the escrow's own Settled events (token / recipient logs interleave).
         const groups: Record<string, { ref: string; amount: bigint }[]> = {};
         let current: string | null = null;
         for (const l of logs) {
+          if (l.contract !== "escrow") continue;
           if (l.name === "AccessSettled") {
             current = l.args!.recordId;
             groups[current!] = [];

--- a/test/dataPortability/dataPortabilityEscrowBatchGas.ts
+++ b/test/dataPortability/dataPortabilityEscrowBatchGas.ts
@@ -17,10 +17,10 @@ should();
  * Gas measurement for `recordAccessAndSettleBatch`, printed as a table.
  *
  * Scenario (chosen to be the EXPENSIVE, realistic shape, not the cheapest):
- *   - every item is a different data owner with its own trusted server and
- *     its own data point → every registry slot touched is cold, every
- *     counter goes 0 → nonzero, every `_isTrustedServer` lookup is a fresh
- *     server
+ *   - every item is a different data owner with its own trusted server
+ *     (production-length public key + relay URL) and its own data point →
+ *     every registry slot touched is cold, every counter goes 0 → nonzero,
+ *     every `_isTrustedServer` lookup is a fresh server
  *   - first access on each data point (both counters zero → nonzero)
  *   - one ERC-20 payment leg per item, one payer (the accessor / builder),
  *     one payee (the protocol fee recipient) — the production shape
@@ -35,6 +35,11 @@ describe("recordAccessAndSettleBatch gas", () => {
   const MAX = Math.max(...SIZES);
   const FEE = 10_000n; // 0.01 USDC (6 decimals), the production access fee
   const scopeFor = (i: number) => `vana.profile.${String(i).padStart(3, "0")}`; // 16 bytes
+  // Production server registrations: 132-char uncompressed public key and a
+  // ~47-char relay URL. `_isTrustedServer` copies both out of storage per
+  // record, so short fixture strings would understate the per-read cost.
+  const prodPublicKey = (i: number) => "0x04" + i.toString(16).padStart(130, "0");
+  const prodServerUrl = (i: number) => `https://${i.toString(16).padStart(24, "0")}.relay.vana.com`;
 
   let deployer: HardhatEthersSigner;
   let owner: HardhatEthersSigner;
@@ -136,8 +141,8 @@ describe("recordAccessAndSettleBatch gas", () => {
       const registration = {
         ownerAddress: dataOwner.address,
         serverAddress: server.address,
-        publicKey: "pk-" + i,
-        serverUrl: "https://ps-" + i + ".example",
+        publicKey: prodPublicKey(i),
+        serverUrl: prodServerUrl(i),
       };
       const regSig = await dataOwner.signTypedData(
         serversDomain,

--- a/test/dataPortability/dataPortabilityEscrowBatchGas.ts
+++ b/test/dataPortability/dataPortabilityEscrowBatchGas.ts
@@ -1,0 +1,264 @@
+import chai, { should } from "chai";
+import chaiAsPromised from "chai-as-promised";
+import { ethers, upgrades } from "hardhat";
+import { takeSnapshot } from "@nomicfoundation/hardhat-network-helpers";
+import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers";
+import {
+  DataPortabilityEscrowImplementation,
+  DataPortabilityServersV2Implementation,
+  DataRegistryV2Implementation,
+  ERC20Mock,
+} from "../../typechain-types";
+
+chai.use(chaiAsPromised);
+should();
+
+/**
+ * Gas measurement for `recordAccessAndSettleBatch`, printed as a table.
+ *
+ * Scenario (chosen to be the EXPENSIVE, realistic shape, not the cheapest):
+ *   - every item is a different data owner with its own trusted server and
+ *     its own data point → every registry slot touched is cold, every
+ *     counter goes 0 → nonzero, every `_isTrustedServer` lookup is a fresh
+ *     server
+ *   - first access on each data point (both counters zero → nonzero)
+ *   - one ERC-20 payment leg per item, one payer (the accessor / builder),
+ *     one payee (the protocol fee recipient) — the production shape
+ *   - 16-byte scopes, as in production (`vana.profile`-length)
+ *
+ * Numbers with the real USDC.e (FiatTokenV2 proxy) come from the mainnet
+ * fork script `scripts/gas/measureBatchOnFork.ts`; this suite uses
+ * ERC20Mock so it runs offline and is deterministic.
+ */
+describe("recordAccessAndSettleBatch gas", () => {
+  const SIZES = [1, 10, 25, 50, 100, 200];
+  const MAX = Math.max(...SIZES);
+  const FEE = 10_000n; // 0.01 USDC (6 decimals), the production access fee
+  const scopeFor = (i: number) => `vana.profile.${String(i).padStart(3, "0")}`; // 16 bytes
+
+  let deployer: HardhatEthersSigner;
+  let owner: HardhatEthersSigner;
+  let facilitator: HardhatEthersSigner;
+  let relayer: HardhatEthersSigner;
+  let builder: HardhatEthersSigner; // accessor + payer
+  let payee: HardhatEthersSigner;
+
+  let escrow: DataPortabilityEscrowImplementation;
+  let servers: DataPortabilityServersV2Implementation;
+  let registry: DataRegistryV2Implementation;
+  let token: ERC20Mock;
+
+  type Item = {
+    record: {
+      ownerAddress: string;
+      scope: string;
+      version: bigint;
+      accessor: string;
+      recordId: string;
+      signature: string;
+    };
+    ops: {
+      from: string;
+      to: string;
+      asset: string;
+      amount: bigint;
+      opKind: bigint;
+      ref: string;
+    }[];
+  };
+  const items: Item[] = [];
+
+  const domain = async (verifyingContract: string) => ({
+    name: "Vana Data Portability",
+    version: "1",
+    chainId: (await ethers.provider.getNetwork()).chainId,
+    verifyingContract,
+  });
+
+  before(async function () {
+    this.timeout(0);
+    [deployer, owner, facilitator, relayer, builder, payee] =
+      await ethers.getSigners();
+
+    escrow = await ethers.getContractAt(
+      "DataPortabilityEscrowImplementation",
+      (
+        await upgrades.deployProxy(
+          await ethers.getContractFactory("DataPortabilityEscrowImplementation"),
+          [owner.address, facilitator.address],
+          { kind: "uups" },
+        )
+      ).target,
+    );
+    servers = await ethers.getContractAt(
+      "DataPortabilityServersV2Implementation",
+      (
+        await upgrades.deployProxy(
+          await ethers.getContractFactory("DataPortabilityServersV2Implementation"),
+          [ethers.ZeroAddress, owner.address],
+          { kind: "uups" },
+        )
+      ).target,
+    );
+    registry = await ethers.getContractAt(
+      "DataRegistryV2Implementation",
+      (
+        await upgrades.deployProxy(
+          await ethers.getContractFactory("DataRegistryV2Implementation"),
+          [owner.address],
+          { kind: "uups" },
+        )
+      ).target,
+    );
+    token = await (await ethers.getContractFactory("ERC20Mock")).deploy("USD Coin", "USDC");
+    await token.waitForDeployment();
+
+    await registry.connect(owner).setDataPortabilityServers(await servers.getAddress());
+    await registry.connect(owner).grantRole(await registry.ACCESS_RECORDER_ROLE(), await escrow.getAddress());
+    await escrow.connect(owner).setDataRegistry(await registry.getAddress());
+    await escrow.connect(owner).setTokenWhitelisted(await token.getAddress(), true);
+
+    // Builder funds its escrow account once.
+    const tokenAddr = await token.getAddress();
+    await token.connect(deployer).transfer(builder.address, FEE * BigInt(MAX) * 10n);
+    await token.connect(builder).approve(await escrow.getAddress(), FEE * BigInt(MAX) * 10n);
+    await escrow.connect(builder).depositToken(builder.address, tokenAddr, FEE * BigInt(MAX) * 10n);
+
+    const serversDomain = await domain(await servers.getAddress());
+    const registryDomain = await domain(await registry.getAddress());
+    const grantRef = ethers.id("grant-ref");
+
+    for (let i = 0; i < MAX; i++) {
+      const dataOwner = ethers.Wallet.createRandom();
+      const server = ethers.Wallet.createRandom();
+      const scope = scopeFor(i);
+
+      const registration = {
+        ownerAddress: dataOwner.address,
+        serverAddress: server.address,
+        publicKey: "pk-" + i,
+        serverUrl: "https://ps-" + i + ".example",
+      };
+      const regSig = await dataOwner.signTypedData(
+        serversDomain,
+        {
+          ServerRegistration: [
+            { name: "ownerAddress", type: "address" },
+            { name: "serverAddress", type: "address" },
+            { name: "publicKey", type: "string" },
+            { name: "serverUrl", type: "string" },
+          ],
+        },
+        registration,
+      );
+      await servers.connect(relayer).registerServerWithSignature(registration, regSig);
+
+      const dataHash = ethers.id("data-" + i);
+      const metadataHash = ethers.id("meta-" + i);
+      const addSig = await dataOwner.signTypedData(
+        registryDomain,
+        {
+          AddData: [
+            { name: "ownerAddress", type: "address" },
+            { name: "scope", type: "string" },
+            { name: "dataHash", type: "bytes32" },
+            { name: "metadataHash", type: "bytes32" },
+            { name: "expectedVersion", type: "uint256" },
+          ],
+        },
+        { ownerAddress: dataOwner.address, scope, dataHash, metadataHash, expectedVersion: 1n },
+      );
+      await registry
+        .connect(relayer)
+        .addDataWithSignature(dataOwner.address, scope, dataHash, metadataHash, 1n, addSig);
+
+      const recordId = ethers.id("record-" + i);
+      const record = {
+        ownerAddress: dataOwner.address,
+        scope,
+        version: 1n,
+        accessor: builder.address,
+        recordId,
+      };
+      const signature = await server.signTypedData(
+        registryDomain,
+        {
+          RecordDataAccess: [
+            { name: "ownerAddress", type: "address" },
+            { name: "scope", type: "string" },
+            { name: "version", type: "uint256" },
+            { name: "accessor", type: "address" },
+            { name: "recordId", type: "bytes32" },
+          ],
+        },
+        record,
+      );
+      items.push({
+        record: { ...record, signature },
+        ops: [
+          {
+            from: builder.address,
+            to: payee.address,
+            asset: tokenAddr,
+            amount: FEE,
+            opKind: 5n, // DataAccess
+            ref: grantRef,
+          },
+        ],
+      });
+    }
+  });
+
+  it("prints gas per batch size (distinct owners, first access, one ERC-20 leg each)", async function () {
+    this.timeout(0);
+    const rows: { n: number; gas: bigint; calldata: number }[] = [];
+
+    // Reference: the single-record path, same item.
+    {
+      const snap = await takeSnapshot();
+      const r = items[0].record;
+      const tx = await escrow
+        .connect(facilitator)
+        .recordAccessAndSettle(r.ownerAddress, r.scope, r.version, r.accessor, r.recordId, r.signature, items[0].ops);
+      const rc = await tx.wait();
+      const calldata = (tx.data.length - 2) / 2;
+      console.log(`\n  recordAccessAndSettle (single, reference): gas=${rc!.gasUsed} calldata=${calldata}B`);
+      await snap.restore();
+    }
+
+    for (const n of SIZES) {
+      const snap = await takeSnapshot();
+      const bundles = items.slice(0, n);
+      const tx = await escrow.connect(facilitator).recordAccessAndSettleBatch(bundles);
+      const rc = await tx.wait();
+      rc!.status!.should.eq(1);
+      (await registry.isRecordIdUsed(items[n - 1].record.recordId)).should.eq(true);
+      rows.push({ n, gas: rc!.gasUsed, calldata: (tx.data.length - 2) / 2 });
+      await snap.restore();
+    }
+
+    const BLOCK = 60_000_000n;
+    const BUDGET = (BLOCK * 80n) / 100n;
+    console.log("\n  | batch | gasUsed | gas/read | marginal gas/read vs prev | calldata bytes | % of 60M block |");
+    console.log("  |---:|---:|---:|---:|---:|---:|");
+    let prev: { n: number; gas: bigint } | null = null;
+    for (const row of rows) {
+      const marginal = prev ? (row.gas - prev.gas) / BigInt(row.n - prev.n) : null;
+      console.log(
+        `  | ${row.n} | ${row.gas.toLocaleString("en-US")} | ${(row.gas / BigInt(row.n)).toLocaleString("en-US")} | ${
+          marginal === null ? "—" : marginal.toLocaleString("en-US")
+        } | ${row.calldata.toLocaleString("en-US")} | ${(Number((row.gas * 10000n) / BLOCK) / 100).toFixed(2)}% |`,
+      );
+      prev = row;
+    }
+    const last = rows[rows.length - 1];
+    const marginal200 = (last.gas - rows[rows.length - 2].gas) / BigInt(last.n - rows[rows.length - 2].n);
+    console.log(`\n  block gas budget with 20% margin: ${BUDGET.toLocaleString("en-US")}`);
+    console.log(`  largest measured batch: ${last.n} at ${last.gas.toLocaleString("en-US")} gas (${(Number((last.gas * 10000n) / BLOCK) / 100).toFixed(2)}% of block)`);
+    console.log(`  marginal gas per read at the top of the range: ${marginal200.toLocaleString("en-US")}`);
+    console.log(`  MAX_ACCESS_BATCH (contract cap): ${await escrow.MAX_ACCESS_BATCH()}\n`);
+
+    // Guard: the largest allowed batch must fit a block with 20% margin.
+    (last.gas < BUDGET).should.eq(true, `batch of ${last.n} exceeds 80% of a 60M block`);
+  });
+});


### PR DESCRIPTION
## Problem

Every paid read settles as its own `recordAccessAndSettle` transaction, which emits one `DataAccessRecorded`. The relayer submits one tx per read, so the ceiling on recorded reads is the relayer's tx rate, not the chain's: a mainnet `recordAccessAndSettle` uses 222,771 gas (tx `0xfc0bb12e707315da1d8376a2a624d636a0089c17fc757c14d114ab3ab450c20b`, one USDC.e leg), so a 60M-gas block could hold ~269 of them, while the relayer sends about 50 per minute. Neither the registry nor the escrow has an entry point that takes more than one access record per call, so the gateway cannot amortise the per-tx overhead even if it wanted to.

This PR adds that entry point on both contracts and measures what it buys.

## Review asks

Three calls that deserve a reviewer's opinion, each argued under Design decisions below:

1. **Failure semantics.** A record the registry rejects (duplicate recordId, untrusted server, unknown version, malformed signature) is skipped and emits `DataAccessSkipped` with the error selector; a payment leg that cannot pay reverts the whole batch.
2. **The `AccessSettled` marker** emitted before each recorded item's `Settled` legs, so a receipt alone groups legs per read.
3. **Caps:** 200 items per batch and 8 legs per item.

Two things to arrange if the approach is accepted: book the Nethermind audit slot (registry upgrade first, then escrow), and assign an owner for the gateway side, which is design-only here (last section).

## What changes

- `DataRegistryV2.recordDataAccessBatch(AccessRecord[] records) returns (bool[] recorded)` — records up to `MAX_ACCESS_BATCH` accesses in one call, gated by `ACCESS_RECORDER_ROLE` exactly like `recordDataAccess`.
- `DataPortabilityEscrow.recordAccessAndSettleBatch(AccessBundle[] bundles) returns (bool[] recorded)` — one registry call for all records, then each recorded item's `SettleOp[]` legs, gated by `FACILITATOR_ROLE` exactly like `recordAccessAndSettle`.
- New events `DataAccessSkipped` (registry) and `AccessSettled` (escrow); new errors `EmptyBatch`, `BatchTooLarge`; new constant `MAX_ACCESS_BATCH = 200` on both.
- `recordDataAccess` is unchanged in behaviour. Its state-mutating tail was factored into `_commitAccess` (shared with the batch path) and its digest into `_recordAccessDigest`; the checks, their order and every revert are as before.
- Two upgrade scripts (`deploy/dataPortability/*-upgrade-batchAccess.ts`), not run. Registry first, then escrow.
- Gas scripts under `scripts/gas/` (mainnet-fork replay and measurement; read-only, nothing broadcast).

Nothing is deployed by this PR. **The upgrade needs a Nethermind audit slot before it can ship.**

## Design decisions

**Shape: array of (record, ops) pairs.** `AccessBundle { AccessRecord record; SettleOp[] ops; }[]`, not a flat `AccessRecord[]` + `SettleOp[]`. The gateway settles each read's fee legs against that read's own recordId, and with skip-and-emit semantics the contract must know which legs belong to which record so a skipped record's legs are not paid. A flat `SettleOp[]` cannot express that. The pairs cost one calldata-to-memory copy of the records (the registry takes one array); measured, it is a small part of the marginal cost.

**Failure semantics: skip-and-emit per item, all-or-nothing within an item, whole-batch revert on a payment leg.**
- A record the registry rejects (`RecordIdAlreadyUsed`, `InvalidSignature`, `UntrustedServer`, `UnknownVersion`) is skipped: the registry emits `DataAccessSkipped(recordId, index, reason)` where `reason` is the selector `recordDataAccess` would have reverted with, and none of that item's legs run. Other items are unaffected. Why: these are the failures the relayer causes itself through its own transaction ordering (a re-sent receipt after an ambiguous broadcast, a server deregistration or version rollback it submitted earlier in the same drain). Simulation cannot close that window, and all-or-nothing would burn a full batch's gas and stall the queue on one stale item.
- A record it commits emits `DataAccessRecorded` (byte-identical to the single path), then `AccessSettled(index, recordId, opCount)` on the escrow, then one `Settled` per leg.
- A leg that cannot execute (`ZeroAmount`, `ZeroAddress`, `InsufficientBalance`, transfer failure) reverts the whole batch, as it reverts the single call. Escrow balances only move through the facilitator, so the facilitator can simulate this away before broadcast; there is no external race to tolerate.
- Batch-level preconditions revert the whole call: role, pause (either contract), registry or servers pointer unset, empty batch, oversize batch.

**Receipt is self-describing.** Per item exactly one of `DataAccessRecorded` / `DataAccessSkipped` (both index-tagged). For a recorded item, the `Settled` events between its `AccessSettled` marker and the next marker are its legs; `opCount` lets a consumer check completeness. The gateway can map every recordId to landed / skipped-with-reason from the receipt alone, and a third-party indexer can group payment legs per read without the calldata. The marker is needed because all registry events precede all escrow events in the receipt, so adjacency alone cannot attribute `Settled` events to reads.

**Signatures.** Each `AccessRecord` carries its own server signature over its own EIP-712 payload (`RECORD_ACCESS_TYPEHASH`, unchanged). No aggregate signature. The batch path uses `ECDSA.tryRecover` so a malformed signature becomes a per-item `InvalidSignature` skip instead of an ECDSA library revert; the single path keeps `ECDSA.recover` and its exact errors.

**Storage.** No storage changes on either proxy. Additions are constants, events, errors, a calldata struct and functions. `DataRegistryV2StorageV1.sol` and `DataPortabilityEscrowStorageV1.sol` are untouched.

**Roles.** `FACILITATOR_ROLE` on the escrow and `ACCESS_RECORDER_ROLE` on the registry remain the only gates. The escrow already holds the recorder role on the registry, so no role grant is needed for the upgrade.

**Cap.** `MAX_ACCESS_BATCH = 200` on both contracts (the escrow cap can never exceed the registry cap) and `MAX_ACCESS_BUNDLE_OPS = 8` legs per item, so one batch call has a bounded amount of work. 200 was chosen because a 200-item batch measures at 48% of a block and geth's 128 KiB transaction size limit already caps a broadcastable batch at ~185 items; a higher on-chain cap would buy nothing today.

**Codex review.** High-effort review of the diff found no P1. Three P2s, all fixed in the second commit: unbounded legs per bundle (now `MAX_ACCESS_BUNDLE_OPS`), oversized scope / signature could cost hashing and memory copy before the skip (now rejected on calldata length: `ScopeTooLong`, `InvalidSignature`), and the marker doc had to state that only escrow `Settled` events count because ERC-20 `Transfer` logs interleave (doc fixed, grouping test now uses an ERC-20 leg).

## Test matrix

Registry (`test/data/dataRegistryV2.ts`, `recordDataAccessBatch`, 14 tests) and escrow (`test/dataPortability/dataPortabilityEscrow.ts`, `recordAccessAndSettleBatch`, 15 tests). Existing fixtures for trusted servers and data points are reused.

| Case | Registry | Escrow |
|---|---|---|
| Batch of 1 vs single call: byte-identical logs (topics + data) and state; escrow adds exactly one `AccessSettled` | ✔ | ✔ |
| Batch of 1 skip reasons equal the single call's revert selectors (duplicate, untrusted, unknown version, malformed signature) | ✔ | — |
| Duplicate recordId inside a batch: first recorded, second skipped, second's legs not paid | ✔ | ✔ |
| Duplicate across two batches (and across batch then single call) | ✔ | ✔ |
| Untrusted server on one item: only that item skipped, legs not paid | ✔ | ✔ |
| Unknown version on one item (too high, zero) | ✔ | ✔ |
| Mixed-owner batch: per-owner servers, per-item payers, cross-signed item skipped | ✔ | ✔ |
| Empty batch reverts `EmptyBatch` | ✔ | ✔ |
| 200 items succeed; 201 revert `BatchTooLarge(201, 200)` | ✔ | ✔ |
| Exactly one of Recorded / Skipped per item, in order | ✔ | — |
| Payment leg failure (`InsufficientBalance`, `ZeroAmount`) reverts the whole batch, nothing recorded | — | ✔ |
| Receipt grouping: legs reconstructed per read from `AccessSettled` markers (0, 1 and 2 legs; one skipped item; an ERC-20 leg whose `Transfer` log interleaves) | — | ✔ |
| ERC-20 legs in a batch | — | ✔ |
| Role gate, pause (own contract, and registry pause bubbling through the escrow), registry/servers unset | ✔ | ✔ |
| Over-long scope (257 B) and 64-byte signature skipped on calldata length alone (`ScopeTooLong`, `InvalidSignature`) | ✔ | — |
| 9 legs on one bundle revert `TooManyOps(0, 9, 8)`; 8 legs accepted | — | ✔ |

Full suite: `MOKSHA_RPC_URL=<moksha rpc> npx hardhat test test/data/dataRegistryV2.ts test/dataPortability/dataPortabilityEscrow.ts test/dataPortability/dataPortabilityEscrowBatchGas.ts` — 166 passing (137 before this PR).

## Gas

All numbers are measured `gasUsed` from receipts, not estimates.

**Reference points (mainnet).** Prod tx `0xfc0bb12e…c20b` (block 9,979,202, `recordAccessAndSettle`, one USDC.e leg, 16-byte scope, first access on the data point): **222,771** gas. Replaying that exact tx on a Hardhat fork of mainnet at block 9,979,201 gives **222,771** (`scripts/gas/replayMainnetAccessTx.ts`, `EXACT` match), so Hardhat's gas accounting matches the chain for this code path. Verified from the source on `origin/dp_escrow` that no function on either contract takes more than one access record per call: the registry has only `recordDataAccess`; the escrow has `recordAccessAndSettle` (one record), `settleBatch` (payouts only) and `runOpAndSettle` (one call to one allowlisted target).

**Measurement scenario** (`scripts/gas/measureBatchOnFork.ts`): Hardhat fork of mainnet at block 9,983,439 with the real deployed `DataPortabilityServersV2` and the real USDC.e token (Circle FiatTokenV2 proxy), this branch's `DataRegistryV2` + `DataPortabilityEscrow` implementations written into the proxies' ERC-1967 slots (nothing broadcast). Every item is a distinct data owner with its own freshly registered trusted server (production-length 132-char public key and 47-char relay URL, matched to the server that signed the prod tx) and its own data point, first access, 16-byte scope, one USDC.e leg of 10,000 units from the prod payer to the prod payee. This is the expensive shape (all registry slots cold, both counters 0→1, fresh server per item), not a warm best case.

Sanity check on the same input shape: deployed implementation single call = **222,759**; this branch's single call = **222,844** (+85 gas from the larger dispatch table; the single path's logic is unchanged). With short fixture server strings the same call costs 206,542, which is why the fixtures use production-length strings: `_isTrustedServer` copies the whole `ServerInfo` (both strings) out of storage per record. A `serverOwner(bytes32)` view on ServersV2 would remove ~16k gas per read from both paths; out of scope here (ServersV2 upgrade).

| batch | gasUsed | gas / read | marginal gas / read vs previous row | calldata bytes | % of 60M block |
|---:|---:|---:|---:|---:|---:|
| 1 | 231,227 | 231,227 | — | 772 | 0.39% |
| 10 | 1,508,925 | 150,892 | 141,966 | 7,108 | 2.51% |
| 25 | 3,642,423 | 145,696 | 142,233 | 17,668 | 6.07% |
| 50 | 7,209,452 | 144,189 | 142,681 | 35,268 | 12.02% |
| 100 | 14,385,926 | 143,859 | 143,529 | 70,468 | 23.98% |
| 200 | 28,909,168 | 144,545 | 145,232 | 140,868 | 48.18% |

- **Marginal gas per additional read:** 141,966 at small batches, rising to **145,232** between 100 and 200 (memory expansion for the calldata→memory record copy and the growing return array). A batch of 1 costs 8,383 more than the single call (marker event, `bool[]` return, the copy).
- **Per read, 200-batch vs single:** 144,545 vs 222,844, i.e. **35% less gas per read**. 200 single txs would cost 44.6M gas; the batch costs 28.9M.
- **Largest batch that fits one block with 20% margin (48M gas):** the contract cap, **200 items at 28,909,168 gas (48.2% of the block)**. Gas alone would allow more, but nothing above 200 was measured and the cap is deliberately there (see below), so 200 is the number.
- **The binding limit is transaction size, not gas.** Calldata is 704 bytes per item + 68 fixed (measured: 140,868 bytes at 200). Vana validators run geth v1.17.4, whose txpool rejects any transaction over 131,072 bytes (`txMaxSize = 4 * txSlotSize`, `core/txpool/legacypool/legacypool.go:56`, a compile-time constant). With a ~110-byte envelope that is **185 items** with 16-byte scopes, fewer with longer scopes. A 200-item batch is valid on-chain but cannot be broadcast through a stock geth RPC. `MAX_ACCESS_BATCH` stays at 200 as the on-chain gas bound; the gateway must size batches by bytes (see below).
- **Reads-per-minute ceiling, one relayer, one batch per 6 s block:** 10 blocks/min × 185 = **1,850 reads/min** through a stock geth txpool; 10 × 200 = **2,000 reads/min** if the node's size limit were raised. Today's relayer does ~50/min (p95 since Aug 25) with one tx per read, so this is a 37× to 40× ceiling increase for the same single key. At 185 reads/block the batch uses ~26.7M gas, 44.6% of the block, leaving room for every other protocol tx in the same block.

Offline reproduction without a fork (`test/dataPortability/dataPortabilityEscrowBatchGas.ts`, ERC20Mock instead of USDC.e, same shape otherwise):

Single `recordAccessAndSettle` reference in this setup: 229,310 gas.

| batch | gasUsed | gas / read | marginal gas / read vs previous row | calldata bytes | % of 60M block |
|---:|---:|---:|---:|---:|---:|
| 1 | 237,693 | 237,693 | — | 772 | 0.40% |
| 10 | 1,494,829 | 149,482 | 139,681 | 7,108 | 2.49% |
| 25 | 3,594,061 | 143,762 | 139,948 | 17,668 | 5.99% |
| 50 | 7,104,028 | 142,080 | 140,398 | 35,268 | 11.84% |
| 100 | 14,166,426 | 141,664 | 141,247 | 70,468 | 23.61% |
| 200 | 28,461,396 | 142,306 | 142,949 | 140,868 | 47.44% |

The test asserts that the 200-item batch stays under 48M gas, so a future change that pushes the cap past the block budget fails CI.


## Gateway integration (design only, no gateway code in this PR)

This describes how `data-gateway`'s drain would use the new entry point. It changes `drainAccessRecords` / `settleOneAccessRecord` in `api/v1/settle.ts`, `lib/settle.ts` (ABI + prepare), and the outbox proof in `lib/settlement-outbox.ts` / `lib/settlement-proof.ts`. Nothing here is implemented in this PR.

**Which rows qualify.** Exactly the rows `drainAccessRecords` selects today: `payments.kind = 'data_access'`, `settlement_outbox_version = 1`, `access_signature IS NOT NULL`, `access_settle_tx_hash IS NULL`, `access_settle_chain_block_height IS NULL`, a `data_point_versions` row for the data point in `confirmed`/`finalized` with `expected_version >= access_data_point_version`, and no tombstone at the exact receipt version. Same `waitForInFlightServers` wait for the affected owners before building. Same `ORDER BY paid_at ASC ... FOR UPDATE SKIP LOCKED`. The `LIMIT` becomes the batch budget instead of the per-tick tx budget. Rows whose payout was already settled (`settled_status != 'unsettled'`) or whose amount is 0 go in with `ops = []`, as they do today; a positive row missing its grant id still fails the row before anything is built.

**Building a batch.** One `AccessBundle` per row: `record` from the row (`dp_owner`, `dp_scope`, `access_data_point_version`, `access_accessor`, `access_record_id`, `access_signature`), `ops` from the same `SettleOp` builder used today (`from = payer`, `to = accepted payee`, `asset`, `amount`, `opKind = DataAccess`, `ref = grant id`). Batch size is bounded by three things, take the minimum: `MAX_ACCESS_BATCH` (200), the block budget (the drain should keep a batch under ~48M gas from `estimateGas`, which at the measured marginal cost is well above 200 items), and the geth txpool's 128 KiB transaction size limit, which at ~704 bytes per item binds around 185 items with 16-byte scopes and fewer with long scopes. A config `ACCESS_BATCH_MAX_ITEMS` (default below the txpool bound) and `ACCESS_BATCH_MAX_CALLDATA_BYTES` (default 120 KiB) make this explicit. Simulate the batch (`simulateContract` as facilitator) before signing; a leg failure (`InsufficientBalance`, `ZeroAmount`) reverts the simulation and names the item through the error args, so the drain drops that row (fail it with `settle_simulation_error`, as the single path does) and re-simulates. Record-level rejections do not revert the simulation; they show up as `recorded[i] == false` in the simulated return value and can be used to drop obviously-dead items (already used, untrusted) before broadcast, or left in and let the chain skip them.

**Nonce owner.** The prepared batch is persisted through the durable outbox before broadcast, like every payout-bearing submission today. A new `persistPreparedAccessBatchSettlement({ paymentIds, recordIds, expectedSettled, prepared })` inserts ONE `settlement_outbox` row with `ownerType: 'batch'`, `ownerId: prepared.txHash`, `submissionKind: 'record_access_and_settle_batch'` (new kind), `paymentIds` = every row in the batch, and claims all of them in the same DB transaction (`settled_status: 'settling'`, `settle_batch_tx_hash`, `access_settle_tx_hash`, `access_settle_tx_nonce` on each payment, CAS on `settled_status = 'unsettled' AND access_settle_tx_hash IS NULL`; any row lost to a concurrent drain raises `OutboxClaimLostError` and the batch is not broadcast). The relayer nonce ledger row is `ownerType: 'outbox-batch'` (`RelayerNonceOwnerType` already has it, `persistThenBroadcastSettlement` already stamps `outbox-${ownerType}`). That keeps the batch under the same rules as other outbox owners: immutable, never RBF-replaced by the direct-owner recovery (`replaceableRelayerNonceOwner` returns null for `outbox-*`), reconciled only through `reconcileSettlementOutbox` by proof. One nonce per batch, so one allocation from `getNextNonce()` per batch instead of per row; `takeSubmitSlots` is charged 1 per batch.

**Mapping the receipt back to rows.** The proof for a batch row is a new `proveAccessBatchSettlement`, run by the outbox reconciler for `submissionKind = 'record_access_and_settle_batch'`. It keeps the canonical / finalized / status checks of `proveSettlement`, then derives the per-item outcome from the receipt:
1. Decode registry logs at `DATA_REGISTRY_CONTRACT`: `DataAccessRecorded(recordId)` → landed; `DataAccessSkipped(recordId, index, reason)` → skipped with reason. Every recordId in the outbox row must appear in exactly one of them; anything else is `mismatch` (quarantine, as today).
2. Decode escrow logs: walk `AccessSettled(index, recordId, opCount)` markers; the `opCount` `Settled` events that follow each marker must equal the row's committed `expectedSettled` for that recordId, in order. Any deviation is `mismatch`.
3. Landed rows finalize exactly as a single access does today (`settled_status: 'settled'`, `access_settle_chain_block_height`, `payment_finalized_at`, balance debit for the settled legs).
4. Skipped rows are released back to `unsettled` (`access_settle_tx_hash`, `settle_batch_tx_hash`, nonce cleared) with the reason recorded:
   - `RecordIdAlreadyUsed` → the access landed elsewhere. Reuse the existing `isRecordIdUsed` at the finalized tip + `finalizeAccessPayment` path; if the row still has an unsettled payout, submit it as a standalone `settleBatch`, as `settleOneAccessRecord` does today for this revert.
   - `UntrustedServer`, `UnknownVersion` → same terminal handling the single path gives those reverts (server no longer trusted; version rolled back). The row is not retried blindly; it goes through the existing deferral / failure classification.
   - `InvalidSignature` → gateway bug (the signature was verified at pay time); fail the row with `settle_simulation_error` for an operator.
   The whole per-item update is one DB transaction per batch, keyed on the outbox row's `status = 'prepared'` so it applies once.
5. A reverted batch (leg failure that escaped simulation) is `reverted` for every row: all claims released, as `releaseRevertedSettlement` does today for single rows.

**Settle-time gate for a batch.** The single path's gate is the SELECT's version predicate; the batch keeps it and adds two batch-level checks between SELECT and broadcast: (a) re-run `waitForInFlightServers` for the batch's owners and drop rows whose owner still has a server in flight (the registry would skip them, but dropping them saves the calldata), and (b) treat the simulated `recorded[]` as the gate for record-level state: an item simulated as `false` with `RecordIdAlreadyUsed` is reconciled immediately through the existing already-used path instead of being broadcast. The batch itself is one tx, so the confirmed-version gate cannot be applied per item after broadcast; that is why it stays in the SELECT.

**Rollout.** Feature-flag the batch path (`ACCESS_SETTLE_BATCH_ENABLED`), default off, and keep `settleOneAccessRecord` as the fallback. Enable after both upgrades are live and `escrow.MAX_ACCESS_BATCH()` reads back non-zero.


## Audit

The upgrade touches two UUPS proxies that hold protocol funds and the access ledger. It needs a Nethermind audit slot before either upgrade script is run. Nothing in this PR is deployed to any network.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UERZbNjmXRbftWXaxUyJCd
