### PR TITLE
fix(vanaStaking): zero-share price floor, saturating forfeit, enforce minStakeAmount, cap bonding payout

### DIFF
--- a/contracts/vanaStaking/vanaPoolEntity/VanaPoolEntityImplementation.sol
+++ b/contracts/vanaStaking/vanaPoolEntity/VanaPoolEntityImplementation.sol
@@ -106,7 +106,7 @@ contract VanaPoolEntityImplementation is
      * @notice Returns the version of the contract
      */
     function version() external pure virtual override returns (uint256) {
-        return 2;
+        return 3;
     }
 
     /**
@@ -153,7 +153,15 @@ contract VanaPoolEntityImplementation is
     function vanaToEntityShare(uint256 entityId) external view override returns (uint256) {
         Entity storage entity = _entities[entityId];
 
-        return entity.activeRewardPool > 0 ? (entity.totalShares * 1e18) / entity.activeRewardPool : 1e18;
+        // With no shares outstanding the pool prices 1:1. Unstakes pay
+        // floor(shares * price), so the last exit can leave rounding dust in
+        // activeRewardPool; pricing that dust against zero shares would return
+        // 0 and make every subsequent stake() revert with InsufficientStakeAmount.
+        if (entity.totalShares == 0 || entity.activeRewardPool == 0) {
+            return 1e18;
+        }
+
+        return (entity.totalShares * 1e18) / entity.activeRewardPool;
     }
 
     /**
@@ -382,7 +390,7 @@ contract VanaPoolEntityImplementation is
     /**
      * @notice Update an entity's max APY
      * @param entityId The entity ID
-     * @param newMaxAPY The new max APY in basis points (1% = 100)
+     * @param newMaxAPY The new max APY, 1e18-scaled (6% = 6e18), matching `calculateYield`
      */
     function updateEntityMaxAPY(uint256 entityId, uint256 newMaxAPY) external override onlyRole(MAINTAINER_ROLE) {
         Entity storage entity = _entities[entityId];
@@ -485,7 +493,12 @@ contract VanaPoolEntityImplementation is
         // Add forfeited rewards to locked pool for gradual redistribution
         // (activeRewardPool was already reduced by updateEntityPool)
         entity.lockedRewardPool += amount;
-        entity.totalDistributedRewards -= amount;
+        // Rounding dust lets a position's value exceed its cost basis by a wei
+        // that was never counted as distributed. Saturate instead of reverting,
+        // otherwise that unstake is blocked for the rest of the bonding period.
+        entity.totalDistributedRewards = entity.totalDistributedRewards > amount
+            ? entity.totalDistributedRewards - amount
+            : 0;
 
         emit ForfeitedRewardsReturned(entityId, amount);
     }

--- a/contracts/vanaStaking/vanaPoolStaking/VanaPoolStakingImplementation.sol
+++ b/contracts/vanaStaking/vanaPoolStaking/VanaPoolStakingImplementation.sol
@@ -153,7 +153,7 @@ contract VanaPoolStakingImplementation is
      * @notice Returns the version of the contract
      */
     function version() external pure virtual override returns (uint256) {
-        return 2;
+        return 3;
     }
 
     /**
@@ -463,6 +463,10 @@ contract VanaPoolStakingImplementation is
             revert InvalidRecipient();
         }
 
+        if (stakeAmount < minStakeAmount) {
+            revert InsufficientStakeAmount();
+        }
+
         // Process entity rewards through VanaPoolEntity to ensure current share price is used
         vanaPoolEntity.processRewards(entityId);
 
@@ -659,8 +663,10 @@ contract VanaPoolStakingImplementation is
             vanaToReturn = shareValue;
             // Note: rewards already tracked above via vestedRewards -> realizedRewards
         } else {
-            // Still in bonding period: user receives only principal (forfeits rewards)
-            vanaToReturn = proportionalCostBasis;
+            // Still in bonding period: user receives only principal (forfeits rewards).
+            // Share issuance is floor()'d, so cost basis can sit a wei above the
+            // burned shares' value; never pay out more than the pool is debited.
+            vanaToReturn = proportionalCostBasis < shareValue ? proportionalCostBasis : shareValue;
             // Calculate forfeited rewards (difference between share value and cost basis)
             if (shareValue > proportionalCostBasis) {
                 forfeitedRewards = shareValue - proportionalCostBasis;

--- a/test/vanaStaking/forkVanaPool.ts
+++ b/test/vanaStaking/forkVanaPool.ts
@@ -173,7 +173,7 @@ describe("VanaPool Fork Tests (Moksha)", () => {
     // Verify version
     const version = await vanaPoolStakingV2.version();
     console.log(`Contract version: ${version}`);
-    version.should.eq(2n, "Version should be 2 after upgrade");
+    version.should.eq(3n, "Version should be 3 after upgrade");
 
     // Verify entity data preserved
     console.log(`\nVerifying entity data...`);

--- a/test/vanaStaking/vanaPool.ts
+++ b/test/vanaStaking/vanaPool.ts
@@ -157,7 +157,7 @@ describe("VanaPool", () => {
       (
         await vanaPoolStaking.hasRole(MAINTAINER_ROLE, maintainer.address)
       ).should.eq(true);
-      (await vanaPoolStaking.version()).should.eq(2);
+      (await vanaPoolStaking.version()).should.eq(3);
       (await vanaPoolStaking.minStakeAmount()).should.eq(minStakeAmount);
       (await vanaPoolStaking.vanaPoolEntity()).should.eq(vanaPoolEntity.target);
       (await vanaPoolStaking.vanaPoolTreasury()).should.eq(
@@ -180,7 +180,7 @@ describe("VanaPool", () => {
       (
         await vanaPoolEntity.hasRole(VANA_POOL_ROLE, vanaPoolStaking.target)
       ).should.eq(true);
-      (await vanaPoolEntity.version()).should.eq(1);
+      (await vanaPoolEntity.version()).should.eq(3);
       (await vanaPoolEntity.minRegistrationStake()).should.eq(
         minRegistrationStake,
       );
@@ -3406,6 +3406,163 @@ describe("VanaPool", () => {
 
     it("should test", async function () {
       console.log(await vanaPoolEntity.calculateExponential(parseEther(2)));
+    });
+  });
+
+  describe("Audit hardening (2026-09)", () => {
+    beforeEach(async () => {
+      await deploy();
+      await vanaPoolEntity.connect(maintainer).createEntity(
+        { ownerAddress: user1.address, name: "Hardened Entity" },
+        { value: minRegistrationStake },
+      );
+    });
+
+    // Drive the share price away from 1:1 so floor() rounding leaves dust.
+    const makePriceIrregular = async () => {
+      await vanaPoolEntity.connect(user3).addRewards(1, { value: parseEther(10) });
+      await helpers.time.increase(year);
+      await vanaPoolEntity.processRewards(1);
+    };
+
+    describe("zero-share price floor", () => {
+      it("should accept new stakes after the last staker exits with rounding dust left in the pool", async function () {
+        await makePriceIrregular();
+
+        // Second staker makes totalShares irregular, so the owner's exit is floor()'d.
+        await vanaPoolStaking
+          .connect(user2)
+          .stake(1, user2.address, 0, { value: parseEther(3) });
+
+        const ownerShares = (await vanaPoolStaking.stakerEntities(user1.address, 1)).shares;
+        await vanaPoolStaking.connect(user1).unstake(1, ownerShares, 0);
+
+        const user2Shares = (await vanaPoolStaking.stakerEntities(user2.address, 1)).shares;
+        await vanaPoolStaking.connect(user2).unstake(1, user2Shares, 0);
+
+        const drained = await vanaPoolEntity.entities(1);
+        drained.totalShares.should.eq(0n);
+        // The test only proves something if dust is actually left behind.
+        drained.activeRewardPool.should.be.gt(0n);
+
+        // Price must fall back to 1:1 with no shares outstanding, not 0.
+        (await vanaPoolEntity.vanaToEntityShare(1)).should.eq(parseEther(1));
+        (await vanaPoolEntity.entityShareToVana(1)).should.eq(parseEther(1));
+
+        const stakeAmount = parseEther(2);
+        await vanaPoolStaking
+          .connect(user4)
+          .stake(1, user4.address, 0, { value: stakeAmount }).should.be.fulfilled;
+
+        (await vanaPoolStaking.stakerEntities(user4.address, 1)).shares.should.eq(stakeAmount);
+        const revived = await vanaPoolEntity.entities(1);
+        revived.totalShares.should.eq(stakeAmount);
+        revived.activeRewardPool.should.eq(drained.activeRewardPool + stakeAmount);
+      });
+    });
+
+    describe("returnForfeitedRewards saturation", () => {
+      it("should not underflow totalDistributedRewards on a pool that never distributed rewards", async function () {
+        await vanaPoolEntity.connect(owner).grantRole(VANA_POOL_ROLE, owner.address);
+
+        const before = await vanaPoolEntity.entities(1);
+        before.totalDistributedRewards.should.eq(0n);
+
+        // Rounding dust can make a bonding-period unstake "forfeit" a wei that was
+        // never counted as distributed. That must not brick the unstake.
+        await vanaPoolEntity.connect(owner).returnForfeitedRewards(1, 5n).should.be.fulfilled;
+
+        const after = await vanaPoolEntity.entities(1);
+        after.totalDistributedRewards.should.eq(0n);
+        after.lockedRewardPool.should.eq(before.lockedRewardPool + 5n);
+      });
+    });
+
+    describe("minStakeAmount enforcement", () => {
+      it("should reject a stake below minStakeAmount", async function () {
+        await vanaPoolStaking
+          .connect(user2)
+          .stake(1, user2.address, 0, { value: minStakeAmount - 1n })
+          .should.be.rejectedWith("InsufficientStakeAmount()");
+      });
+
+      it("should accept a stake of exactly minStakeAmount", async function () {
+        await vanaPoolStaking
+          .connect(user2)
+          .stake(1, user2.address, 0, { value: minStakeAmount }).should.be.fulfilled;
+      });
+
+      it("should accept any non-zero-share stake when minStakeAmount is 0", async function () {
+        await vanaPoolStaking.connect(maintainer).updateMinStakeAmount(0);
+        await vanaPoolStaking
+          .connect(user2)
+          .stake(1, user2.address, 0, { value: 1000n }).should.be.fulfilled;
+      });
+    });
+
+    describe("bonding-period payout is capped at share value", () => {
+      it("should never pay out more than the burned shares are worth", async function () {
+        // Irregular price with NO remaining stream: a live stream adds ~1e9 wei
+        // per block and hides a 1-wei rounding deficit.
+        await vanaPoolEntity.connect(user3).addRewards(1, { value: 12345678901234567n });
+        await helpers.time.increase(year);
+        await vanaPoolEntity.processRewards(1);
+        (await vanaPoolEntity.entities(1)).lockedRewardPool.should.eq(0n);
+
+        // The fixture deploys with a zero bonding period; the cap only matters
+        // while a position is still bonding.
+        await vanaPoolStaking.connect(maintainer).updateBondingPeriod(week);
+
+        // Exact replica of the contract's integer math, used to find a
+        // (firstStake, secondStake) pair where the in-bonding cost basis ends
+        // up above the position's floor()'d value.
+        const ONE = parseEther(1);
+        const ent = await vanaPoolEntity.entities(1);
+        const sim = (P0: bigint, S0: bigint, a1: bigint, a2: bigint) => {
+          let P = P0, S = S0, shares = 0n, cost = 0n;
+          const stakeSim = (a: bigint, bonding: boolean) => {
+            const issued = ((S * ONE) / P * a) / ONE;
+            if (issued === 0n) return false;
+            const shareToVana = (P * ONE) / S;
+            const newShares = shares + issued;
+            if (!bonding) cost = (newShares * shareToVana) / ONE;
+            else cost += a;
+            shares = newShares; S += issued; P += a;
+            return true;
+          };
+          if (!stakeSim(a1, false) || !stakeSim(a2, true)) return null;
+          const value = (shares * ((P * ONE) / S)) / ONE;
+          return { cost, value, P, S, shares };
+        };
+        let pair: { a1: bigint; a2: bigint; cost: bigint; value: bigint; P: bigint; S: bigint; shares: bigint } | null = null;
+        outer: for (let i = 0n; i < 400n; i++) {
+          for (let k = 0n; k < 400n; k++) {
+            const a1 = parseEther(1.5) + i, a2 = parseEther(0.7) + k;
+            const r = sim(ent.activeRewardPool, ent.totalShares, a1, a2);
+            if (r && r.cost > r.value) { pair = { a1, a2, ...r }; break outer; }
+          }
+        }
+        // Keep the test honest: it must actually hit the rounding case.
+        (pair !== null).should.eq(true);
+
+        await vanaPoolStaking.connect(user2).stake(1, user2.address, 0, { value: pair!.a1 });
+        await vanaPoolStaking.connect(user2).stake(1, user2.address, 0, { value: pair!.a2 });
+        const pos = await vanaPoolStaking.stakerEntities(user2.address, 1);
+        const value = (pos.shares * (await vanaPoolEntity.entityShareToVana(1))) / ONE;
+        pos.costBasis.should.eq(pair!.cost);
+        value.should.eq(pair!.value);
+        pos.costBasis.should.be.gt(value);
+
+        const tx = await vanaPoolStaking.connect(user2).unstake(1, pos.shares, 0);
+        const receipt = await getReceipt(tx);
+        const log = receipt.logs
+          .map((l) => { try { return vanaPoolStaking.interface.parseLog(l); } catch { return null; } })
+          .find((l) => l && l.name === "Unstaked");
+        (log !== undefined && log !== null).should.eq(true);
+        // Without the cap the payout equals costBasis, one wei above the
+        // burned shares' value.
+        log!.args.amount.should.eq(value);
+      });
     });
   });
 });


### PR DESCRIPTION
## Problem

Pre-audit hardening of the share-price staking vault (`VanaPoolEntity` + `VanaPoolStaking`), ahead of the Nethermind slot. Four defects, all reproduced in tests:

| # | Where | Defect | Effect |
|---|---|---|---|
| 1 | `Entity.vanaToEntityShare` | Prices the pool against `totalShares == 0` when rounding dust is left in `activeRewardPool` after the last exit → returns `0` | Every later `stake()` reverts with `InsufficientStakeAmount`. No admin reset (`removeEntity` is commented out). `lockedRewardPool` keeps streaming to nobody. Entity 1 holds ~15.7k VANA locked. |
| 2 | `Entity.returnForfeitedRewards` | `totalDistributedRewards -= amount` underflows when a bonding position's value exceeds its cost basis by rounding dust that was never "distributed" | That unstake reverts until the bonding period ends. |
| 3 | `Staking.stake` | `minStakeAmount` (storage var, initializer arg, `updateMinStakeAmount`) is never read | Dust positions; the parameter is a no-op. |
| 4 | `Staking._unstake` | Bonding-period payout = `proportionalCostBasis`, which can sit 1 wei above the burned shares' value because issuance is `floor()`'d | Treasury pays the excess from other entities' balances. Wei-level, but it is a leak. |

## Fix

- **Entity**: `vanaToEntityShare` returns `1e18` when `totalShares == 0` (a pool with no shares outstanding prices 1:1); `returnForfeitedRewards` saturates; natspec for `maxAPY` corrected to 1e18-scale; `version()` → 3.
- **Staking**: `stake()` reverts with `InsufficientStakeAmount` below `minStakeAmount` (`registerEntityStake` bypasses `stake()`, so entity creation is unaffected); `_unstake` pays `min(proportionalCostBasis, shareValue)` during bonding; `version()` → 3.

No storage layout change on either contract. Hunks avoid the regions PR #75 rewrites (`entities()`, `processRewards`, `updateEntityMaxAPY` tail, `calculateYield`, `IVanaPoolEntity.sol:77`).

## Tests (`test/vanaStaking/vanaPool.ts`, new `Audit hardening (2026-09)` block)

- Last-staker exit with observed dust (`activeRewardPool > 0`, `totalShares == 0`) → price falls back to 1:1 and a new stake succeeds.
- `returnForfeitedRewards(1, 5)` on a pool with `totalDistributedRewards == 0` → no revert, saturates to 0, locked pool credited.
- Stake below / at / with `minStakeAmount == 0`.
- Payout cap: an exact integer replica of `stake`/`_unstake` searches for a `(firstStake, secondStake)` pair where the in-bonding cost basis ends 1 wei above value, replays it on-chain (asserts `costBasis > value`), and checks the `Unstaked` amount equals value. Without the cap it pays cost basis (observed: `…999` vs `…997`).
- Version expectations updated (the pre-existing `"should have correct initial values"` failure was the Entity version assertion).

Ran without the moksha fork (fresh deploys): `test/vanaStaking/vanaPool.ts` 89 passing, 0 failing. `forkVanaPool.ts` expectation updated but not run here (needs the fork).

## Left out on purpose

- **APY ceiling** in `updateEntityMaxAPY` (maintainer can release the whole locked pool in one call): sits inside #75's hunk; suggest adding it there. Held by the Safe today.
- **`IVanaPoolEntity.sol:77` parameter order** vs the implementation: same region as #75.
- **`costBasis == 0` on every pre-V2 position** (the V1 struct had only `shares`; the fork test codifies it). Payouts are safe today, but reward accounting reports principal as rewards and any future commission/matured-weight formula on `value − costBasis` would charge the full principal. Proposal: lazy migration on first touch (`if (costBasis == 0 && shares > 0) costBasis = shares · price`) or a sentinel rule; product call on what counts as principal for legacy stakers, so not in this PR.
- **Registration-stake floor**: `CannotRemoveRegistrationStake` is declared and never used; the owner can unstake the registration stake. Moot while `createEntity` is maintainer-only; owner's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013vj2HQ89AiQ9CWhsvqaYc6
