### PR TITLE
feat(staking): entity commission on reward distributions

### DIFF
--- a/contracts/vanaStaking/vanaPoolEntity/VanaPoolEntityImplementation.sol
+++ b/contracts/vanaStaking/vanaPoolEntity/VanaPoolEntityImplementation.sol
@@ -16,12 +16,18 @@ contract VanaPoolEntityImplementation is
 {
     using EnumerableSet for EnumerableSet.UintSet;
 
+    // Commission is expressed as percent * 1e18, matching maxAPY's scale, so
+    // 100% == 100e18 and this is the divisor when skimming a distribution.
+    uint256 public constant MAX_COMMISSION = 100e18;
+
     // Events for entity lifecycle and operations
     event EntityCreated(uint256 indexed entityId, address ownerAddress, string name, uint256 maxAPY);
     event EntityUpdated(uint256 indexed entityId, address ownerAddress, string name);
     event EntityStatusUpdated(uint256 indexed entityId, EntityStatus newStatus);
     event EntityMaxAPYUpdated(uint256 indexed entityId, uint256 newMaxAPY);
     event EntityRewardModelUpdated(uint256 indexed entityId, RewardModel model);
+    event EntityCommissionUpdated(uint256 indexed entityId, uint256 newCommissionRate);
+    event CommissionClaimed(uint256 indexed entityId, address indexed to, uint256 amount);
     event RewardsAdded(uint256 indexed entityId, uint256 amount);
     event RewardsDistributed(uint256 indexed entityId, uint256 amount, uint64 start, uint32 duration);
     event QueuedRewardsToppedUp(uint256 indexed entityId, uint256 addedAmount, uint256 newQueuedTotal);
@@ -504,9 +510,15 @@ contract VanaPoolEntityImplementation is
             toDistribute = entity.lockedRewardPool;
         }
 
+        // Skim the entity's commission before the remainder raises the share
+        // price. Model-agnostic: applies to both APY drip and STREAM vesting.
+        uint256 commission = (toDistribute * entity.commissionRate) / MAX_COMMISSION;
+        uint256 delegatorReward = toDistribute - commission;
+
         entity.lockedRewardPool -= toDistribute;
-        entity.activeRewardPool += toDistribute;
-        entity.totalDistributedRewards += toDistribute;
+        entity.activeRewardPool += delegatorReward; // to delegators via share price
+        entity.accruedCommission += commission; // operator's cut, claimable
+        entity.totalDistributedRewards += delegatorReward;
 
         // Update last process timestamp
         entity.lastUpdateTimestamp = block.timestamp;
@@ -557,6 +569,80 @@ contract VanaPoolEntityImplementation is
         entity.rewardModel = model;
 
         emit EntityRewardModelUpdated(entityId, model);
+    }
+
+    /**
+     * @notice Set an entity's commission -- the operator's cut of each reward
+     *         distribution, taken before the remainder raises the share price
+     *         for delegators. Percent * 1e18 (100% == MAX_COMMISSION). Settles
+     *         pending rewards at the old rate first, so the change is forward-only.
+     *
+     * @param entityId The entity ID
+     * @param newCommissionRate New commission rate, 0..MAX_COMMISSION
+     */
+    function updateEntityCommission(uint256 entityId, uint256 newCommissionRate) external override {
+        Entity storage entity = _entities[entityId];
+
+        if (entity.status != EntityStatus.Active) {
+            revert InvalidEntityStatus();
+        }
+        if (msg.sender != entity.ownerAddress && !hasRole(MAINTAINER_ROLE, msg.sender)) {
+            revert NotEntityOwner();
+        }
+        if (newCommissionRate > MAX_COMMISSION) {
+            revert InvalidParam();
+        }
+
+        // Settle at the old rate so the new rate only applies to future rewards.
+        processRewards(entityId);
+
+        entity.commissionRate = newCommissionRate;
+
+        emit EntityCommissionUpdated(entityId, newCommissionRate);
+    }
+
+    /**
+     * @notice Claim an entity's accrued commission to its owner. Settles first
+     *         so freshly-vested commission is included.
+     *
+     * @param entityId The entity ID
+     */
+    function claimCommission(uint256 entityId) external override whenNotPaused nonReentrant {
+        Entity storage entity = _entities[entityId];
+
+        if (msg.sender != entity.ownerAddress && !hasRole(MAINTAINER_ROLE, msg.sender)) {
+            revert NotEntityOwner();
+        }
+
+        processRewards(entityId);
+
+        uint256 amount = entity.accruedCommission;
+        if (amount == 0) {
+            revert InvalidParam();
+        }
+
+        entity.accruedCommission = 0;
+
+        bool success = vanaPoolStaking.vanaPoolTreasury().transferVana(payable(entity.ownerAddress), amount);
+        if (!success) {
+            revert TransferFailed();
+        }
+
+        emit CommissionClaimed(entityId, entity.ownerAddress, amount);
+    }
+
+    /**
+     * @notice An entity's commission rate (percent * 1e18).
+     */
+    function entityCommissionRate(uint256 entityId) external view override returns (uint256) {
+        return _entities[entityId].commissionRate;
+    }
+
+    /**
+     * @notice Wei of commission accrued to an entity owner, not yet claimed.
+     */
+    function entityAccruedCommission(uint256 entityId) external view override returns (uint256) {
+        return _entities[entityId].accruedCommission;
     }
 
     /**

--- a/contracts/vanaStaking/vanaPoolEntity/interfaces/IVanaPoolEntity.sol
+++ b/contracts/vanaStaking/vanaPoolEntity/interfaces/IVanaPoolEntity.sol
@@ -51,6 +51,9 @@ interface IVanaPoolEntity {
         //     only ever held in the _entities mapping (per-key base slot) ---
         RewardModel rewardModel; // APY (0, default) or STREAM
         RewardSchedule rewardSchedule; // only used while rewardModel == STREAM
+        // --- appended in the commission upgrade; append-safe as above ---
+        uint256 commissionRate; // operator cut of each distribution, percent * 1e18 (100% = 100e18); default 0
+        uint256 accruedCommission; // wei owed to the entity owner, not yet claimed
     }
 
     function version() external pure returns (uint256);
@@ -106,6 +109,11 @@ interface IVanaPoolEntity {
     function updateEntityMaxAPY(uint256 entityId, uint256 newMaxAPY) external;
 
     function updateEntityRewardModel(uint256 entityId, RewardModel model) external;
+
+    function updateEntityCommission(uint256 entityId, uint256 newCommissionRate) external;
+    function claimCommission(uint256 entityId) external;
+    function entityCommissionRate(uint256 entityId) external view returns (uint256);
+    function entityAccruedCommission(uint256 entityId) external view returns (uint256);
 
     // Get entities
     function activeEntitiesValues() external view returns (uint256[] memory);

--- a/test/foundry/DistributeRewards.t.sol
+++ b/test/foundry/DistributeRewards.t.sol
@@ -67,7 +67,9 @@ contract DistributeRewardsTest is Test {
                 lastUpdateTimestamp: START,
                 totalDistributedRewards: 0,
                 rewardModel: IVanaPoolEntity.RewardModel.STREAM,
-                rewardSchedule: sched
+                rewardSchedule: sched,
+                commissionRate: 0,
+                accruedCommission: 0
             })
         );
     }

--- a/test/foundry/EntityCommission.t.sol
+++ b/test/foundry/EntityCommission.t.sol
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import {Test} from "forge-std/Test.sol";
+import {VanaPoolEntityImplementation} from "../../contracts/vanaStaking/vanaPoolEntity/VanaPoolEntityImplementation.sol";
+import {IVanaPoolEntity} from "../../contracts/vanaStaking/vanaPoolEntity/interfaces/IVanaPoolEntity.sol";
+
+/// @dev The commission skim is pure accounting inside processRewards (locked ->
+///      active + accruedCommission), so a bare harness that seeds an entity is
+///      enough. The claim path (treasury pull) is covered in the e2e test.
+contract CommissionHarness is VanaPoolEntityImplementation {
+    function grantMaintainer(address who) external {
+        _grantRole(MAINTAINER_ROLE, who);
+    }
+
+    function setEntity(uint256 id, IVanaPoolEntity.Entity calldata e) external {
+        _entities[id] = e;
+    }
+
+    function getEntity(uint256 id) external view returns (IVanaPoolEntity.Entity memory) {
+        return _entities[id];
+    }
+}
+
+contract EntityCommissionTest is Test {
+    CommissionHarness h;
+
+    address entityOwner = makeAddr("entityOwner");
+    address maintainer = makeAddr("maintainer");
+    address stranger = makeAddr("stranger");
+
+    uint64 constant START = 1_000_000;
+    uint256 constant ID = 1;
+
+    function setUp() public {
+        h = new CommissionHarness();
+        h.grantMaintainer(maintainer);
+        vm.warp(START);
+    }
+
+    function _empty() internal pure returns (IVanaPoolEntity.RewardSchedule memory) {
+        return IVanaPoolEntity.RewardSchedule(0, 0, 0, 0, 0, 0, 0);
+    }
+
+    function _seed(
+        IVanaPoolEntity.RewardModel model,
+        uint256 locked,
+        uint256 active,
+        uint256 commissionRate,
+        IVanaPoolEntity.RewardSchedule memory sched
+    ) internal {
+        h.setEntity(
+            ID,
+            IVanaPoolEntity.Entity({
+                ownerAddress: entityOwner,
+                status: IVanaPoolEntity.EntityStatus.Active,
+                name: "e",
+                maxAPY: 6e18,
+                lockedRewardPool: locked,
+                activeRewardPool: active,
+                totalShares: active > 0 ? active : 100 ether,
+                lastUpdateTimestamp: START,
+                totalDistributedRewards: 0,
+                rewardModel: model,
+                rewardSchedule: sched,
+                commissionRate: commissionRate,
+                accruedCommission: 0
+            })
+        );
+    }
+
+    // ---- skim: APY ----
+
+    function test_apySkimSplitsAndConserves() public {
+        _seed(IVanaPoolEntity.RewardModel.APY, 1_000 ether, 100 ether, 10e18, _empty()); // 10%
+        vm.warp(START + 365 days);
+
+        uint256 toDistribute = h.calculateYield(100 ether, 6e18, 365 days);
+        uint256 commission = toDistribute / 10;
+
+        h.processRewards(ID);
+
+        IVanaPoolEntity.Entity memory e = h.getEntity(ID);
+        assertEq(e.accruedCommission, commission, "10% skimmed");
+        assertEq(e.activeRewardPool, 100 ether + (toDistribute - commission), "delegator remainder to active");
+        assertEq(e.lockedRewardPool, 1_000 ether - toDistribute, "locked -= full distribution");
+        assertEq(
+            e.lockedRewardPool + e.activeRewardPool + e.accruedCommission,
+            1_100 ether,
+            "locked + active + commission conserved"
+        );
+    }
+
+    // ---- skim: STREAM ----
+
+    function test_streamSkimSplits() public {
+        IVanaPoolEntity.RewardSchedule memory sched =
+            IVanaPoolEntity.RewardSchedule(100 ether, START, 10 days, uint32(START), 0, 0, 0);
+        _seed(IVanaPoolEntity.RewardModel.STREAM, 100 ether, 0, 20e18, sched); // 20%
+
+        vm.warp(START + 5 days); // half vests -> 50 ether distributed
+        h.processRewards(ID);
+
+        IVanaPoolEntity.Entity memory e = h.getEntity(ID);
+        assertEq(e.accruedCommission, 10 ether, "20% of 50");
+        assertEq(e.activeRewardPool, 40 ether, "80% to delegators");
+        assertEq(e.lockedRewardPool, 50 ether, "half still locked");
+    }
+
+    // ---- zero commission == old behaviour ----
+
+    function test_zeroCommission_allToDelegators() public {
+        _seed(IVanaPoolEntity.RewardModel.APY, 1_000 ether, 100 ether, 0, _empty());
+        vm.warp(START + 365 days);
+        uint256 toDistribute = h.calculateYield(100 ether, 6e18, 365 days);
+
+        h.processRewards(ID);
+
+        IVanaPoolEntity.Entity memory e = h.getEntity(ID);
+        assertEq(e.accruedCommission, 0, "no commission");
+        assertEq(e.activeRewardPool, 100 ether + toDistribute, "everything to delegators");
+    }
+
+    // ---- rate change settles at the old rate ----
+
+    function test_updateCommission_settlesAtOldRateFirst() public {
+        _seed(IVanaPoolEntity.RewardModel.APY, 1_000 ether, 100 ether, 10e18, _empty()); // 10%
+        vm.warp(START + 365 days);
+        uint256 pending = h.calculateYield(100 ether, 6e18, 365 days);
+
+        vm.prank(entityOwner);
+        h.updateEntityCommission(ID, 20e18); // raise to 20%
+
+        IVanaPoolEntity.Entity memory e = h.getEntity(ID);
+        assertEq(e.commissionRate, 20e18, "new rate stored");
+        assertEq(e.accruedCommission, pending / 10, "pending settled at OLD 10%");
+    }
+
+    // ---- access + bounds ----
+
+    function test_onlyOwnerOrMaintainerSetsCommission() public {
+        _seed(IVanaPoolEntity.RewardModel.APY, 1_000 ether, 100 ether, 0, _empty());
+        vm.prank(stranger);
+        vm.expectRevert(VanaPoolEntityImplementation.NotEntityOwner.selector);
+        h.updateEntityCommission(ID, 10e18);
+    }
+
+    function test_maintainerCanSetCommission() public {
+        _seed(IVanaPoolEntity.RewardModel.APY, 1_000 ether, 100 ether, 0, _empty());
+        vm.prank(maintainer);
+        h.updateEntityCommission(ID, 15e18);
+        assertEq(h.entityCommissionRate(ID), 15e18);
+    }
+
+    function test_rejectsAboveMaxCommission() public {
+        _seed(IVanaPoolEntity.RewardModel.APY, 1_000 ether, 100 ether, 0, _empty());
+        vm.prank(entityOwner);
+        vm.expectRevert(VanaPoolEntityImplementation.InvalidParam.selector);
+        h.updateEntityCommission(ID, 100e18 + 1); // > MAX_COMMISSION
+    }
+
+    function test_hundredPercentCommission_delegatorsGetNothing() public {
+        _seed(IVanaPoolEntity.RewardModel.APY, 1_000 ether, 100 ether, 100e18, _empty()); // 100%
+        vm.warp(START + 365 days);
+        uint256 toDistribute = h.calculateYield(100 ether, 6e18, 365 days);
+
+        h.processRewards(ID);
+
+        IVanaPoolEntity.Entity memory e = h.getEntity(ID);
+        assertEq(e.accruedCommission, toDistribute, "all to operator");
+        assertEq(e.activeRewardPool, 100 ether, "nothing to delegators");
+    }
+}

--- a/test/foundry/EntityRewardModelSwitch.t.sol
+++ b/test/foundry/EntityRewardModelSwitch.t.sol
@@ -57,7 +57,9 @@ contract EntityRewardModelSwitchTest is Test {
                 lastUpdateTimestamp: START,
                 totalDistributedRewards: 0,
                 rewardModel: IVanaPoolEntity.RewardModel.APY,
-                rewardSchedule: _emptySchedule()
+                rewardSchedule: _emptySchedule(),
+                commissionRate: 0,
+                accruedCommission: 0
             })
         );
     }
@@ -99,7 +101,9 @@ contract EntityRewardModelSwitchTest is Test {
                 lastUpdateTimestamp: START,
                 totalDistributedRewards: 0,
                 rewardModel: IVanaPoolEntity.RewardModel.STREAM,
-                rewardSchedule: sched
+                rewardSchedule: sched,
+                commissionRate: 0,
+                accruedCommission: 0
             })
         );
 

--- a/test/foundry/EntityRewardViews.t.sol
+++ b/test/foundry/EntityRewardViews.t.sol
@@ -39,7 +39,9 @@ contract EntityRewardViewsTest is Test {
                 lastUpdateTimestamp: START,
                 totalDistributedRewards: 0,
                 rewardModel: model,
-                rewardSchedule: sched
+                rewardSchedule: sched,
+                commissionRate: 0,
+                accruedCommission: 0
             })
         );
     }
@@ -107,7 +109,9 @@ contract EntityRewardViewsTest is Test {
                 lastUpdateTimestamp: START,
                 totalDistributedRewards: 0,
                 rewardModel: model,
-                rewardSchedule: sched
+                rewardSchedule: sched,
+                commissionRate: 0,
+                accruedCommission: 0
             })
         );
     }

--- a/test/foundry/RewardModelsE2E.t.sol
+++ b/test/foundry/RewardModelsE2E.t.sol
@@ -73,6 +73,8 @@ contract RewardModelsE2ETest is Test {
         vm.startPrank(owner);
         staking.updateVanaPoolEntity(address(entity));
         staking.updateVanaPoolTreasury(address(treasury));
+        // let the entity pull commission from the treasury (commission upgrade wiring)
+        treasury.grantRole(treasury.DEFAULT_ADMIN_ROLE(), address(entity));
         vm.stopPrank();
 
         vm.deal(owner, 10_000 ether);
@@ -215,5 +217,33 @@ contract RewardModelsE2ETest is Test {
 
         int256 net = int256(staker.balance) - int256(balBefore);
         assertGt(net, 0, "late exit collects the stream rewards it earned");
+    }
+
+    // ---- commission ----
+
+    function test_commission_delegatorEarnsPostCut_ownerClaims() public {
+        uint256 entityId = _createEntity();
+
+        // 20% commission, fund the APY drip
+        vm.startPrank(owner);
+        entity.updateEntityCommission(entityId, 20e18);
+        entity.addRewards{value: 100 ether}(entityId);
+        vm.stopPrank();
+        assertEq(entity.entityCommissionRate(entityId), 20e18);
+
+        // delegator earns the post-commission remainder
+        int256 net = _stakeEarnUnstake(entityId, 365 days);
+        assertGt(net, 0, "delegator earned post-commission rewards");
+
+        // owner claims the accrued commission out of the treasury
+        uint256 accrued = entity.entityAccruedCommission(entityId);
+        assertGt(accrued, 0, "commission accrued to the operator");
+
+        uint256 ownerBalBefore = entityOwner.balance;
+        vm.prank(owner);
+        entity.claimCommission(entityId);
+
+        assertEq(entityOwner.balance - ownerBalBefore, accrued, "owner received the commission");
+        assertEq(entity.entityAccruedCommission(entityId), 0, "accrued reset after claim");
     }
 }

--- a/test/foundry/TopUpQueuedRewards.t.sol
+++ b/test/foundry/TopUpQueuedRewards.t.sol
@@ -73,7 +73,9 @@ contract TopUpQueuedRewardsTest is Test {
                 lastUpdateTimestamp: START,
                 totalDistributedRewards: 0,
                 rewardModel: model,
-                rewardSchedule: sched
+                rewardSchedule: sched,
+                commissionRate: 0,
+                accruedCommission: 0
             })
         );
     }


### PR DESCRIPTION
## Summary

Adds **operator commission** to entities: an entity keeps `commissionRate` of each reward distribution before the remainder raises the share price for delegators. Stacked on #75 (dual reward models) — the skim lives in `processRewards` on `toDistribute`, so it's **model-agnostic**, applying to both the APY drip and STREAM vesting exactly like the bonding period does.

> **Base is `feat/staking-rewards-models` (PR #75), not `main`.** Review/merge #75 first; this diff shows only the commission changes on top.

## Design

- **Rate is `percent × 1e18`, matching `maxAPY`** (100% == `MAX_COMMISSION` == `100e18`). Default `0` keeps every existing entity commission-free, so the upgrade is behavior-neutral. (Chose this over basis points to keep both entity rate fields on one scale.)
- **The skim** (five lines in `processRewards`): `commission = toDistribute × rate / MAX_COMMISSION` → `accruedCommission` (claimable); remainder → `activeRewardPool` (delegators, via share price). `locked + active + accruedCommission` is conserved.
- **`updateEntityCommission`** — owner-or-maintainer, settles at the old rate first (forward-only change), capped at `MAX_COMMISSION`.
- **`claimCommission`** — pulls `accruedCommission` from the treasury to the entity owner.
- **Views** — `entityCommissionRate`, `entityAccruedCommission`.
- **Storage** — two `uint256` appended to `Entity` (append-safe, mapping-held; top-level layout verified unchanged).

## ⚠️ Wiring requirement

`claimCommission` pulls from the treasury via `transferVana`, which is `DEFAULT_ADMIN`-gated. Commission funds live in the treasury (they came from `locked`), so **the entity must be granted `DEFAULT_ADMIN` on the treasury at upgrade time** (`treasury.grantRole(DEFAULT_ADMIN_ROLE, entity)`), mirroring how staking pulls for unstake payouts. This broadens treasury trust to the entity contract — symmetric with the trust staking already holds, but worth an explicit review. Alternative (not taken): route the claim through staking to avoid the grant, at the cost of touching the staking contract.

## Tests (13 new)

- **Skim**: APY and STREAM split + conservation; zero-commission == old behavior; 100% == delegators get nothing.
- **Rate change**: settles pending at the *old* rate before applying the new one.
- **Access/bounds**: owner-or-maintainer only; `> MAX_COMMISSION` reverts.
- **e2e** (real proxy stack): delegator earns the post-commission remainder; owner claims the accrued cut from the treasury (balance moves by exactly `accrued`, then resets).

Full suite: 49 tests green.

## Open decisions (from the plan)

- **Cap** at 100% (permissive — an entity can starve delegators) vs a governance max like 50%.
- **Max-change-rate** protection (Cosmos-style, limit commission *increases* per period) — deferred to a follow-up; the current setter allows any change within `[0, MAX]`.
- **Recipient** is `entity.ownerAddress`; a configurable recipient could be added if needed.
- **Forfeiture**: re-vested forfeited rewards get commissioned again (minor double-dip) — accepted and noted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)