### PR TITLE
fix(dataPortability): allow deregistration while paused; bind grantee registration to the caller

### DIFF
--- a/contracts/dataPortability/dataPortabilityGrantees/DataPortabilityGranteesImplementation.sol
+++ b/contracts/dataPortability/dataPortabilityGrantees/DataPortabilityGranteesImplementation.sol
@@ -107,11 +107,6 @@ contract DataPortabilityGranteesImplementation is
         address granteeAddress,
         string memory publicKey
     ) external override whenNotPaused returns (uint256) {
-        // Allow registration if caller has MAINTAINER_ROLE OR owner is the granteeAddress
-        if (!hasRole(MAINTAINER_ROLE, _msgSender()) && owner != granteeAddress) {
-            revert UnauthorizedRegistration();
-        }
-
         if (bytes(publicKey).length == 0) {
             revert EmptyPublicKey();
         }
@@ -122,6 +117,18 @@ contract DataPortabilityGranteesImplementation is
 
         if (owner == address(0)) {
             revert ZeroAddress();
+        }
+
+        // Allow registration if the caller has MAINTAINER_ROLE (the gateway
+        // relayer path), OR the caller is registering ITSELF as both owner and
+        // grantee. Records are immutable, so a caller must never be able to
+        // register an address it does not control: that would let anyone bind
+        // an attacker-chosen public key to a victim's builder address forever.
+        if (
+            !hasRole(MAINTAINER_ROLE, _msgSender()) &&
+            (owner != granteeAddress || _msgSender() != granteeAddress)
+        ) {
+            revert UnauthorizedRegistration();
         }
 
         if (granteeAddressToId[granteeAddress] != 0) {

--- a/contracts/dataPortability/dataPortabilityGrantees/DataPortabilityGranteesImplementation.sol
+++ b/contracts/dataPortability/dataPortabilityGrantees/DataPortabilityGranteesImplementation.sol
@@ -24,6 +24,11 @@ contract DataPortabilityGranteesImplementation is
 
     bytes32 public constant MAINTAINER_ROLE = keccak256("MAINTAINER_ROLE");
     bytes32 public constant PERMISSION_MANAGER_ROLE = keccak256("PERMISSION_MANAGER_ROLE");
+    /// @notice May register grantees on behalf of other owners (the gateway
+    ///         relayer). Deliberately narrower than MAINTAINER_ROLE: a hot key
+    ///         that only needs registration must not also get pause() or
+    ///         updateTrustedForwarder().
+    bytes32 public constant REGISTRAR_ROLE = keccak256("REGISTRAR_ROLE");
 
     error ZeroAddress();
     error EmptyPublicKey();
@@ -119,14 +124,17 @@ contract DataPortabilityGranteesImplementation is
             revert ZeroAddress();
         }
 
-        // Allow registration if the caller has MAINTAINER_ROLE (the gateway
-        // relayer path), OR the caller is registering ITSELF as both owner and
-        // grantee. Records are immutable, so a caller must never be able to
-        // register an address it does not control: that would let anyone bind
-        // an attacker-chosen public key to a victim's builder address forever.
+        // Allow registration if the caller holds REGISTRAR_ROLE or
+        // MAINTAINER_ROLE (the gateway relayer path), OR the caller is
+        // registering ITSELF as both owner and grantee. Records are immutable,
+        // so a caller must never be able to register an address it does not
+        // control: that would let anyone bind an attacker-chosen public key to
+        // a victim's builder address forever.
+        address sender = _msgSender();
         if (
-            !hasRole(MAINTAINER_ROLE, _msgSender()) &&
-            (owner != granteeAddress || _msgSender() != granteeAddress)
+            !hasRole(REGISTRAR_ROLE, sender) &&
+            !hasRole(MAINTAINER_ROLE, sender) &&
+            (owner != granteeAddress || sender != granteeAddress)
         ) {
             revert UnauthorizedRegistration();
         }

--- a/contracts/dataPortability/dataPortabilityGrantees/interfaces/IDataPortabilityGrantees.sol
+++ b/contracts/dataPortability/dataPortabilityGrantees/interfaces/IDataPortabilityGrantees.sol
@@ -26,7 +26,8 @@ import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
  * 
  * Security Considerations:
  * - Only authorized contracts can modify permission associations
- * - Grantee registration is open but creates immutable records
+ * - Grantee registration is self-service (caller == owner == granteeAddress) or
+ *   by MAINTAINER_ROLE, and creates immutable records
  * - Public keys are stored for encryption and verification purposes
  * - Administrative functions require appropriate role permissions
  * 
@@ -154,6 +155,9 @@ interface IDataPortabilityGrantees {
      * - Grantee address must not be zero
      * - Public key must not be empty
      * - Contract must not be paused
+     * - Caller must hold MAINTAINER_ROLE, or be registering itself
+     *   (`_msgSender() == owner == granteeAddress`). Records are immutable,
+     *   so a caller can never bind a public key to an address it does not control
      * 
      * Effects:
      * - Increments grantees count

--- a/contracts/dataPortability/dataPortabilityGrantees/interfaces/IDataPortabilityGrantees.sol
+++ b/contracts/dataPortability/dataPortabilityGrantees/interfaces/IDataPortabilityGrantees.sol
@@ -27,7 +27,7 @@ import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
  * Security Considerations:
  * - Only authorized contracts can modify permission associations
  * - Grantee registration is self-service (caller == owner == granteeAddress) or
- *   by MAINTAINER_ROLE, and creates immutable records
+ *   by REGISTRAR_ROLE / MAINTAINER_ROLE, and creates immutable records
  * - Public keys are stored for encryption and verification purposes
  * - Administrative functions require appropriate role permissions
  * 
@@ -155,7 +155,7 @@ interface IDataPortabilityGrantees {
      * - Grantee address must not be zero
      * - Public key must not be empty
      * - Contract must not be paused
-     * - Caller must hold MAINTAINER_ROLE, or be registering itself
+     * - Caller must hold REGISTRAR_ROLE or MAINTAINER_ROLE, or be registering itself
      *   (`_msgSender() == owner == granteeAddress`). Records are immutable,
      *   so a caller can never bind a public key to an address it does not control
      * 

--- a/contracts/dataPortability/dataPortabilityServersV2/DataPortabilityServersV2Implementation.sol
+++ b/contracts/dataPortability/dataPortabilityServersV2/DataPortabilityServersV2Implementation.sol
@@ -237,10 +237,14 @@ contract DataPortabilityServersV2Implementation is
         );
     }
 
+    /// @dev Deliberately NOT `whenNotPaused`: deregistration is the only lever
+    /// that strips a server's delegate authority (grants, data writes, status
+    /// flips in PermissionsV2 / DataRegistryV2), and an incident pause is
+    /// exactly when an owner needs it. Registration stays paused.
     function deregisterServerWithSignature(
         ServerDeregistration calldata input,
         bytes calldata signature
-    ) external override whenNotPaused {
+    ) external override {
         if (block.timestamp > input.deadline) revert DeadlineExpired(input.deadline, block.timestamp);
 
         // Verify owner's signature.

--- a/contracts/dataPortability/dataPortabilityServersV2/interfaces/IDataPortabilityServersV2.sol
+++ b/contracts/dataPortability/dataPortabilityServersV2/interfaces/IDataPortabilityServersV2.sol
@@ -174,6 +174,8 @@ interface IDataPortabilityServersV2 {
     ///         stored id (ties revocation to a specific registration instance).
     ///         Reverts if `block.timestamp > input.deadline` or if the server
     ///         is already revoked.
+    ///         Not gated by `whenNotPaused`: an owner can still revoke a
+    ///         server during an incident pause. Registration stays paused.
     function deregisterServerWithSignature(
         ServerDeregistration calldata input,
         bytes calldata signature

--- a/test/dataPortability/dataPortabilityGrantees.ts
+++ b/test/dataPortability/dataPortabilityGrantees.ts
@@ -19,15 +19,17 @@ describe("DataPortabilityGrantees", () => {
   let granteeAddress2: HardhatEthersSigner;
   let trustedForwarder: HardhatEthersSigner;
 
+  let registrar: HardhatEthersSigner;
   let granteesContract: DataPortabilityGranteesImplementation;
   let permissionsContract: DataPortabilityPermissionsImplementation;
 
   const DEFAULT_ADMIN_ROLE = ethers.ZeroHash;
   const MAINTAINER_ROLE = ethers.keccak256(ethers.toUtf8Bytes("MAINTAINER_ROLE"));
   const PERMISSION_MANAGER_ROLE = ethers.keccak256(ethers.toUtf8Bytes("PERMISSION_MANAGER_ROLE"));
+  const REGISTRAR_ROLE = ethers.keccak256(ethers.toUtf8Bytes("REGISTRAR_ROLE"));
 
   beforeEach(async () => {
-    [deployer, owner, maintainer, user1, user2, granteeAddress1, granteeAddress2, trustedForwarder] =
+    [deployer, owner, maintainer, user1, user2, granteeAddress1, granteeAddress2, trustedForwarder, registrar] =
       await ethers.getSigners();
 
     // Deploy DataPortabilityGrantees
@@ -320,7 +322,7 @@ describe("DataPortabilityGrantees", () => {
           .connect(user1)
           .registerGrantee(granteeAddress2.address, granteeAddress2.address, "attacker-key"),
       ).to.be.revertedWithCustomError(granteesContract, "UnauthorizedRegistration");
-      (await granteesContract.granteeAddressToId(granteeAddress2.address)).should.eq(0n);
+      expect(await granteesContract.granteeAddressToId(granteeAddress2.address)).to.eq(0n);
     });
 
     it("should reject a non-maintainer naming a different owner for themselves", async () => {
@@ -332,19 +334,40 @@ describe("DataPortabilityGrantees", () => {
     });
 
     it("should allow a grantee to register itself", async () => {
-      await granteesContract
+      await expect(granteesContract
         .connect(granteeAddress1)
-        .registerGrantee(granteeAddress1.address, granteeAddress1.address, "self-key").should.be
-        .fulfilled;
-      (await granteesContract.granteeAddressToId(granteeAddress1.address)).should.eq(1n);
+        .registerGrantee(granteeAddress1.address, granteeAddress1.address, "self-key")).to.not.be.reverted;
+      expect(await granteesContract.granteeAddressToId(granteeAddress1.address)).to.eq(1n);
     });
 
     it("should still allow a maintainer (the gateway relayer) to register any grantee", async () => {
-      await granteesContract
+      await expect(granteesContract
         .connect(maintainer)
-        .registerGrantee(user2.address, granteeAddress2.address, "relayed-key").should.be
-        .fulfilled;
-      (await granteesContract.granteeAddressToId(granteeAddress2.address)).should.eq(1n);
+        .registerGrantee(user2.address, granteeAddress2.address, "relayed-key")).to.not.be.reverted;
+      expect(await granteesContract.granteeAddressToId(granteeAddress2.address)).to.eq(1n);
+    });
+
+    // REGISTRAR_ROLE is the narrow role for the gateway relayer: it can register
+    // on behalf of others but gets none of MAINTAINER_ROLE's pause / forwarder
+    // powers, so a leaked relayer key cannot freeze the registry.
+    it("should let a REGISTRAR_ROLE holder register any grantee", async () => {
+      await granteesContract.connect(owner).grantRole(REGISTRAR_ROLE, registrar.address);
+      await expect(granteesContract
+        .connect(registrar)
+        .registerGrantee(user2.address, granteeAddress2.address, "relayed-key")).to.not.be.reverted;
+      expect(await granteesContract.granteeAddressToId(granteeAddress2.address)).to.eq(1n);
+    });
+
+    it("should not let a REGISTRAR_ROLE holder pause or change the forwarder", async () => {
+      await granteesContract.connect(owner).grantRole(REGISTRAR_ROLE, registrar.address);
+      await expect(granteesContract.connect(registrar).pause()).to.be.revertedWithCustomError(
+        granteesContract,
+        "AccessControlUnauthorizedAccount",
+      );
+      await expect(
+        granteesContract.connect(registrar).updateTrustedForwarder(registrar.address),
+      ).to.be.revertedWithCustomError(granteesContract, "AccessControlUnauthorizedAccount");
+      expect(await granteesContract.paused()).to.eq(false);
     });
   });
 

--- a/test/dataPortability/dataPortabilityGrantees.ts
+++ b/test/dataPortability/dataPortabilityGrantees.ts
@@ -308,6 +308,46 @@ describe("DataPortabilityGrantees", () => {
     });
   });
 
+  describe("registerGrantee caller binding", () => {
+    // Without MAINTAINER_ROLE, the only allowed registration is a grantee
+    // registering ITSELF. Previously any caller could register any address
+    // with an attacker-chosen public key; records are immutable, so the
+    // victim could never register and consumers would encrypt to the
+    // attacker's key.
+    it("should reject a non-maintainer registering an address they do not control", async () => {
+      await expect(
+        granteesContract
+          .connect(user1)
+          .registerGrantee(granteeAddress2.address, granteeAddress2.address, "attacker-key"),
+      ).to.be.revertedWithCustomError(granteesContract, "UnauthorizedRegistration");
+      (await granteesContract.granteeAddressToId(granteeAddress2.address)).should.eq(0n);
+    });
+
+    it("should reject a non-maintainer naming a different owner for themselves", async () => {
+      await expect(
+        granteesContract
+          .connect(granteeAddress1)
+          .registerGrantee(user1.address, granteeAddress1.address, "key"),
+      ).to.be.revertedWithCustomError(granteesContract, "UnauthorizedRegistration");
+    });
+
+    it("should allow a grantee to register itself", async () => {
+      await granteesContract
+        .connect(granteeAddress1)
+        .registerGrantee(granteeAddress1.address, granteeAddress1.address, "self-key").should.be
+        .fulfilled;
+      (await granteesContract.granteeAddressToId(granteeAddress1.address)).should.eq(1n);
+    });
+
+    it("should still allow a maintainer (the gateway relayer) to register any grantee", async () => {
+      await granteesContract
+        .connect(maintainer)
+        .registerGrantee(user2.address, granteeAddress2.address, "relayed-key").should.be
+        .fulfilled;
+      (await granteesContract.granteeAddressToId(granteeAddress2.address)).should.eq(1n);
+    });
+  });
+
   describe("Edge cases and stress tests", () => {
     it("should handle pagination with exactly matching boundaries", async () => {
       // Register a grantee (owner must equal granteeAddress when called by non-maintainer)

--- a/test/dataPortability/dataPortabilityPermissions.ts
+++ b/test/dataPortability/dataPortabilityPermissions.ts
@@ -313,7 +313,7 @@ describe("DataPortabilityPermissions", () => {
     it("should add a valid permission and emit event", async function () {
       // First register a grantee
       await granteesContract
-        .connect(testUser1)
+        .connect(testUser2)
         .registerGrantee(testUser2.address, testUser2.address, "publicKey1");
 
       const permission = {
@@ -366,7 +366,7 @@ describe("DataPortabilityPermissions", () => {
     it("should reject permission with incorrect nonce", async function () {
       // First register a grantee
       await granteesContract
-        .connect(testUser1)
+        .connect(testUser2)
         .registerGrantee(testUser2.address, testUser2.address, "publicKey1");
 
       const permission = {
@@ -391,7 +391,7 @@ describe("DataPortabilityPermissions", () => {
     it("should reject permission with empty grant", async function () {
       // First register a grantee
       await granteesContract
-        .connect(testUser1)
+        .connect(testUser2)
         .registerGrantee(testUser2.address, testUser2.address, "publicKey1");
 
       const permission = {
@@ -414,7 +414,7 @@ describe("DataPortabilityPermissions", () => {
     it("should allow multiple permissions with the same grant", async function () {
       // First register a grantee
       await granteesContract
-        .connect(testUser1)
+        .connect(testUser2)
         .registerGrantee(testUser2.address, testUser2.address, "publicKey1");
 
       const permission1 = {
@@ -464,7 +464,7 @@ describe("DataPortabilityPermissions", () => {
     it("should add multiple permissions for the same user with sequential nonces", async function () {
       // First register a grantee
       await granteesContract
-        .connect(testUser1)
+        .connect(testUser2)
         .registerGrantee(testUser2.address, testUser2.address, "publicKey1");
 
       const permission1 = {
@@ -545,10 +545,10 @@ describe("DataPortabilityPermissions", () => {
     it("should add permissions for different users independently", async function () {
       // First register grantees for both users
       await granteesContract
-        .connect(testUser1)
+        .connect(testUser2)
         .registerGrantee(testUser2.address, testUser2.address, "publicKey1");
       await granteesContract
-        .connect(testUser2)
+        .connect(testUser1)
         .registerGrantee(testUser1.address, testUser1.address, "publicKey2");
 
       const permission1 = {
@@ -603,13 +603,13 @@ describe("DataPortabilityPermissions", () => {
     it("should assign sequential IDs to permissions", async function () {
       // First register grantees for all users
       await granteesContract
-        .connect(testUser1)
+        .connect(testUser2)
         .registerGrantee(testUser2.address, testUser2.address, "publicKey1");
       await granteesContract
-        .connect(testUser2)
+        .connect(user3)
         .registerGrantee(user3.address, user3.address, "publicKey2");
       await granteesContract
-        .connect(user3)
+        .connect(maintainer)
         .registerGrantee(maintainer.address, maintainer.address, "publicKey3");
 
       const permissions = [
@@ -651,7 +651,7 @@ describe("DataPortabilityPermissions", () => {
     it("should revert when accessing out of bounds permission indices", async function () {
       // First register a grantee
       await granteesContract
-        .connect(testUser1)
+        .connect(testUser2)
         .registerGrantee(testUser2.address, testUser2.address, "publicKey1");
 
       const permission = {
@@ -678,10 +678,10 @@ describe("DataPortabilityPermissions", () => {
     it("should track nonces correctly across multiple users", async function () {
       // First register grantees for both users
       await granteesContract
-        .connect(testUser1)
+        .connect(testUser2)
         .registerGrantee(testUser2.address, testUser2.address, "publicKey1");
       await granteesContract
-        .connect(testUser2)
+        .connect(testUser1)
         .registerGrantee(testUser1.address, testUser1.address, "publicKey2");
 
       const permission1 = {
@@ -746,7 +746,7 @@ describe("DataPortabilityPermissions", () => {
     it("should handle grants with special characters", async function () {
       // First register a grantee
       await granteesContract
-        .connect(testUser1)
+        .connect(testUser2)
         .registerGrantee(testUser2.address, testUser2.address, "publicKey1");
 
       const permission = {
@@ -768,7 +768,7 @@ describe("DataPortabilityPermissions", () => {
     it("should test userPermissionIdsValues function with multiple permissions", async function () {
       // First register a grantee
       await granteesContract
-        .connect(testUser1)
+        .connect(testUser2)
         .registerGrantee(testUser2.address, testUser2.address, "publicKey1");
 
       const permissions = [
@@ -803,10 +803,10 @@ describe("DataPortabilityPermissions", () => {
     it("should emit events with correct parameters for multiple permissions", async function () {
       // First register grantees for both users
       await granteesContract
-        .connect(testUser1)
+        .connect(testUser2)
         .registerGrantee(testUser2.address, testUser2.address, "publicKey1");
       await granteesContract
-        .connect(testUser2)
+        .connect(testUser1)
         .registerGrantee(testUser1.address, testUser1.address, "publicKey2");
 
       const permission1 = {
@@ -865,7 +865,7 @@ describe("DataPortabilityPermissions", () => {
     it("should work when called by sponsor wallet but signed by actual user", async function () {
       // First register a grantee
       await granteesContract
-        .connect(testUser1)
+        .connect(testUser2)
         .registerGrantee(testUser2.address, testUser2.address, "publicKey1");
 
       const permission = {
@@ -901,7 +901,7 @@ describe("DataPortabilityPermissions", () => {
     it("should validate IPFS URI format in grant field", async function () {
       // First register a grantee
       await granteesContract
-        .connect(testUser1)
+        .connect(testUser2)
         .registerGrantee(testUser2.address, testUser2.address, "publicKey1");
 
       const validPermission = {
@@ -927,7 +927,7 @@ describe("DataPortabilityPermissions", () => {
     it("should handle grant field with very long strings", async function () {
       // First register a grantee
       await granteesContract
-        .connect(testUser1)
+        .connect(testUser2)
         .registerGrantee(testUser2.address, testUser2.address, "publicKey1");
 
       const longGrant = "ipfs://" + "a".repeat(1000); // Very long grant
@@ -950,7 +950,7 @@ describe("DataPortabilityPermissions", () => {
     it("should handle unicode characters in grant", async function () {
       // First register a grantee
       await granteesContract
-        .connect(testUser1)
+        .connect(testUser2)
         .registerGrantee(testUser2.address, testUser2.address, "publicKey1");
 
       const permission = {
@@ -972,7 +972,7 @@ describe("DataPortabilityPermissions", () => {
     it("should verify signature but not store it", async function () {
       // First register a grantee
       await granteesContract
-        .connect(testUser1)
+        .connect(testUser2)
         .registerGrantee(testUser2.address, testUser2.address, "publicKey1");
 
       const permission = {
@@ -1004,7 +1004,7 @@ describe("DataPortabilityPermissions", () => {
     it("should handle max nonce values", async function () {
       // First register a grantee
       await granteesContract
-        .connect(testUser1)
+        .connect(testUser2)
         .registerGrantee(testUser2.address, testUser2.address, "publicKey1");
 
       const permission = {
@@ -1138,7 +1138,7 @@ describe("DataPortabilityPermissions", () => {
       it("should revoke permission by owner successfully", async function () {
         // First register a grantee
         await granteesContract
-          .connect(testUser1)
+          .connect(testUser2)
           .registerGrantee(testUser2.address, testUser2.address, "publicKey1");
 
         // First add a permission
@@ -1186,7 +1186,7 @@ describe("DataPortabilityPermissions", () => {
       it("should reject revocation by non-owner", async function () {
         // First register a grantee
         await granteesContract
-          .connect(testUser1)
+          .connect(testUser2)
           .registerGrantee(testUser2.address, testUser2.address, "publicKey1");
 
         // User1 adds a permission
@@ -1218,7 +1218,7 @@ describe("DataPortabilityPermissions", () => {
       it("should reject revoking already revoked permission", async function () {
         // First register a grantee
         await granteesContract
-          .connect(testUser1)
+          .connect(testUser2)
           .registerGrantee(testUser2.address, testUser2.address, "publicKey1");
 
         // Add and revoke a permission
@@ -1248,7 +1248,7 @@ describe("DataPortabilityPermissions", () => {
       it("should handle multiple permissions correctly", async function () {
         // First register a grantee
         await granteesContract
-          .connect(testUser1)
+          .connect(testUser2)
           .registerGrantee(testUser2.address, testUser2.address, "publicKey1");
 
         // Add multiple permissions
@@ -1293,7 +1293,7 @@ describe("DataPortabilityPermissions", () => {
       it("should revoke permission with valid signature", async function () {
         // First register a grantee
         await granteesContract
-          .connect(testUser1)
+          .connect(testUser2)
           .registerGrantee(testUser2.address, testUser2.address, "publicKey1");
 
         // Add a permission first
@@ -1345,7 +1345,7 @@ describe("DataPortabilityPermissions", () => {
       it("should reject revocation with wrong nonce", async function () {
         // First register a grantee
         await granteesContract
-          .connect(testUser1)
+          .connect(testUser2)
           .registerGrantee(testUser2.address, testUser2.address, "publicKey1");
 
         // Add a permission
@@ -1387,10 +1387,10 @@ describe("DataPortabilityPermissions", () => {
       it("should reject revocation of non-owned permission", async function () {
         // First register grantees for both users
         await granteesContract
-          .connect(testUser1)
+          .connect(testUser2)
           .registerGrantee(testUser2.address, testUser2.address, "publicKey1");
         await granteesContract
-          .connect(testUser2)
+          .connect(testUser1)
           .registerGrantee(testUser1.address, testUser1.address, "publicKey2");
 
         // User1 adds a permission
@@ -1436,7 +1436,7 @@ describe("DataPortabilityPermissions", () => {
       it("should handle gasless revocation via sponsor", async function () {
         // First register a grantee
         await granteesContract
-          .connect(testUser1)
+          .connect(testUser2)
           .registerGrantee(testUser2.address, testUser2.address, "publicKey1");
 
         // Add permission
@@ -1486,7 +1486,7 @@ describe("DataPortabilityPermissions", () => {
       it("should correctly update user permission sets", async function () {
         // First register a grantee
         await granteesContract
-          .connect(testUser1)
+          .connect(testUser2)
           .registerGrantee(testUser2.address, testUser2.address, "publicKey1");
 
         // Add 3 permissions
@@ -1542,7 +1542,7 @@ describe("DataPortabilityPermissions", () => {
       it("should prevent replay attacks on revocation", async function () {
         // First register a grantee
         await granteesContract
-          .connect(testUser1)
+          .connect(testUser2)
           .registerGrantee(testUser2.address, testUser2.address, "publicKey1");
 
         // Add permission
@@ -1597,7 +1597,7 @@ describe("DataPortabilityPermissions", () => {
       it("should maintain correct state after mixed operations", async function () {
         // First register a grantee
         await granteesContract
-          .connect(testUser1)
+          .connect(testUser2)
           .registerGrantee(testUser2.address, testUser2.address, "publicKey1");
 
         // Add permission 1
@@ -1651,7 +1651,7 @@ describe("DataPortabilityPermissions", () => {
       it("should work correctly with trusted servers", async function () {
         // First register a grantee
         await granteesContract
-          .connect(testUser1)
+          .connect(testUser2)
           .registerGrantee(testUser2.address, testUser2.address, "publicKey1");
 
         // Add a permission
@@ -1696,7 +1696,7 @@ describe("DataPortabilityPermissions", () => {
       it("should handle nonce correctly across different operations", async function () {
         // First register a grantee
         await granteesContract
-          .connect(testUser1)
+          .connect(testUser2)
           .registerGrantee(testUser2.address, testUser2.address, "publicKey1");
 
         // Initial nonce
@@ -1748,7 +1748,7 @@ describe("DataPortabilityPermissions", () => {
       it("should reject revocation when paused", async function () {
         // First register a grantee
         await granteesContract
-          .connect(testUser1)
+          .connect(testUser2)
           .registerGrantee(testUser2.address, testUser2.address, "publicKey1");
 
         // Add a permission
@@ -1847,10 +1847,10 @@ describe("DataPortabilityPermissions", () => {
     it("should handle multiple users with same grant (should succeed)", async function () {
       // First register grantees
       await granteesContract
-        .connect(testUser1)
+        .connect(testUser2)
         .registerGrantee(testUser2.address, testUser2.address, "publicKey1");
       await granteesContract
-        .connect(testUser2)
+        .connect(user3)
         .registerGrantee(user3.address, user3.address, "publicKey2");
 
       const permission = {
@@ -1900,7 +1900,7 @@ describe("DataPortabilityPermissions", () => {
     it("should handle rapid succession of permissions", async function () {
       // First register a grantee
       await granteesContract
-        .connect(testUser1)
+        .connect(testUser2)
         .registerGrantee(testUser2.address, testUser2.address, "publicKey1");
 
       const permissions = [];
@@ -3092,7 +3092,7 @@ describe("DataPortabilityPermissions", () => {
       it("should prevent replay of permission signatures in server context", async function () {
         // First register a grantee
         await granteesContract
-          .connect(testUser1)
+          .connect(testUser2)
           .registerGrantee(testUser2.address, testUser2.address, "publicKey1");
 
         // Add a permission
@@ -3266,7 +3266,7 @@ describe("DataPortabilityPermissions", () => {
       it("should add permission with file IDs for files owned by user", async function () {
         // First register grantee
         await granteesContract
-          .connect(testUser1)
+          .connect(testUser2)
           .registerGrantee(testUser2.address, testUser2.address, "publicKey1");
 
         // Set up files owned by testUser1
@@ -3324,7 +3324,7 @@ describe("DataPortabilityPermissions", () => {
       it("should reject permission with file IDs not owned by user", async function () {
         // First register grantee
         await granteesContract
-          .connect(testUser1)
+          .connect(testUser2)
           .registerGrantee(testUser2.address, testUser2.address, "publicKey1");
 
         // Set up files owned by different users
@@ -3354,7 +3354,7 @@ describe("DataPortabilityPermissions", () => {
       it("should handle empty fileIds array", async function () {
         // First register grantee
         await granteesContract
-          .connect(testUser1)
+          .connect(testUser2)
           .registerGrantee(testUser2.address, testUser2.address, "publicKey1");
 
         const permission = {
@@ -3383,7 +3383,7 @@ describe("DataPortabilityPermissions", () => {
       it("should handle duplicate fileIds in input", async function () {
         // First register grantee
         await granteesContract
-          .connect(testUser1)
+          .connect(testUser2)
           .registerGrantee(testUser2.address, testUser2.address, "publicKey1");
 
         await dataRegistry.setFile(1, testUser1.address, "ipfs://file1");
@@ -3419,7 +3419,7 @@ describe("DataPortabilityPermissions", () => {
       it("should handle multiple permissions for same file", async function () {
         // First register grantee
         await granteesContract
-          .connect(testUser1)
+          .connect(testUser2)
           .registerGrantee(testUser2.address, testUser2.address, "publicKey1");
 
         await dataRegistry.setFile(1, testUser1.address, "ipfs://file1");
@@ -3470,7 +3470,7 @@ describe("DataPortabilityPermissions", () => {
       it("should handle permissions with overlapping fileIds", async function () {
         // First register a grantee
         await granteesContract
-          .connect(testUser1)
+          .connect(testUser2)
           .registerGrantee(testUser2.address, testUser2.address, "publicKey1");
 
         await dataRegistry.setFile(1, testUser1.address, "ipfs://file1");
@@ -3520,7 +3520,7 @@ describe("DataPortabilityPermissions", () => {
       it("should clean up file associations when permission is revoked", async function () {
         // First register a grantee
         await granteesContract
-          .connect(testUser1)
+          .connect(testUser2)
           .registerGrantee(testUser2.address, testUser2.address, "publicKey1");
 
         await dataRegistry.setFile(1, testUser1.address, "ipfs://file1");
@@ -3562,7 +3562,7 @@ describe("DataPortabilityPermissions", () => {
       it("should handle large number of fileIds", async function () {
         // First register a grantee
         await granteesContract
-          .connect(testUser1)
+          .connect(testUser2)
           .registerGrantee(testUser2.address, testUser2.address, "publicKey1");
 
         // Set up 100 files owned by testUser1
@@ -3607,7 +3607,7 @@ describe("DataPortabilityPermissions", () => {
       it("should reject permission for non-existent file", async function () {
         // First register a grantee
         await granteesContract
-          .connect(testUser1)
+          .connect(testUser2)
           .registerGrantee(testUser2.address, testUser2.address, "publicKey1");
 
         // Only set up file 1
@@ -3635,7 +3635,7 @@ describe("DataPortabilityPermissions", () => {
       it("should handle revocation with signature for permissions with fileIds", async function () {
         // First register a grantee
         await granteesContract
-          .connect(testUser1)
+          .connect(testUser2)
           .registerGrantee(testUser2.address, testUser2.address, "publicKey1");
 
         await dataRegistry.setFile(1, testUser1.address, "ipfs://file1");
@@ -3728,7 +3728,7 @@ describe("DataPortabilityPermissions", () => {
       it("should handle permissions and servers together", async function () {
         // First register a grantee
         await granteesContract
-          .connect(testUser1)
+          .connect(testUser2)
           .registerGrantee(testUser2.address, testUser2.address, "publicKey1");
 
         // Add a permission for testUser1
@@ -4827,7 +4827,7 @@ describe("DataPortabilityPermissions", () => {
     describe("Grantee Registration", () => {
       it("should register a new grantee", async () => {
         const tx = await granteesContract
-          .connect(testUser1)
+          .connect(grantee1)
           .registerGrantee(grantee1.address, grantee1.address, "publicKey1");
 
         await expect(tx)
@@ -4848,7 +4848,7 @@ describe("DataPortabilityPermissions", () => {
       it("should reject grantee registration with empty public key", async () => {
         await expect(
           granteesContract
-            .connect(testUser1)
+            .connect(grantee1)
             .registerGrantee(grantee1.address, grantee1.address, ""),
         ).to.be.revertedWithCustomError(granteesContract, "EmptyPublicKey");
       });
@@ -4879,12 +4879,12 @@ describe("DataPortabilityPermissions", () => {
 
       it("should reject duplicate grantee registration", async () => {
         await granteesContract
-          .connect(testUser1)
+          .connect(grantee1)
           .registerGrantee(grantee1.address, grantee1.address, "publicKey1");
 
         await expect(
           granteesContract
-            .connect(testUser2)
+            .connect(grantee1)
             .registerGrantee(grantee1.address, grantee1.address, "publicKey2"),
         ).to.be.revertedWithCustomError(
           granteesContract,
@@ -4894,11 +4894,11 @@ describe("DataPortabilityPermissions", () => {
 
       it("should register multiple grantees", async () => {
         await granteesContract
-          .connect(testUser1)
+          .connect(grantee1)
           .registerGrantee(grantee1.address, grantee1.address, "publicKey1");
 
         await granteesContract
-          .connect(testUser2)
+          .connect(grantee2)
           .registerGrantee(grantee2.address, grantee2.address, "publicKey2");
 
         expect(await granteesContract.granteesCount()).to.equal(2);
@@ -4916,10 +4916,10 @@ describe("DataPortabilityPermissions", () => {
     describe("View Functions", () => {
       beforeEach(async () => {
         await granteesContract
-          .connect(testUser1)
+          .connect(grantee1)
           .registerGrantee(grantee1.address, grantee1.address, "publicKey1");
         await granteesContract
-          .connect(testUser2)
+          .connect(grantee2)
           .registerGrantee(grantee2.address, grantee2.address, "publicKey2");
       });
 
@@ -4973,7 +4973,7 @@ describe("DataPortabilityPermissions", () => {
     describe("Permission Management", () => {
       beforeEach(async () => {
         await granteesContract
-          .connect(testUser1)
+          .connect(grantee1)
           .registerGrantee(grantee1.address, grantee1.address, "publicKey1");
 
         // Grant permission manager role to deployOwner for testing
@@ -5469,7 +5469,7 @@ describe("DataPortabilityPermissions", () => {
       await deploy();
       // Register a grantee for testing
       await granteesContract
-        .connect(testUser1)
+        .connect(testUser2)
         .registerGrantee(testUser2.address, testUser2.address, "publicKey1");
     });
 

--- a/test/dataPortability/dataPortabilityServersV2.ts
+++ b/test/dataPortability/dataPortabilityServersV2.ts
@@ -906,7 +906,7 @@ describe("DataPortabilityServersV2", () => {
         .withArgs(serverOwner1.address, MAINTAINER_ROLE);
     });
 
-    it("should reject register and deregister while paused", async function () {
+    it("should reject register but allow deregister while paused", async function () {
       const { serverId } = await registerServer(
         serverOwner1,
         server1.address,
@@ -939,22 +939,51 @@ describe("DataPortabilityServersV2", () => {
         serverOwner1,
         deregistration,
       );
-      await expect(
-        serversContract
-          .connect(relayer)
-          .deregisterServerWithSignature(deregistration, deregSignature),
-      ).to.be.revertedWithCustomError(serversContract, "EnforcedPause");
+      // Deregistration is the only lever that strips a server's delegate
+      // authority (grants, writes, status flips). An incident is exactly
+      // when an owner needs it, so pause must NOT block it.
+      await serversContract
+        .connect(relayer)
+        .deregisterServerWithSignature(deregistration, deregSignature).should
+        .be.fulfilled;
+      (await serversContract.activeServerId(server1.address)).should.eq(
+        ethers.ZeroHash,
+      );
 
-      // After unpausing, both operations succeed again.
+      // After unpausing, registration succeeds again.
       await serversContract.connect(maintainer).unpause();
       await serversContract
         .connect(relayer)
         .registerServerWithSignature(registration, regSignature).should.be
         .fulfilled;
+    });
+
+    it("should let an owner revoke a compromised server during an incident pause", async function () {
+      const { serverId } = await registerServer(
+        serverOwner1,
+        server1.address,
+        PUBLIC_KEY_1,
+        SERVER_URL_1,
+      );
+      await serversContract.connect(maintainer).pause();
+
+      const deregistration: ServerDeregistration = {
+        ownerAddress: serverOwner1.address,
+        serverAddress: server1.address,
+        serverId,
+        deadline: await futureDeadline(),
+      };
+      const deregSignature = await signDeregistration(
+        serverOwner1,
+        deregistration,
+      );
       await serversContract
         .connect(relayer)
         .deregisterServerWithSignature(deregistration, deregSignature).should
         .be.fulfilled;
+      (await serversContract.getServer(serverId)).revokedAtBlock.should.not.eq(
+        0,
+      );
     });
 
     it("should allow maintainer to update the trusted forwarder", async function () {


### PR DESCRIPTION
## Problem

Two authorization gaps in the live V2 data-portability contracts.

**1. A paused `DataPortabilityServersV2` blocks the one action an incident needs.** `deregisterServerWithSignature` was `whenNotPaused`. Deregistration is the only way an owner strips a server's delegate authority: `PermissionsV2` and `DataRegistryV2` trust whatever `activeServerId[serverAddress]` says. If we pause during a compromise, owners cannot revoke the compromised server until we unpause, which reopens registration at the same time.

**2. Anyone could register any address as a grantee, permanently.** `registerGrantee` only required `owner == granteeAddress` on the non-maintainer path; the caller was never bound. Records are immutable, and V1 `Permissions` encrypts grant payloads to `granteeByAddress(addr).publicKey`. So an attacker could front-run a builder and bind an attacker-chosen public key to the builder's address forever.

## Fix

| Contract | Change |
|---|---|
| `DataPortabilityServersV2Implementation` | `deregisterServerWithSignature` drops `whenNotPaused` (natspec explains why). Registration stays paused. Signature, `serverId`, owner, and deadline checks are unchanged; no external calls. |
| `DataPortabilityGranteesImplementation` | Non-maintainer path now requires `_msgSender() == granteeAddress` as well as `owner == granteeAddress`. New `REGISTRAR_ROLE` (constant only, admin = `DEFAULT_ADMIN_ROLE`) may register on behalf of others without getting `pause()` / `updateTrustedForwarder()`. Zero-address / empty-key checks run before the authorization check so malformed input keeps its original revert reason. |
| Interfaces | Natspec updated to state the rules. |

No storage layout, selector, event, or error changes; safe as a UUPS implementation upgrade.

## ⚠️ Rollout prerequisite (mainnet)

The gateway relayer `0x80534af0b80ae88d653Cae0a8f5d2667439538a0` submits every `registerGrantee` on mainnet directly (last 50 txs on `0x8325…1234`, latest 2026-09-06) and **holds no role there** (`hasRole(MAINTAINER_ROLE, relayer) == false`). It has been relying on the open path this PR closes. On moksha the same key does hold `MAINTAINER_ROLE`, which is why the gateway code's assumption (`data-gateway/lib/settle.ts` "relayer MUST hold MAINTAINER_ROLE") never failed there.

Order of operations for mainnet, both from the admin Safe:

1. `Grantees.grantRole(REGISTRAR_ROLE, 0x80534af0b80ae88d653Cae0a8f5d2667439538a0)` where `REGISTRAR_ROLE = keccak256("REGISTRAR_ROLE")`. Harmless before the upgrade (the role is unknown to the current implementation).
2. Upgrade the Grantees implementation.

If step 2 lands without step 1, every gateway builder registration on mainnet reverts with `UnauthorizedRegistration()` until the grant is made. Moksha needs no action (`MAINTAINER_ROLE` still passes).

## Callers

- Gateway relayer: `data-gateway/lib/settle.ts` `submitRegisterGrantee` → needs the role grant above on mainnet; unchanged on moksha.
- No SDK or app calls `registerGrantee` directly (the SDK only ships the ABI).
- A builder registering itself from its own wallet still works.

## Tests

- `dataPortabilityServersV2.ts`: pause test now asserts register rejected / deregister fulfilled while paused, plus an incident-pause revocation scenario.
- `dataPortabilityGrantees.ts`: `registerGrantee caller binding` block (third-party rejected, owner mismatch rejected, self-registration and maintainer allowed, registrar allowed, registrar cannot pause / change forwarder).
- `dataPortabilityPermissions.ts` (V1): fixture registered grantees from an unrelated signer, which is exactly the shape being closed; rewritten to self-registration (64 call sites, identities unchanged).

Ran locally without the moksha fork (fresh deploys): `dataPortability/*` + `vanaStaking/vanaPool.ts` → 456 passing, 1 failing (`VanaPool "should have correct initial values"`, pre-existing on `dp_escrow`). Grantees alone: 53 passing.

## Rollout

Both are implementation upgrades behind the existing proxies (Safe-gated `_authorizeUpgrade`). Suggest bundling with the next Nethermind slot; neither needs a data migration. Mainnet Grantees needs the role grant above first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013vj2HQ89AiQ9CWhsvqaYc6
